### PR TITLE
multiple outer loops opt now working again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 ################################################################################
 
 cmake_minimum_required( VERSION 3.12 )
-project( gsibec VERSION 1.1.0 LANGUAGES Fortran )
+project( gsibec VERSION 1.1.1 LANGUAGES Fortran )
 
 ## Ecbuild integration
 set( ECBUILD_DEFAULT_BUILD_TYPE Release )

--- a/src/gsibec/gsi/compact_diffs.f90
+++ b/src/gsibec/gsi/compact_diffs.f90
@@ -99,7 +99,7 @@ module compact_diffs
   public:: cdiff_initialized
 
   integer(i_kind),save :: noq
-  logical,save :: initialized_=.false.
+  logical,save :: compdiff_initialized_=.false.
   real(r_kind),allocatable,dimension(:):: coef
   integer(i_kind) nxh,nbp,nya,nxa,lbcox1,lacox1,lbcox2
   integer(i_kind) lacoy1,lacox2,lbcoy1,lcy,lacoy2,lbcoy2
@@ -115,12 +115,12 @@ contains
   function cdiff_created() result(created)
     implicit none
     logical:: created
-    created = initialized_
+    created = compdiff_initialized_
   end function cdiff_created
   function cdiff_initialized() result(inited)
     implicit none
     logical:: inited
-    inited = initialized_ .and. inisphed_
+    inited = compdiff_initialized_ .and. inisphed_
   end function cdiff_initialized
 
   subroutine init_compact_diffs
@@ -175,9 +175,9 @@ contains
   use gridmod, only: nlat,nlon
   implicit none
 
-  if(initialized_) return
+  if(compdiff_initialized_) return
   allocate(coef(3*nlat+4*(2*(noq+5)+1)*(nlat+nlon/2)))
-  initialized_=.true.
+  compdiff_initialized_=.true.
   nlon_alloced_=nlon
   nlat_alloced_=nlat
   noq_alloced_ =noq
@@ -210,9 +210,9 @@ contains
 !
 !$$$
     implicit none
-    if(.not.initialized_) return
+    if(.not.compdiff_initialized_) return
     deallocate(coef)
-    initialized_=.false.
+    compdiff_initialized_=.false.
     inisphed_=.false.
 
     nlon_alloced_=-1
@@ -1316,7 +1316,7 @@ end subroutine uv2vordiv
 
   character(len=*),parameter :: myname_='compact_diffs.inisph'
 
-  if(.not.initialized_) call die(myname_,'coef not created')
+  if(.not.compdiff_initialized_) call die(myname_,'coef not created')
   if( nlon_alloced_ /= nx       .or. &
       nlat_alloced_ /= ny+2     .or. &
       noq_alloced_  /= noq    ) then

--- a/src/gsibec/gsi/compute_derived.F90
+++ b/src/gsibec/gsi/compute_derived.F90
@@ -298,6 +298,8 @@ subroutine compute_derived(mype,init_pass)
 
 #ifdef USE_ALL_ORIGINAL
         if(.not. wrf_mass_regional .and. tendsflag)then
+#else
+        if(tendsflag)then
 #endif
           if(.not.tnd_initialized) &
             call die(myname,'unexpected tnd_initialized =',tnd_initialized)
@@ -326,10 +328,8 @@ subroutine compute_derived(mype,init_pass)
            end if
 #endif /* TLNMC */
           end if       ! (init_pass)
-#ifdef USE_ALL_ORIGINAL
-        end if
-#endif
-     end if
+        end if     ! tendsflag
+     end if     ! switch_on_derivatives
 
      if(init_pass) then
 
@@ -452,6 +452,7 @@ subroutine compute_derived(mype,init_pass)
 
   call final_vars_('guess')
 
+#ifdef USE_ALL_ORIGINAL
 !??????????????????????????  need any of this????
 !! qoption 1:  use psuedo-RH
 !  if(qoption==1)then
@@ -465,7 +466,6 @@ subroutine compute_derived(mype,init_pass)
 ! Load arrays based on option for moisture background error
 
 ! variance update for anisotropic mode
