### PR TITLE
Use ip@5 if found instead of sp as optional NCEP spectral library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,10 @@ find_package( MPI REQUIRED COMPONENTS Fortran )
 find_package( NetCDF REQUIRED COMPONENTS Fortran )
 
 # NCEP spectral library (optional)
-find_package( sp QUIET )
+find_package(ip 5)
+if(NOT ip_FOUND)
+  find_package(sp)
+endif()
 
 ################################################################################
 # Sources

--- a/src/gsibec/CMakeLists.txt
+++ b/src/gsibec/CMakeLists.txt
@@ -20,7 +20,9 @@ target_link_libraries( ${PROJECT_NAME} PUBLIC MPI::MPI_Fortran )
 target_link_libraries( ${PROJECT_NAME} PUBLIC ${LAPACK_LIBRARIES} )
 
 # NCEP spectral library
-if( sp_FOUND )
+if( ip_FOUND )
+    target_link_libraries( gsibec PUBLIC ip::ip_d)
+elseif( sp_FOUND )
     target_link_libraries( gsibec PUBLIC sp::sp_d)
 endif()
 

--- a/src/gsibec/gsi/CMakeLists.txt
+++ b/src/gsibec/gsi/CMakeLists.txt
@@ -99,7 +99,7 @@ xhat_vordivmod.f90
 )
 
 # Stubs for sp lib if package is not found
-if( NOT sp_FOUND )
+if( NOT ip_FOUND AND NOT sp_FOUND )
   list( APPEND gsi_src_files_list stub_sp.f90 )
 endif()
 


### PR DESCRIPTION
This resolves https://github.com/GEOS-ESM/GSIbec/issues/65. I've tested compiling with either ip@5 loaded, or sp@2.5 loaded, or none of them, and it compiled successfully each time. I didn't run any tests with it, though.