### PR TITLE
Pass date/time down to handle ensemble

### DIFF
--- a/src/gsibec/CMakeLists.txt
+++ b/src/gsibec/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Build list of subdirs with files to add
-set(_subdirs gsi gsigeos )
+set(_subdirs gsi gsigeos gsigfs )
 foreach( _subdir IN LISTS _subdirs )
     add_subdirectory( ${_subdir} )
     list( TRANSFORM ${_subdir}_src_files PREPEND ${_subdir}/ )

--- a/src/gsibec/gsi/abstract_ensmod.f90
+++ b/src/gsibec/gsi/abstract_ensmod.f90
@@ -65,7 +65,7 @@ module abstract_ensmod
   end interface
 
   abstract interface
-    subroutine get_user_ens(this,grd,member,ntindex,tau,atm_bundle,iret)
+    subroutine get_user_ens(this,grd,member,nymd,nhms,tau,atm_bundle,iret)
       use m_kinds, only: i_kind
       use general_sub2grid_mod, only: sub2grid_info
       use gsi_bundlemod, only: gsi_bundle
@@ -74,7 +74,7 @@ module abstract_ensmod
       class(abstractEnsemble), intent(inout) :: this
       type(sub2grid_info), intent(in   ) :: grd
       integer(i_kind),     intent(in   ) :: member
-      integer(i_kind),     intent(in   ) :: ntindex
+      integer(i_kind),     intent(in   ) :: nymd,nhms
       integer(i_kind),     intent(in   ) :: tau
       type(gsi_bundle),    intent(inout) :: atm_bundle
       integer(i_kind),     intent(  out) :: iret
@@ -82,7 +82,7 @@ module abstract_ensmod
   end interface
 
   abstract interface
-    subroutine get_user_Nens(this,grd,members,ntindex,tau,atm_bundle,iret)
+    subroutine get_user_Nens(this,grd,members,nymd,nhms,tau,atm_bundle,iret)
       use m_kinds, only: i_kind
       use general_sub2grid_mod, only: sub2grid_info
       use gsi_bundlemod, only: gsi_bundle
@@ -91,7 +91,7 @@ module abstract_ensmod
       class(abstractEnsemble), intent(inout) :: this
       type(sub2grid_info), intent(in   ) :: grd
       integer(i_kind),     intent(in   ) :: members
-      integer(i_kind),     intent(in   ) :: ntindex
+      integer(i_kind),     intent(in   ) :: nymd,nhms
       integer(i_kind),     intent(in   ) :: tau
       type(gsi_bundle),    intent(inout) :: atm_bundle(:)
       integer(i_kind),     intent(  out) :: iret

--- a/src/gsibec/gsi/get_gefs_ensperts_dualres.F90
+++ b/src/gsibec/gsi/get_gefs_ensperts_dualres.F90
@@ -1,4 +1,4 @@
-subroutine get_gefs_ensperts_dualres (tau)
+subroutine get_gefs_ensperts_dualres (nymd,nhms,tau)
 !$$$  subprogram documentation block
 !                .      .    .                                       .
 ! subprogram:    get_gefs_ensperts_dualres copy of get_gefs_ensperts for dual resolution
@@ -76,6 +76,8 @@ subroutine get_gefs_ensperts_dualres (tau)
 #endif /* USE_ALL_ORIGINAL */
   implicit none
 
+  integer(i_kind),intent(in) :: nymd ! yyyymmdd
+  integer(i_kind),intent(in) :: nhms ! hhmmss
   integer(i_kind),intent(in) :: tau
 
   real(r_kind),pointer,dimension(:,:)   :: ps
@@ -162,7 +164,7 @@ subroutine get_gefs_ensperts_dualres (tau)
 
      en_bar(m)%values=zero
 