-#ifdef USE_ALL_ORIGINAL
      if( anisotropic .and. .not.rtma_subdomain_option ) then
         hswgtsum=sum(hswgt(1:ngauss))
         call setup_sub2fslab
@@ -575,14 +575,16 @@ subroutine compute_derived(mype,init_pass)
 
               end if
            end do
-           deallocate(rh0f,rh2f,rh3f)
+           deallocate(rh3f)
+           deallocate(rh2f)
+           deallocate(rh0f)
         end if
         call destroy_sub2fslab
      end if
-#endif
 
 ! End of qoption block
   endif
+#endif
 
 ! End of routine
   return

--- a/src/gsibec/gsi/constants.f90
+++ b/src/gsibec/gsi/constants.f90
@@ -55,6 +55,8 @@ module constants
 ! set subroutines as public
   public :: init_constants_derived
   public :: init_constants
+  public :: final_constants_derived
+  public :: final_constants
   public :: gps_constants
 ! set passed variables to public
   public :: one,two,half,zero,deg2rad,pi,three,quarter,one_tenth
@@ -342,6 +344,10 @@ contains
     return
   end subroutine init_constants_derived
 
+  subroutine final_constants_derived
+    cnts_derived_initialized_=.false.
+  end subroutine final_constants_derived
+
   subroutine init_constants(regional)
 !$$$  subprogram documentation block
 !                .      .    .                                       .
@@ -442,6 +448,10 @@ contains
     cnts_initialized_=.true.
     return
   end subroutine init_constants
+
+  subroutine final_constants
+    cnts_initialized_=.false.
+  end subroutine final_constants
 
   subroutine gps_constants(use_compress)
 !$$$  subprogram documentation block

--- a/src/gsibec/gsi/egrid2agrid_mod.f90
+++ b/src/gsibec/gsi/egrid2agrid_mod.f90
@@ -339,7 +339,10 @@ module egrid2agrid_mod
 
       if(present(e2a_only)) then
          if(e2a_only) then
-            allocate(e2a%twin(1,1),e2a%itwin(1,1),e2a%ntwin(1),e2a%swin(1,1))
+            if(.not.associated(e2a%twin)) allocate(e2a%twin(1,1))
+            if(.not.associated(e2a%itwin)) allocate(e2a%itwin(1,1))
+            if(.not.associated(e2a%ntwin)) allocate(e2a%ntwin(1))
+            if(.not.associated(e2a%swin)) allocate(e2a%swin(1,1))
             e2a%lallocated=.true.
             return
          end if

--- a/src/gsibec/gsi/general_sub2grid_mod.f90
+++ b/src/gsibec/gsi/general_sub2grid_mod.f90
@@ -589,12 +589,19 @@ end subroutine get_iuse_pe
          deallocate(s%irc_s,s%ird_s,s%isc_g,s%isd_g,s%displs_s,s%rdispls_s,s%sendcounts_s,s%sdispls_s)
          deallocate(s%ijn_s,s%kbegin,s%kend,s%lnames,s%names)
          if(present(s_ref)) then
-            s%ltosj   => NULL()
-            s%ltosi   => NULL()
-            s%ltosj_s => NULL()
-            s%ltosi_s => NULL()
+!           s_ref%ltosj   => NULL()
+!           s_ref%ltosi   => NULL()
+!           s_ref%ltosj_s => NULL()
+!           s_ref%ltosi_s => NULL()
+            if(associated(s_ref%ltosj_s)) deallocate(s_ref%ltosj_s)
+            if(associated(s_ref%ltosi_s)) deallocate(s_ref%ltosi_s)
+            if(associated(s_ref%ltosj)) deallocate(s_ref%ltosj)
+            if(associated(s_ref%ltosi)) deallocate(s_ref%ltosi)
          else
-            deallocate(s%ltosj,s%ltosi,s%ltosj_s,s%ltosi_s)
+            if(associated(s%ltosj_s)) deallocate(s%ltosj_s)
+            if(associated(s%ltosi_s)) deallocate(s%ltosi_s)
+            if(associated(s%ltosj)) deallocate(s%ltosj)
+            if(associated(s%ltosi)) deallocate(s%ltosi)
          end if
          s%lallocated=.false.
       end if

