### PR TITLE
Addressing tskin and other surface variabels

### DIFF
--- a/src/gsibec/gsi/guess_grids.f90
+++ b/src/gsibec/gsi/guess_grids.f90
@@ -68,6 +68,8 @@ real(r_kind),allocatable,dimension(:,:,:):: fact_tv
 real(r_kind),allocatable,dimension(:,:):: tropprs
 integer(i_kind),allocatable,dimension(:,:):: isli2
 
+real(r_kind),allocatable :: debugvar(:,:,:)
+
 interface gsiguess_init; module procedure init_; end interface
 interface gsiguess_final; module procedure final_; end interface
 interface gsiguess_get_ref_gesprs; module procedure get_ref_gesprs_; end interface
@@ -205,6 +207,8 @@ subroutine other_set_(need)
        where(need=='div')
           need='filled-'//need
        endwhere
+!      call write_bkgvars_grid(ges_u,ges_v,ges_vor,ges_div(:,:,1),&
+!                             'wind.grd',mype) ! debug
     endif
   endif
 ! fill in land-water-ice mask
@@ -734,6 +738,13 @@ end subroutine final_
   else
     if(mype==0) write(6,'(2a)') myname_, ': filled LWI (no T-skin)'
   endif
+! allocate(debugvar(size(frocean,1),size(frocean,2),nsig))
+! debugvar(:,:,1) = frocean
+! debugvar(:,:,2) = frlake
+! debugvar(:,:,3) = frseaice
+! debugvar(:,:,4) = tskin
+! call write_bkgvars_grid(debugvar,debugvar,debugvar,tskin,'skin.grd',mype) ! debug
+! deallocate(debugvar)
   end subroutine lwi_mask_
 
   subroutine load_guess_tsen_(mock)

--- a/src/gsibec/gsi/jfunc.f90
+++ b/src/gsibec/gsi/jfunc.f90
@@ -52,9 +52,9 @@ logical :: clip_supersaturation
 integer,save :: jouter_def=0
 contains
 subroutine jfunc_init
- mockbkg=.true. ! fake background state (internally generated)
- jiter=1        ! used as index for output spread - wired for now
- jiterstart=1   ! used as index for output spread - wired for now
+ mockbkg=.false. ! fake background state (internally generated)
+ jiter=1         ! used as index for output spread - wired for now
+ jiterstart=1    ! used as index for output spread - wired for now
  npred=0
  npredp=0
  npcptype=0

--- a/src/gsibec/gsi/prewgt.F90
+++ b/src/gsibec/gsi/prewgt.F90
@@ -439,7 +439,8 @@ subroutine prewgt(mype)
   if (bkgv_flowdep) then
       call bkgvar_rewgt(sfvar,vpvar,tvar,psvar,mype)
   else
-      if (bkgv_write) call write_bkgvars_grid(sfvar,vpvar,tvar,psvar,mype)
+      if (bkgv_write) call write_bkgvars_grid(sfvar,vpvar,tvar,psvar,&
+                                             'bkgvar_rewgt.grd',mype)
   endif
 
 ! vertical length scales

--- a/src/gsibec/gsi/write_bkgvars_grid.F90
+++ b/src/gsibec/gsi/write_bkgvars_grid.F90
@@ -1,4 +1,4 @@
-subroutine write_bkgvars_grid(a,b,c,d,mype)
+subroutine write_bkgvars_grid(a,b,c,d,grdfile,mype)
 !$$$  subroutine documentation block
 !
 ! subprogram:    write_bkgvars_grid
@@ -34,11 +34,11 @@ subroutine write_bkgvars_grid(a,b,c,d,mype)
   implicit none
 
   integer(i_kind)                       ,intent(in   ) :: mype
+  character(len=*)                      ,intent(in   ) :: grdfile
 
   real(r_kind),dimension(lat2,lon2,nsig),intent(in   ) :: a,b,c
   real(r_kind),dimension(lat2,lon2)     ,intent(in   ) :: d
 
-  character(255):: grdfile
 
   real(r_kind),dimension(nlat,nlon,nsig):: ag,bg,cg
   real(r_kind),dimension(nlat,nlon):: dg
@@ -75,7 +75,6 @@ subroutine write_bkgvars_grid(a,b,c,d,mype)
      end do
 
 ! Create byte-addressable binary file for grads
-     grdfile='bkgvar_rewgt.grd'
      ncfggg=len_trim(grdfile)
 #ifdef HAVE_BACIO
      call baopenwt(22,grdfile(1:ncfggg),iret)


### PR DESCRIPTION
This allows GSIbec to handle tskin as in the original GSI. We now get an increment of tskin when, say, MW obs are assimilated, or ship temperature data.