-     call gsi_enscoupler_get_user_Nens(grd_tmp,n_ens,m,tau,en_read,iret)
+     call gsi_enscoupler_get_user_Nens(grd_tmp,n_ens,nymd,nhms,tau,en_read,iret)
 
      ! Check read return code.  Revert to static B if read error detected
      if ( iret /= 0 ) then

--- a/src/gsibec/gsi/gsi_enscouplermod.f90
+++ b/src/gsibec/gsi/gsi_enscouplermod.f90
@@ -94,7 +94,7 @@ function typename_() result(name)
         ! Note the use of typemold_, instead of this_ensemble_.
 end function typename_
 
-   subroutine get_user_ens_(grd,member,ntindex,tau,atm_bundle,iret)
+   subroutine get_user_ens_(grd,member,nymd,nhms,tau,atm_bundle,iret)
    use m_kinds, only: i_kind,r_kind
    use gsi_bundlemod, only: gsi_bundle
    use general_sub2grid_mod, only: sub2grid_info
@@ -102,15 +102,15 @@ end function typename_
 !  Declare passed variables
       type(sub2grid_info)                   ,intent(in   ) :: grd
       integer(i_kind)                       ,intent(in   ) :: member
-      integer(i_kind)                       ,intent(in   ) :: ntindex
+      integer(i_kind)                       ,intent(in   ) :: nymd,nhms
       integer(i_kind)                       ,intent(in   ) :: tau
       type(gsi_bundle)                      ,intent(inout) :: atm_bundle
       integer(i_kind)                       ,intent(  out) :: iret
       call ifn_alloc_()     ! to ensure an allocated(this_ensemble_)
-      call this_ensemble_%get_user_ens(grd,member,ntindex,tau,atm_bundle,iret)
+      call this_ensemble_%get_user_ens(grd,member,nymd,nhms,tau,atm_bundle,iret)
    end subroutine get_user_ens_
 
-   subroutine get_user_Nens_(grd,members,ntindex,tau,atm_bundle,iret)
+   subroutine get_user_Nens_(grd,members,nymd,nhms,tau,atm_bundle,iret)
    use m_kinds, only: i_kind,r_kind
    use gsi_bundlemod, only: gsi_bundle
    use general_sub2grid_mod, only: sub2grid_info
@@ -118,12 +118,12 @@ end function typename_
 !  Declare passed variables
       type(sub2grid_info)                   ,intent(in   ) :: grd
       integer(i_kind)                       ,intent(in   ) :: members
-      integer(i_kind)                       ,intent(in   ) :: ntindex
+      integer(i_kind)                       ,intent(in   ) :: nymd,nhms
       integer(i_kind)                       ,intent(in   ) :: tau
       type(gsi_bundle)                      ,intent(inout) :: atm_bundle(:)
       integer(i_kind)                       ,intent(  out) :: iret
       call ifn_alloc_()     ! to ensure an allocated(this_ensemble_)
-      call this_ensemble_%get_user_Nens(grd,members,ntindex,tau,atm_bundle,iret)
+      call this_ensemble_%get_user_Nens(grd,members,nymd,nhms,tau,atm_bundle,iret)
    end subroutine get_user_Nens_
 
    subroutine put_user_ens_(grd,member,ntindex,pert,iret)

--- a/src/gsibec/gsi/guess_grids.f90
+++ b/src/gsibec/gsi/guess_grids.f90
@@ -89,7 +89,7 @@ end interface gsiguess_bkgcov_final
 
 logical, save :: gesgrid_initialized_ = .false.
 logical, save :: gesgrid_iamset_ = .false.
-logical :: debug_guess=.false.
+logical :: debug_guess=.true.
 
 character(len=*), parameter :: myname="guess_grids"
 contains
@@ -768,7 +768,7 @@ end subroutine final_
      endif
      ic=ic+1; debugvar(:,:,ic) = tskin
      ic=ic+1; debugvar(:,:,ic) = z
-     call write_bkgvars_grid(debugvar,debugvar,debugvar,tskin,'skin.grd',mype) ! debug
+     call write_bkgvars_grid(debugvar,debugvar,debugvar,ps,'skin.grd',mype) ! debug
      deallocate(debugvar)
   endif
 

