### PR TITLE
Flags to get compiling with GNU and clean up some copyrights

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 *~
 *.swp
 
-build/
+build*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,3 @@
-# (C) Copyright 2019 UCAR.
-#
-# This software is licensed under the terms of the Apache Licence Version 2.0
-# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-
 ################################################################################
 # GSIBCLIM
 ################################################################################

--- a/cmake/compiler_flags_GNU_Fortran.cmake
+++ b/cmake/compiler_flags_GNU_Fortran.cmake
@@ -1,38 +1,23 @@
-# (C) Copyright 2019 UCAR
-#
-# This software is licensed under the terms of the Apache Licence Version 2.0
-# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# Definitions
+# -----------
+add_definitions(-D__GFORTRAN__)
 
-####################################################################
-# FLAGS COMMON TO ALL BUILD TYPES
-####################################################################
 
-####################################################################
-# RELEASE FLAGS
-####################################################################
+# Common flags
+# ------------
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fdefault-real-8")
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fdefault-double-8")
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fPIC")
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -falign-commons")
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ffixed-line-length-132")
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fcray-pointer")
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -frecord-marker=4")
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fno-range-check")
 
-#set( CMAKE_Fortran_FLAGS_RELEASE "-r8 -O3 -qopt-report0 -ftz -align all -fno-alias -traceback -assume realloc_lhs     -convert big_endian -assume byterecl -fPIC -fp-model strict -align dcommons " )
 
-####################################################################
-# DEBUG FLAGS
-####################################################################
-
-#set( CMAKE_Fortran_FLAGS_DEBUG "-r8 -O0 -g -qopt-report0 -ftz -align all -fno-alias -traceback -assume realloc_lhs     -convert big_endian -assume byterecl -fPIC -fp-model strict -align dcommons " )
-
-####################################################################
-# BIT REPRODUCIBLE FLAGS
-####################################################################
-
-#set( CMAKE_Fortran_FLAGS_BIT     "-O2 -ip -ipo -unroll -inline -no-heap-arrays" )
-
-####################################################################
-# LINK FLAGS
-####################################################################
-
-#set( CMAKE_Fortran_LINK_FLAGS    "" )
-
-####################################################################
-
-# Meaning of flags
-# ----------------
-# todo
+# GNU version 10 or greater
+# -------------------------
+if (CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fallow-argument-mismatch")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fallow-invalid-boz")
+endif ()

--- a/cmake/compiler_flags_Intel_Fortran.cmake
+++ b/cmake/compiler_flags_Intel_Fortran.cmake
@@ -1,39 +1,13 @@
-# (C) Copyright 2019 UCAR
-#
-# This software is licensed under the terms of the Apache Licence Version 2.0
-# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-
-####################################################################
-# FLAGS COMMON TO ALL BUILD TYPES
-####################################################################
-
-####################################################################
-# RELEASE FLAGS
-####################################################################
-
-set( CMAKE_Fortran_FLAGS_RELEASE "-r8 -O3 -qopt-report0 -ftz -align all -fno-alias -traceback -assume realloc_lhs -convert big_endian -assume byterecl -fPIC -fp-model strict -align dcommons " )
-
-####################################################################
-# DEBUG FLAGS
-####################################################################
-
-set( CMAKE_Fortran_FLAGS_DEBUG "-r8 -O0 -g -qopt-report0 -ftz -align all -fno-alias -traceback -assume realloc_lhs -convert big_endian -assume byterecl -fPIC -fp-model strict -align dcommons " )
-
-####################################################################
-# BIT REPRODUCIBLE FLAGS
-####################################################################
-
-#set( CMAKE_Fortran_FLAGS_BIT     "-O2 -ip -ipo -unroll -inline -no-heap-arrays" )
-
-####################################################################
-# LINK FLAGS
-####################################################################
-
-set( CMAKE_Fortran_LINK_FLAGS    "" )
-
-####################################################################
-
-# Meaning of flags
-# ----------------
-# todo
-
+# Common flags
+# ------------
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -r8")
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -qopt-report0")
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ftz ")
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -align all")
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fno-alias")
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -assume realloc_lhs")
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -convert big_endian")
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -assume byterecl")
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fPIC")
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fp-model strict")
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -align dcommons")

--- a/cmake/gsibclim_compiler_flags.cmake
+++ b/cmake/gsibclim_compiler_flags.cmake
@@ -1,19 +1,14 @@
-# (C) Copyright 2019 UCAR
-#
-# This software is licensed under the terms of the Apache Licence Version 2.0
-# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-
-# Standard FMS compiler definitions
+# Compiler definitions
+# --------------------
 add_definitions( -D_REAL8_ -DLINUX -Dfunder -DFortranByte=char -DFortranInt=int -I/usr/local/intel/2020/compilers_and_libraries_2020.0.166/linux/mpi/intel64/include )
 
 if( NOT CMAKE_BUILD_TYPE MATCHES "Debug" )
   add_definitions( -DNDEBUG )
 endif( )
 
