### PR TITLE
Tendencies and Derivatives when needed only

### DIFF
--- a/src/gsibec/gsi/calctends.F90
+++ b/src/gsibec/gsi/calctends.F90
@@ -116,6 +116,9 @@ subroutine calctends(mype,teta,pri,guess,xderivative,yderivative,tendency)
   real(r_kind),dimension(:,:,:),pointer :: oz_t=>NULL()
   real(r_kind),dimension(:,:,:),pointer :: cw_t=>NULL()
 
+! Basic check
+  if (xderivative%n2d<=0.and.xderivative%n3d<=0) return 
+
 ! Get all pointers:
 
 ! from guess ...

--- a/src/gsibec/gsi/get_derivatives.F90
+++ b/src/gsibec/gsi/get_derivatives.F90
@@ -90,6 +90,8 @@ subroutine get_derivatives (guess,xderivative,yderivative)
 
 ! inquire variable names in x(y)derivative
 
+  if(xderivative%n2d<=0.and.xderivative%n3d<=0) return ! nothing to do
+
   if(xderivative%n2d>0) allocate(dvars2d(xderivative%n2d))
   if(xderivative%n3d>0) allocate(dvars3d(xderivative%n3d))
   call gsi_bundleinquire (xderivative,'shortnames::2d',dvars2d,istatus)

--- a/src/gsibec/gsi/gsimod.F90
+++ b/src/gsibec/gsi/gsimod.F90
@@ -14,6 +14,7 @@
 
   use m_kinds, only: i_kind,r_kind
 
+  use mpeu_util,only: die,warn
   use m_mpimod, only: npe,gsi_mpi_comm_world,ierror,mype
   use balmod, only: init_balmod,fstat,lnobalance
 
@@ -489,7 +490,6 @@
 !*************************************************************
 ! Begin gsi code
 !
-  use mpeu_util,only: die
   use gsi_fixture, only: fixture_config
   implicit none
   character(len=*),optional,intent(in):: nmlfile
@@ -549,7 +549,9 @@
 
   open(11,file=thisrc)
   read(11,hybrid_ensemble,iostat=ios)
-  if(ios/=0) call die(myname_,'read(hybrid_ensemble)',ios)
+  if(ios/=0) then
+     call warn(myname_,'using defaults(hybrid_ensemble)')
+  endif
   close(11)
 
   if(jcap > jcap_cut)then
@@ -612,7 +614,6 @@
   end subroutine gsimain_initialize_
 
   subroutine gridopts0_(nmlfile)
-  use mpeu_util,only: die
   implicit none
   character(len=*),optional,intent(in)  :: nmlfile
   character(len=*),parameter :: myname_="gsimod*gridopts0_"
@@ -638,7 +639,6 @@
                         glon2,glat2,&
                         isc,iec,jsc,jec,igdim)
   use general_sub2grid_mod, only: general_deter_subdomain_withLayout
-  use mpeu_util,only: die
   implicit none
   character(len=*),intent(in)  :: thisrc
   integer,intent(in)  :: thispe

--- a/src/gsibec/gsi/tendsmod.f90
+++ b/src/gsibec/gsi/tendsmod.f90
@@ -53,7 +53,7 @@ module tendsmod
   use constants, only: max_varname_length
   use gridmod, only: lat2,lon2,nsig
   use m_mpimod, only : mype
-  use mpeu_util, only: die
+  use mpeu_util, only: die,warn
   use GSI_BundleMod, only : GSI_BundleCreate
   use GSI_BundleMod, only : GSI_Bundle
   use GSI_BundleMod, only : GSI_BundleGetPointer
@@ -339,7 +339,7 @@ subroutine create_ges_tendencies(tendsflag,rcfile)
       call GSI_BundleCreate(gsi_tendency_bundle,grid,bname,ierror, &
                             names3d=tvars3d,levels=levels,bundle_kind=r_kind)
   else
-      call die(myname_,'improper initialization of tendsmod, aborting ...',999)
+      call warn(myname_,'no tendency fields requested')
   endif
 
 ! create wired-in fields


### PR DESCRIPTION
Changes to avoid allocating derivatives and tendencies when not needed (or requested). 

The intro of tendencies and derivatives for Q variable handling (and eventually TLNMC) had broken the feature of code being able to run w/ univariate quantities, e.g., ozone only. The changes here avoid errors.