--- a/src/gsibec/gsi/hybrid_ensemble_isotropic.F90
+++ b/src/gsibec/gsi/hybrid_ensemble_isotropic.F90
@@ -1145,7 +1145,7 @@ end subroutine normal_new_factorization_rf_y
 
   end subroutine create_ensemble
 
-  subroutine load_ensemble (tau)
+  subroutine load_ensemble (nymd,nhms,tau)
 !$$$  subprogram documentation block
 !                .      .    .                                       .
 ! subprogram:    load_ensemble    read/generate ensemble perturbations
@@ -1196,6 +1196,7 @@ end subroutine normal_new_factorization_rf_y
 
     implicit none
 
+    integer,intent(in) :: nymd,nhms
     integer,intent(in) :: tau
 
     type(get_pseudo_ensperts_class) :: pseudo_enspert
@@ -1320,7 +1321,7 @@ end subroutine normal_new_factorization_rf_y
 !            read in ensembles
        if (.not.regional) then
 
-          call get_gefs_ensperts_dualres(tau)
+          call get_gefs_ensperts_dualres(nymd,nhms,tau)
 
        else
 
@@ -5239,11 +5240,12 @@ subroutine setup_pwgt
 end subroutine setup_pwgt
 
 #ifdef USE_ALL_ORIGINAL
-subroutine ens_iterate_update(jiter)
+subroutine ens_iterate_update(nymd,nhms,jiter)
   use hybrid_ensemble_parameters, only: destroy_hybens_localization_parameters
   use hybrid_ensemble_parameters, only: bens_recenter
   use m_revBens, only: update_spread
   implicit none
+  integer(i_kind),intent(in) :: nymd,nhms
   integer(i_kind),intent(in) :: jiter
 
   if (jiter<2) return
@@ -5259,7 +5261,7 @@ subroutine ens_iterate_update(jiter)
 
 ! reload ensemble but this time use analysis for recentering
   call create_ensemble
-  call load_ensemble(-1)
+  call load_ensemble(nymd,nhms,-1)
   call hybens_localization_setup
 
 end subroutine ens_iterate_update

--- a/src/gsibec/gsi/hybrid_ensemble_parameters.f90
+++ b/src/gsibec/gsi/hybrid_ensemble_parameters.f90
@@ -296,6 +296,7 @@ module hybrid_ensemble_parameters
   public :: bens_recenter
   public :: upd_ens_spread
   public :: upd_ens_localization
+  public :: EnsSource
 
   logical l_hyb_ens,uv_hyb_ens,q_hyb_ens,oz_univ_static,sst_staticB
   logical bens_recenter,upd_ens_spread,upd_ens_localization
@@ -335,6 +336,7 @@ module hybrid_ensemble_parameters
   integer(i_kind) regional_ensemble_option
   character(len=512),save :: ensemble_path
   character(len=512),save :: ens_fname_tmpl
+  character(len=80) :: EnsSource
 
 ! following is for storage of ensemble perturbations:
 
@@ -424,6 +426,7 @@ subroutine init_hybrid_ensemble_parameters
   upd_ens_spread=.false.     ! redefine ens spread (for jiter>1) by recentering ens around guess 
   upd_ens_localization=.false.  ! update localization when upd_ens_spread=.t.
 
+  EnsSource = 'NULL'
 
 end subroutine init_hybrid_ensemble_parameters
 

--- a/src/gsibec/gsi/m_rf.f90
+++ b/src/gsibec/gsi/m_rf.f90
@@ -36,7 +36,10 @@ interface rf_unset; module procedure unset_; end interface
 
 character(len=*), parameter :: myname = 'm_rf'
 contains