-#######################################################################################
-# Fortran
-#######################################################################################
 
+# Compiler flags
+# --------------
 if( CMAKE_Fortran_COMPILER_ID MATCHES "Intel" )
   include( compiler_flags_Intel_Fortran )
 elseif( CMAKE_Fortran_COMPILER_ID MATCHES "GNU" )
@@ -21,4 +16,3 @@ elseif( CMAKE_Fortran_COMPILER_ID MATCHES "GNU" )
 else()
   message( STATUS "Fortran compiler with ID ${CMAKE_Fortran_COMPILER_ID} will be used with CMake default options")
 endif()
-

--- a/src/gsibclim/CMakeLists.txt
+++ b/src/gsibclim/CMakeLists.txt
@@ -1,8 +1,3 @@
-# (C) Copyright 2017-2020 UCAR.
-#
-# This software is licensed under the terms of the Apache Licence Version 2.0
-# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-
 # Build list of subdirs with files to add
 set(_subdirs gsi gsigeos )
 foreach( _subdir IN LISTS _subdirs )

--- a/src/gsibclim/gsi/CMakeLists.txt
+++ b/src/gsibclim/gsi/CMakeLists.txt
@@ -1,9 +1,3 @@
-# (C) Copyright 2022 United States Government as represented by the Administrator of the National
-#     Aeronautics and Space Administration
-#
-# This software is licensed under the terms of the Apache Licence Version 2.0
-# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-
 # BClim
 list(APPEND gsi_src_files_list
 

--- a/src/gsibclim/gsi/hybrid_ensemble_isotropic.F90
+++ b/src/gsibclim/gsi/hybrid_ensemble_isotropic.F90
@@ -3222,7 +3222,7 @@ subroutine init_sf_xy(jcap_in)
         enddo
      enddo
      write(mapname,'("out_",i4.4)')1+mod(grd_loc%kbegin_loc-1,grd_ens%nsig)
-     call outgrads1(out1,grd_ens%nlon,grd_ens%nlat,mapname)
+     !call outgrads1(out1,grd_ens%nlon,grd_ens%nlat,mapname)
    end if
   end if
   deallocate(rkm,f,f0)
@@ -4889,25 +4889,25 @@ subroutine get_region_lat_lon_ens(region_lat_ens,region_lon_ens,rlat_e,rlon_e,nl
            out1e(j,i)=region_lon_ens(i,j)
         enddo
      enddo
-     call outgrads1(out1e,nlon_e,nlat_e,'region_lon_e')
+     !call outgrads1(out1e,nlon_e,nlat_e,'region_lon_e')
      do j=1,nlon
         do i=1,nlat
            out1(j,i)=region_lon(i,j)
         enddo
      enddo
-     call outgrads1(out1,nlon,nlat,'region_lon')
+     !call outgrads1(out1,nlon,nlat,'region_lon')
      do j=1,nlon_e
         do i=1,nlat_e
            out1e(j,i)=region_lat_ens(i,j)
         enddo
      enddo
-     call outgrads1(out1e,nlon_e,nlat_e,'region_lat_e')
+     !call outgrads1(out1e,nlon_e,nlat_e,'region_lat_e')
      do j=1,nlon
         do i=1,nlat
            out1(j,i)=region_lat(i,j)
         enddo
      enddo
-     call outgrads1(out1,nlon,nlat,'region_lat')
+     !call outgrads1(out1,nlon,nlat,'region_lat')
      deallocate(out1e,out1)
   end if
   return
@@ -4973,25 +4973,25 @@ subroutine get_region_dx_dy_ens(region_dx_ens,region_dy_ens)
            out1ens(j,i)=region_dx_ens(i,j)
         enddo
      enddo
-     call outgrads1(out1ens,nlon_ens,nlat_ens,'region_dx_ens')
+     !call outgrads1(out1ens,nlon_ens,nlat_ens,'region_dx_ens')
      do j=1,nlon
         do i=1,nlat
            out1(j,i)=region_dx(i,j)
         enddo
      enddo
-     call outgrads1(out1,nlon,nlat,'region_dx')
+     !call outgrads1(out1,nlon,nlat,'region_dx')
      do j=1,nlon_ens
         do i=1,nlat_ens
            out1ens(j,i)=region_dy_ens(i,j)
         enddo
      enddo
-     call outgrads1(out1ens,nlon_ens,nlat_ens,'region_dy_ens')
+     !call outgrads1(out1ens,nlon_ens,nlat_ens,'region_dy_ens')
      do j=1,nlon
         do i=1,nlat
            out1(j,i)=region_dy(i,j)
         enddo
      enddo
-     call outgrads1(out1,nlon,nlat,'region_dy')
+     !call outgrads1(out1,nlon,nlat,'region_dy')
      deallocate(out1ens,out1)
   end if
   return

--- a/src/gsibclim/gsigeos/CMakeLists.txt
+++ b/src/gsibclim/gsigeos/CMakeLists.txt
@@ -1,9 +1,3 @@
-# (C) Copyright 2022 United States Government as represented by the Administrator of the National
-#     Aeronautics and Space Administration
-#
-# This software is licensed under the terms of the Apache Licence Version 2.0
-# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-
 # GSI-GEOS
 
 list(APPEND gsigeos_src_files_list

--- a/src/gsibclim/gsigeos/m_nc_GEOSens.f90
+++ b/src/gsibclim/gsigeos/m_nc_GEOSens.f90
@@ -46,7 +46,7 @@ character(len=5),parameter :: cvars3d(nv3d) = (/ &
                                               'tv   ', 'u    ', 'v    ', &
                                               'sphu ', 'qitot', 'qltot', &
                                               'qrtot', 'qstot', 'ozone', &
-                                              'delp '& 
+                                              'delp '&
                                               /)
 
 interface nc_GEOSens_dims; module procedure    &
@@ -69,14 +69,14 @@ interface nc_GEOSens_geos2gsi; module procedure    &
   geos2gsi_ ; end interface
 interface nc_GEOSens_gsi2geos; module procedure    &
   gsi2geos_ ; end interface
-interface nc_GEOSens_getpointer 
-  module procedure get_pointer_2d_ 
+interface nc_GEOSens_getpointer
+  module procedure get_pointer_2d_
   module procedure get_pointer_3d_
 end interface
 
 ! internal only
-interface stddev_ 
-  module procedure stddev2_ 
+interface stddev_
+  module procedure stddev2_
   module procedure stddev3_
 end interface
 contains
@@ -95,14 +95,14 @@ subroutine read_dims_ (fname,nlat,nlon,nlev,rc, myid,root)
 ! Local variables
   character(len=*), parameter :: myname_ = myname//"::dims_"
   logical :: verbose
-   
+
 ! Return code (status)
   rc=0; mype_=0; root_=0
   if(present(myid) .and. present(root) ) then
      mype_ = myid
      root_ = root
   endif
- 
+
 ! Open the file. NF90_NOWRITE tells netCDF we want read-only access to
 ! the file.
 
@@ -146,7 +146,7 @@ subroutine read_GEOSens_ (fname,bvars,rc, myid,root, gsiset)
   logical :: verbose
   logical :: init_
   logical :: gsi_
-  
+
 ! Return code (status)
   rc=0; mype_=0; root_=0
   verbose=.true.
@@ -161,7 +161,7 @@ subroutine read_GEOSens_ (fname,bvars,rc, myid,root, gsiset)
   if(present(gsiset)) then
      gsi_=gsiset
   endif
- 
+
 ! Get dimensions
   call read_dims_ (fname,nlat_,nlon_,nlev_,rc, mype_,root_)
 
@@ -332,7 +332,7 @@ subroutine write_GEOSens_ (fname,bvars,lats,lons,rc, myid,root,plevs)
   integer :: mype_,root_
   integer, allocatable :: varid2d(:), varid3d(:)
   logical :: verbose
-  
+
 ! This is the data array we will write. It will just be filled with
 ! a progression of integers for this example.
   real(4), allocatable :: data_out(:,:,:)
@@ -372,7 +372,7 @@ subroutine write_GEOSens_ (fname,bvars,lats,lons,rc, myid,root,plevs)
   call check_( nf90_create(fname, NF90_CLOBBER, ncid), rc, mype_, root_ )
   if(rc/=0) return
 
-! Define the dimensions. NetCDF will hand back an ID for each. 
+! Define the dimensions. NetCDF will hand back an ID for each.
   call check_( nf90_def_dim(ncid, "lon", nlon, x_dimid), rc, mype_, root_ )
   call check_( nf90_def_dim(ncid, "lat", nlat, y_dimid), rc, mype_, root_ )
   call check_( nf90_def_dim(ncid, "lev", nlev, z_dimid), rc, mype_, root_ )
@@ -468,18 +468,18 @@ subroutine init_GEOSens_vars_(vr,nlon,nlat,nsig,gsi)
     vr%gsiset = gsi
   endif
 
-  vr%nlon=nlon 
+  vr%nlon=nlon
   vr%nlat=nlat
   vr%nsig=nsig
 
 ! allocate single precision arrays
   if (vr%gsiset) then
-     allocate(vr%tv(nlat,nlon,nsig),vr%u (nlat,nlon,nsig),vr%v (nlat,nlon,nsig),vr%qv(nlat,nlon,nsig),&  
+     allocate(vr%tv(nlat,nlon,nsig),vr%u (nlat,nlon,nsig),vr%v (nlat,nlon,nsig),vr%qv(nlat,nlon,nsig),&
               vr%qi(nlat,nlon,nsig),vr%ql(nlat,nlon,nsig),vr%qr(nlat,nlon,nsig),vr%qs(nlat,nlon,nsig),&
               vr%oz(nlat,nlon,nsig),vr%dp(nlat,nlon,nsig) )
      allocate(vr%ps(nlat,nlon),vr%ts(nlat,nlon))
   else
-     allocate(vr%tv(nlon,nlat,nsig),vr%u (nlon,nlat,nsig),vr%v (nlon,nlat,nsig),vr%qv(nlon,nlat,nsig),&  
+     allocate(vr%tv(nlon,nlat,nsig),vr%u (nlon,nlat,nsig),vr%v (nlon,nlat,nsig),vr%qv(nlon,nlat,nsig),&
               vr%qi(nlon,nlat,nsig),vr%ql(nlon,nlat,nsig),vr%qr(nlon,nlat,nsig),vr%qs(nlon,nlat,nsig),&
               vr%oz(nlon,nlat,nsig),vr%dp(nlon,nlat,nsig) )
      allocate(vr%ps(nlon,nlat),vr%ts(nlon,nlat))
@@ -491,7 +491,7 @@ subroutine init_GEOSens_vars_(vr,nlon,nlat,nsig,gsi)
   type(nc_GEOSens_vars) vr
 ! deallocate arrays
   if(.not. vr%initialized) return
-  deallocate(vr%tv,vr%u ,vr%v ,vr%qv,  &  
+  deallocate(vr%tv,vr%u ,vr%v ,vr%qv,  &
              vr%qi,vr%ql,vr%qr,vr%qs,&
              vr%oz,vr%dp)
   deallocate(vr%ps,vr%ts)
@@ -568,7 +568,7 @@ subroutine copy_(ivars,ovars,rc)
       return
   endif
 
-  if (ivars%gsiset /= ovars%gsiset ) then
+  if (ivars%gsiset .neqv. ovars%gsiset ) then
      do kk=1,ovars%nsig
         ovars%dp(:,:,kk) = transpose(ivars%dp(:,:,kk))
         ovars%tv(:,:,kk) = transpose(ivars%tv(:,:,kk))
@@ -703,11 +703,11 @@ subroutine check_(status,rc, myid, root)
     integer, intent (out) :: rc
     integer, intent ( in) :: myid, root
     rc=0
-    if(status /= nf90_noerr) then 
+    if(status /= nf90_noerr) then
       if(myid==root) print *, trim(nf90_strerror(status))
       rc=999
     end if
-end subroutine check_  
+end subroutine check_
 
 subroutine geos2gsi_ (x)
   implicit none

--- a/src/gsibclim/gsigfs/CMakeLists.txt
+++ b/src/gsibclim/gsigfs/CMakeLists.txt
@@ -1,9 +1,3 @@
-# (C) Copyright 2022 United States Government as represented by the Administrator of the National
-#     Aeronautics and Space Administration
-#
-# This software is licensed under the terms of the Apache Licence Version 2.0
-# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-
 # GSI-GEOS
 
 list(APPEND gsigfs_src_files_list

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,8 +1,3 @@
-# (C) Copyright 2017-2021 UCAR.
-#
-# This software is licensed under the terms of the Apache Licence Version 2.0
-# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-
 # Include macros for creating links and symlinks
 #include( gsibclim_functions )
 

--- a/test/mains/CMakeLists.txt
+++ b/test/mains/CMakeLists.txt
@@ -1,8 +1,3 @@
-# (C) Copyright 2017-2018 UCAR.
-#
-# This software is licensed under the terms of the Apache Licence Version 2.0
-# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-
 ecbuild_add_executable( TARGET  test_bkerror_clim.x
                         SOURCES test_bkerror_clim.F90
                         LIBS    gsibclim


### PR DESCRIPTION
- Add compiler flags for GNU.
- Clean up compiler flags for Intel.
- Minor code change to get things to compile with GNU
- Clean up the copyright so UCAR does not appear.
- Outgrads is not found so does not compile with debug flags, needed for CI @ JCSDA