### PR TITLE
Fix compilation error in src/gsibec/gsigeos/m_read_geosens.F90

### DIFF
--- a/src/gsibec/gsigeos/m_read_geosens.F90
+++ b/src/gsibec/gsigeos/m_read_geosens.F90
@@ -137,10 +137,13 @@ contains
  end subroutine init_
 
  subroutine read_(n,proc1)
+
+  implicit none
+
   integer, intent(in) :: n, proc1
 
   character(len=*),parameter :: myname_ = myname//'*read_' 
-  integer i,j,k,ke,nv,istatus
+  integer i,j,k,ii,ke,nv,istatus
 
     if(mype/=proc1) return
 


### PR DESCRIPTION
## Description

Fix compilation error in `src/gsibec/gsigeos/m_read_geosens.F90` with gfortran 11.3.0: use `jj` instead of `ii` in subroutine `read_`

## Issues

This should fix https://github.com/GEOS-ESM/GSIbec/issues/51.

This branch compiles on my macOS where 1.1.1 aborted with the compilation error reported in the issue.