-  subroutine set_ ()
+  subroutine set_ (nymd,nhms)
+  implicit none
+  integer(i_kind), intent(in) :: nymd,nhms
+ 
   character(len=*), parameter :: mynmae_ = myname//'*set_'
   integer(i_kind) msig,mlat,mlon
   logical good
@@ -54,7 +57,7 @@ contains
   call prewgt(mype)
 ! If hybrid covariance
   if(l_hyb_ens) then
-     call load_ensemble(-1)
+     call load_ensemble(nymd,nhms,-1)
      call hybens_localization_setup
   end if
   end subroutine set_

--- a/src/gsibec/gsi/stub_ensmod.f90
+++ b/src/gsibec/gsi/stub_ensmod.f90
@@ -58,7 +58,7 @@ contains
     mytype="["//myname//"::ensemble]"
   end function mytype
 
-  subroutine get_user_ens(this,grd,member,ntindex,tau,atm_bundle,iret)
+  subroutine get_user_ens(this,grd,member,nymd,nhms,tau,atm_bundle,iret)
 
      use m_kinds, only: i_kind
      use general_sub2grid_mod, only: sub2grid_info
@@ -70,7 +70,7 @@ contains
      class(ensemble),     intent(inout) :: this
      type(sub2grid_info), intent(in   ) :: grd
      integer(i_kind),     intent(in   ) :: member
-     integer(i_kind),     intent(in   ) :: ntindex
+     integer(i_kind),     intent(in   ) :: nymd,nhms
      integer(i_kind),     intent(in   ) :: tau
      type(gsi_bundle),    intent(inout) :: atm_bundle
      integer(i_kind),     intent(  out) :: iret
@@ -82,7 +82,7 @@ contains
 
   end subroutine get_user_ens
   
-  subroutine get_user_Nens(this,grd,members,ntindex,tau,atm_bundle,iret)
+  subroutine get_user_Nens(this,grd,members,nymd,nhms,tau,atm_bundle,iret)
  
      use m_kinds, only: i_kind
      use general_sub2grid_mod, only: sub2grid_info
@@ -94,7 +94,7 @@ contains
      class(ensemble),     intent(inout) :: this
      type(sub2grid_info), intent(in   ) :: grd
      integer(i_kind),     intent(in   ) :: members
-     integer(i_kind),     intent(in   ) :: ntindex
+     integer(i_kind),     intent(in   ) :: nymd,nhms
      integer(i_kind),     intent(in   ) :: tau
      type(gsi_bundle),    intent(inout) :: atm_bundle(:)
      integer(i_kind),     intent(  out) :: iret

--- a/src/gsibec/gsigeos/cplr_ensemble.F90
+++ b/src/gsibec/gsigeos/cplr_ensemble.F90
@@ -35,7 +35,7 @@ function typename()
   typename='['//myname//'::ensemble]'
 end function typename
 
-subroutine get_geos_ens(this,grd,member,ntindex,tau,atm_bundle,iret)
+subroutine get_geos_ens(this,grd,member,nymd,nhms,tau,atm_bundle,iret)
 !$$$  subprogram documentation block
 !                .      .    .                                       .
 ! subprogram:    get_user_ens_    pretend atmos bkg is the ensemble
@@ -95,7 +95,7 @@ implicit none
    class(ensemble)                      , intent(inout) :: this
    type(sub2grid_info)                   ,intent(in   ) :: grd
    integer(i_kind)                       ,intent(in   ) :: member
-   integer(i_kind)                       ,intent(in   ) :: ntindex
+   integer(i_kind)                       ,intent(in   ) :: nymd,nhms
    integer(i_kind)                       ,intent(in   ) :: tau
    integer(i_kind)                       ,intent(  out) :: iret
    type(gsi_bundle)                      ,intent(inout) :: atm_bundle                      
@@ -103,7 +103,7 @@ implicit none
 !  Declare internal variables
    character(len=*),parameter::myname='geos_get_ens_'
    character(len=40) evar
