### PR TITLE
bypass tropause calc when tv not avail

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 ################################################################################
 
 cmake_minimum_required( VERSION 3.12 )
-project( gsibec VERSION 1.0.7 LANGUAGES Fortran )
+project( gsibec VERSION 1.1.0 LANGUAGES Fortran )
 
 ## Ecbuild integration
 set( ECBUILD_DEFAULT_BUILD_TYPE Release )

--- a/src/gsibec/gsi/tpause.f90
+++ b/src/gsibec/gsi/tpause.f90
@@ -94,6 +94,12 @@ subroutine tpause(mype,method)
   if(istatus/=0) return ! if ps not defined forget it ...
 
   call gsi_bundlegetpointer (gsi_metguess_bundle(nt),'tv',ges_tv_nt,ifound_tv)
+  if (ifound_tv/=0) then
+     if (mype==0) then
+         write(6,*) trim(myname), ': Warning, tv-not avail not t-pause calc'
+     endif
+     return
+  endif
   pvoz_capable=ifound_tv==0
   call gsi_bundlegetpointer (gsi_metguess_bundle(nt),'oz',ges_oz_nt,ifound_oz)
   pvoz_capable=pvoz_capable.and.ifound_oz==0


### PR DESCRIPTION
This is to avoid using vars that are not truly needed.

Should not try to calculate tropopause info if Tv is not available.