--- a/src/gsibec/gsi/gridmod.F90
+++ b/src/gsibec/gsi/gridmod.F90
@@ -694,7 +694,8 @@ contains
 !_#omp end parallel
     nthreads=nth
     if(print_verbose)write(6,*) 'INIT_GRID_VARS:  number of threads ',nthreads
-    allocate(jtstart(nthreads),jtstop(nthreads))
+    if(.not.allocated(jtstart)) allocate(jtstart(nthreads))
+    if(.not.allocated(jtstop)) allocate(jtstop(nthreads))
     do tid=1,nthreads
        call looplimits(tid-1, nthreads, 1, lon2, jtstart(tid), jtstop(tid))
        if(print_verbose)write(6,*)'INIT_GRID_VARS:  for thread ',tid,  &
@@ -938,8 +939,9 @@ contains
 !-------------------------------------------------------------------------
     integer(i_kind) i
 
-    allocate(periodic_s(npe),jstart(npe),istart(npe),&
-         ilat1(npe),jlon1(npe),&
+    if(.not.allocated(periodic_s)) &
+       allocate(periodic_s(npe),jstart(npe),istart(npe),&
+       ilat1(npe),jlon1(npe),&
        ijn_s(npe),irc_s(npe),ird_s(npe),displs_s(npe),&
        ijn(npe),isc_g(npe),isd_g(npe),displs_g(npe))
 
@@ -994,6 +996,7 @@ contains
 !-------------------------------------------------------------------------
     implicit none
 
+    if(allocated(periodic_s)) &
     deallocate(periodic_s,jstart,istart,ilat1,jlon1,&
        ijn_s,irc_s,ird_s,displs_s,&
        ijn,isc_g,isd_g,displs_g)

--- a/src/gsibec/gsi/gsi_4dvar.f90
+++ b/src/gsibec/gsi/gsi_4dvar.f90
@@ -368,7 +368,7 @@ if ( mype == 0 ) &
 ! Set up the time levels (nobs_bins) for the ensemble
 if ( mype == 0 ) &
     write(6,'(A)')' SETUP_4DVAR: allocate array containing time levels for ensemble'
-allocate(ens_fmnlevs(ntlevs_ens))
+if(.not.allocated(ens_fmnlevs)) allocate(ens_fmnlevs(ntlevs_ens))
 do k=1,ntlevs_ens
    ens_fmnlevs(k) = ens_nstarthr*60 + (k-1)*ens_nmn
    if ( mype == 0 ) &

--- a/src/gsibec/gsi/jfunc.f90
+++ b/src/gsibec/gsi/jfunc.f90
@@ -5,6 +5,7 @@ public :: jfunc_init
 
 public :: mockbkg
 
+public :: jouter_def
 public :: jiter
 public :: jiterstart
 public :: npred
@@ -47,6 +48,8 @@ logical :: pseudo_q2
 logical :: switch_on_derivatives
 logical :: tendsflag
 logical :: clip_supersaturation
+
+integer,save :: jouter_def=0
 contains
 subroutine jfunc_init
  mockbkg=.true. ! fake background state (internally generated)

--- a/src/gsibec/gsi/m_berror_stats.f90
+++ b/src/gsibec/gsi/m_berror_stats.f90
@@ -58,7 +58,8 @@ module m_berror_stats
    public :: berror_read_bal ! get cross-cov.stats., balmod::prebal()
    public :: berror_read_wgt ! get auto-cov.stats., prewgt()
    public :: berror_set      ! set internal parameters
-   public :: berror_init     ! init internal variables
+   public :: berror_init     ! initialize internal variables
+   public :: berror_final    ! finalize internal variables
 
    public :: varq
    public :: varcw
@@ -69,6 +70,7 @@ module m_berror_stats
    interface berror_read_wgt; module procedure read_wgt; end interface
    interface berror_set;      module procedure lset;     end interface
    interface berror_init;     module procedure init_;    end interface
+   interface berror_final;    module procedure final_;   end interface
 
 ! !REVISION HISTORY:
 !       30Jul08 - Jing Guo <guo@gmao.gsfc.nasa.gov>
@@ -113,6 +115,11 @@ subroutine init_(mlat,msig)
       varcw=zero
    endif
 end subroutine init_
+
+subroutine final_
+  if(allocated(varq))  deallocate(varq)
+  if(allocated(varcw)) deallocate(varcw)
+end subroutine final_
 
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ! NASA/GSFC, Global Modeling and Assimilation Office, 900.3, GEOS/DAS  !

--- a/src/gsibec/gsi/m_kinds.F90
+++ b/src/gsibec/gsi/m_kinds.F90
@@ -38,6 +38,7 @@ module m_kinds
 !$$$ end documentation block
   implicit none
   private
+  save
 
 ! Integer type definitions below
 

--- a/src/gsibec/gsi/m_rf.f90
+++ b/src/gsibec/gsi/m_rf.f90
@@ -16,7 +16,7 @@ use smooth_polcarf, only: destroy_smooth_polcas
 use gridmod, only: nlon,nlat,lon2,lat2,lon2,nsig
 use m_berror_stats, only: berror_get_dims
 use m_berror_stats, only: berror_init
-
+use m_berror_stats, only: berror_final
 
 use hybrid_ensemble_parameters, only: l_hyb_ens
 use hybrid_ensemble_parameters, only: destroy_hybens_localization_parameters
@@ -67,6 +67,7 @@ contains
   call destroy_berror_vars
   call destroy_balance_vars
   call final_rftable         ! out of place as consequence of gsi typically has inconsistent set/unset
+  call berror_final
   call final_
   end subroutine unset_
   subroutine final_

--- a/src/gsibec/gsi/tendsmod.f90
+++ b/src/gsibec/gsi/tendsmod.f90
@@ -339,8 +339,9 @@ subroutine create_ges_tendencies(tendsflag,rcfile)
       call GSI_BundleCreate(gsi_tendency_bundle,grid,bname,ierror, &
                             names3d=tvars3d,levels=levels,bundle_kind=r_kind)
   else
-      call warn(myname_,'no tendency fields requested')
+      if(mype==0) call warn(myname_,'no tendency fields requested')
   endif
+! call GSI_GridDestroy(
 
 ! create wired-in fields
   call create_tendvars
@@ -396,14 +397,19 @@ subroutine destroy_ges_tendencies
      if(mype==0) write(6,*)'destroy_ges_tendencies warning: vector not allocated'
   endif
 
-  if(allocated(tvars2d))deallocate(tvars2d)
-  if(allocated(tvars3d))deallocate(tvars3d)
-  if(allocated(tsrcs2d))deallocate(tsrcs2d)
-  if(allocated(tsrcs3d))deallocate(tsrcs3d)
-  if(allocated(levels))deallocate(levels)
+  call unset_
 
   tnd_initialized = .false.
   if(mype==0) write(6,*) 'destroy_ges_tendencies: successfully complete'
 end subroutine destroy_ges_tendencies
+
+subroutine unset_
+if(allocated(tvars2d)) deallocate(tvars2d)
+if(allocated(tvars3d)) deallocate(tvars3d)
+if(allocated(tsrcs2d)) deallocate(tsrcs2d)
+if(allocated(tsrcs3d)) deallocate(tsrcs3d)
+if(allocated(levels)) deallocate(levels)
+tnd_set_= .false.
+end subroutine unset_
 
 end module tendsmod

--- a/src/gsibec/gsi/xhat_vordivmod.f90
+++ b/src/gsibec/gsi/xhat_vordivmod.f90
@@ -41,12 +41,12 @@ module xhat_vordivmod
   public xhat_vordiv_init
   public xhat_vordiv_calc
   public xhat_vordiv_calc2
-  public xhat_vordiv_clean
+  public xhat_vordiv_final
 
   interface xhat_vordiv_init;  module procedure init_ ; end interface
   interface xhat_vordiv_calc;  module procedure calc_ ; end interface
   interface xhat_vordiv_calc2; module procedure calc2_; end interface
-  interface xhat_vordiv_clean; module procedure clean_; end interface
+  interface xhat_vordiv_final; module procedure clean_; end interface
 
   real(r_kind),public,allocatable,dimension(:,:,:,:):: xhat_vor
   real(r_kind),public,allocatable,dimension(:,:,:,:):: xhat_div
@@ -75,8 +75,8 @@ subroutine init_
 !$$$ end documentation block
   implicit none
 
-  allocate(xhat_vor(lat2,lon2,nsig,nobs_bins))
-  allocate(xhat_div(lat2,lon2,nsig,nobs_bins))
+  if(.not.allocated(xhat_vor)) allocate(xhat_vor(lat2,lon2,nsig,nobs_bins))
+  if(.not.allocated(xhat_div)) allocate(xhat_div(lat2,lon2,nsig,nobs_bins))
 end subroutine init_
 
 subroutine clean_
@@ -139,9 +139,10 @@ subroutine calc_(sval)
 
 ! Declare local variables
   integer(i_kind) i,j,k,ii,istatus
-  real(r_kind),dimension(nlat,nlon):: usm,vsm
+  real(r_kind),dimension(:,:),allocatable:: usm,vsm
   real(r_kind),dimension(:,:,:,:),allocatable:: work1,worksub
-  real(r_kind),pointer,dimension(:,:,:):: uptr,vptr
+  real(r_kind),pointer,dimension(:,:,:):: uptr=>NULL()
+  real(r_kind),pointer,dimension(:,:,:):: vptr=>NULL()
   logical docalc
 
 !*******************************************************************************
@@ -177,6 +178,7 @@ subroutine calc_(sval)
 
      allocate(work1(2,s2guv%nlat,s2guv%nlon,s2guv%kbegin_loc:s2guv%kend_alloc))
      allocate(worksub(2,s2guv%lat2,s2guv%lon2,s2guv%nsig))
+     allocate(usm(nlat,nlon),vsm(nlat,nlon))
      do ii=1,nobs_bins
 !       NCEP GFS interface
   
@@ -232,6 +234,7 @@ subroutine calc_(sval)
 
 !    End of NCEP GFS block
      end do
+     deallocate(usm,vsm)
      deallocate(work1,worksub)
   endif
 
@@ -275,7 +278,7 @@ subroutine calc2_(u,v,vor,div)
 
 ! Declare local variables
   integer(i_kind) i,j,k
-  real(r_kind),dimension(nlat,nlon):: usm,vsm
+  real(r_kind),dimension(:,:),allocatable:: usm,vsm
   real(r_kind),dimension(:,:,:,:),allocatable:: work1,worksub
 
 !*******************************************************************************
@@ -309,6 +312,7 @@ subroutine calc2_(u,v,vor,div)
 
      allocate(work1(2,s2guv%nlat,s2guv%nlon,s2guv%kbegin_loc:s2guv%kend_alloc))
      allocate(worksub(2,s2guv%lat2,s2guv%lon2,s2guv%nsig))
+     allocate(usm(nlat,nlon),vsm(nlat,nlon))
 !    NCEP GFS interface
 
      do k=1,nsig
@@ -354,6 +358,7 @@ subroutine calc2_(u,v,vor,div)
      end do
 
 ! End of NCEP GFS block
+     deallocate(usm,vsm)
      deallocate(work1,worksub)
 
   endif


### PR DESCRIPTION
This introduces a number of changes that try to be more careful about initialization and finalization of components in GSIbec. This is to address issue #45 - which will be closed after the changes here are placed into develop. Unfortunately, the basic changes here do not quite address the problem, since the issue is really in saber. Despite what I've been told, the fact is that there is a create/delete combination is saber that is not correct - or certainly not working in a way that it is trivial to understand - it seems that saber does a delete w/o a create or (more likely) a create with deleting a component that has already been created. 

The solution to the trouble I was having lays in my deactivating and deletion in gsi_covariance_mod in saber/gs/covariance. To problem trigger or not the corresponding create, GSIbec has been aided with a counter that essentially monitors the outer iterations; initializations are only done once - in view of the deactivation of saber/gsi/cov finalization.  

The changes here are zero diff to the existing code in develop: 1.1.0 - so these will make up what will be named 1.1.1