-   integer(i_kind) nymd,nhms,istatus,ii,ier
+   integer(i_kind) istatus,ii,ier
    integer(i_kind) ida(8),jda(8)
    logical,save :: first=.true.
    real(r_kind) fha(5)
@@ -148,19 +148,6 @@ implicit none
    endif
 
 !  Read in a single ensemble member
-   if(l4densvar) then
-      ida(1:3)=ibdate(1:3)
-      ida(5:6)=ibdate(4:5)
-      jda(:)=0
-      fha(:)=0.0
-      fha(3)=ens_fmnlevs(ntindex)-180.0_r_kind ! NCEP counts time from previous syn analysis (180min=3hr)
-      !call w3movdat(fha,ida,jda)
-      nymd=jda(1)*10000+jda(2)*100+jda(3)
-      nhms=jda(5)*10000+jda(6)*100
-   else
-      nymd = iadate(1)*10000 + iadate(2)*100 + iadate(3)
-      nhms = iadate(4)*10000 + iadate(5)*100
-   endif
 #ifdef USE_ALL_ORIGINAL
    call timer_ini('GetEns')
 #endif /* USE_ALL_ORIGINAL */
@@ -209,7 +196,7 @@ implicit none
 
 end subroutine get_geos_ens
 
-subroutine get_geos_Nens(this,grd,members,ntindex,tau,atm_bundle,iret)
+subroutine get_geos_Nens(this,grd,members,nymd,nhms,tau,atm_bundle,iret)
 !$$$  subprogram documentation block
 !                .      .    .                                       .
 ! subprogram:    get_user_Nens_    pretend atmos bkg is the ensemble
@@ -270,7 +257,7 @@ implicit none
    class(ensemble)                      , intent(inout) :: this
    type(sub2grid_info)                   ,intent(in   ) :: grd
    integer(i_kind)                       ,intent(in   ) :: members
-   integer(i_kind)                       ,intent(in   ) :: ntindex
+   integer(i_kind)                       ,intent(in   ) :: nymd,nhms
    integer(i_kind)                       ,intent(in   ) :: tau
    integer(i_kind)                       ,intent(  out) :: iret
    type(gsi_bundle)                      ,intent(inout) :: atm_bundle(:)                      
@@ -278,7 +265,7 @@ implicit none
 !  Declare internal variables
    character(len=*),parameter::myname='geos_get_Nens_'
    character(len=40) evar
-   integer(i_kind) nymd,nhms,istatus,ii,ier
+   integer(i_kind) istatus,ii,ier
    integer(i_kind) ida(8),jda(8)
    integer(i_kind) mm
    logical,save :: first=.true.
@@ -327,19 +314,6 @@ implicit none
    enddo
 
 !  Read in ensemble members
-   if(l4densvar) then
-      ida(1:3)=ibdate(1:3)
-      ida(5:6)=ibdate(4:5)
-      jda(:)=0
-      fha(:)=0.0
-      fha(3)=ens_fmnlevs(ntindex)-180.0_r_kind ! NCEP counts time from previous syn analysis (180min=3hr)
-      !call w3movdat(fha,ida,jda)
-      nymd=jda(1)*10000+jda(2)*100+jda(3)
-      nhms=jda(5)*10000+jda(6)*100
-   else
-      nymd = iadate(1)*10000 + iadate(2)*100 + iadate(3)
-      nhms = iadate(4)*10000 + iadate(5)*100
-   endif
 #ifdef USE_ALL_ORIGINAL
    call timer_ini('GetEns')
 #endif /* USE_ALL_ORIGINAL */

--- a/src/gsibec/gsigeos/gsi_fixture_GEOS.F90
+++ b/src/gsibec/gsigeos/gsi_fixture_GEOS.F90
@@ -1,4 +1,4 @@
-module gsi_fixture
+module gsi_fixture_GEOS
 !$$$  subprogram documentation block
 !                .      .    .                                       .
 ! subprogram:	 module gsi_fixture_GEOS (but named as gsi_fixture)
@@ -46,20 +46,17 @@ subroutine fixture_config()
 !> singleton timermod and gsi_enscouplemod, which manage the actual timer and
 !> geos_ensenble extentions.
 
-!_RT  use timermod         , only: timer_typedef
   use gsi_enscouplermod, only: ensemble_typedef => gsi_enscoupler_registry
 
 !> Define the actual extensions (timermod and geos_ensemble) to be used.
 
-!_RT  use m_zeitTimer  , only: my_timer_mold    => timer_typemold
   use cplr_ensemble, only: my_ensemble_mold => ensemble_typemold
 
   implicit none
 
 !> Fix up the extensions used by corresponding GSI singleton modules.
 
-!_RT  call    timer_typedef(my_timer_mold())
   call ensemble_typedef(my_ensemble_mold())
 
 end subroutine fixture_config
-end module gsi_fixture
+end module gsi_fixture_GEOS

--- a/src/gsibec/gsigfs/CMakeLists.txt
+++ b/src/gsibec/gsigfs/CMakeLists.txt
@@ -1,7 +1,7 @@
-# GSI-GEOS
+# GSI-GFS
 
 list(APPEND gsigfs_src_files_list
-ncepnems_io.f90
+gsi_fixture_GFS.F90
 )
 
 set( gsigfs_src_files

--- a/src/gsibec/gsigfs/gsi_fixture_GFS.F90
+++ b/src/gsibec/gsigfs/gsi_fixture_GFS.F90
@@ -1,4 +1,4 @@
-module gsi_fixture
+module gsi_fixture_GFS
 !$$$  subprogram documentation block
 !                .      .    .                                       .
 ! subprogram:	 module gsi_fixture_GFS (but named as gsi_fixture)
@@ -46,20 +46,19 @@ subroutine fixture_config()
 !> singleton timermod and gsi_enscouplemod, which manage the actual timer and
 !> gfs_ensenble extentions.
 
-!_RT  use timermod         , only: timer_typedef
-  use gsi_enscouplermod, only: ensemble_typedef => gsi_enscoupler_registry
+! use gsi_enscouplermod, only: ensemble_typedef => gsi_enscoupler_registry
 
 !> Define the actual extensions (timermod and gfs_ensemble) to be used.
 
-!_RT  use m_stubTimer       , only: my_timer_mold    => timer_typemold
-  use get_gfs_ensmod_mod, only: my_ensemble_mold => ensemble_typemold
+! use get_gfs_ensmod_mod, only: my_ensemble_mold => ensemble_typemold
 
   implicit none
 
 !> Fix up the extensions used by corresponding GSI singleton modules.
 
-!_RT  call    timer_typedef(my_timer_mold())
-  call ensemble_typedef(my_ensemble_mold())
+! call ensemble_typedef(my_ensemble_mold())
+  print *, 'Want to read GFS ensemble, not avail, abort ... ' 
+  call stop2(9999)
 
 end subroutine fixture_config
-end module gsi_fixture
+end module gsi_fixture_GFS


### PR DESCRIPTION
This allows for reader of ensemble to see actual date and time. This introduces the ability for JEDI to run Hybrid-4dEnVar. However, it should be noted that this is accomplished here not by triggering the GSI knobs for hub-4DenVar, but rather by using simply the hybrid-3dVar knobs. By seeing the time, the ensemble part of such configuration can know which time slot should be read in and treated accordingly. 

This feature makes it hard for implementing time localization within the context of GSIbec ... but this is not something either GMAO or EMC is doing right now. 

Also, this implementation has a larger memory footprint since a copy of the climatological B exists in the every chunk of PEs used by JEDI to handle each time slot. The consequences of this will need to be investigated later.

This is a zero diff changes unless JEDI is running hybrid 4dEnVar.

Note: this also has a preliminary entry to accommodate the ensemble from EMC. The code actually filling in the feature is being worked out and will be added in another PR.