### PR TITLE
Bring 1.2.1 to develop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 ################################################################################
 
 cmake_minimum_required( VERSION 3.12 )
-project( gsibec VERSION 1.1.3 LANGUAGES Fortran )
+project( gsibec VERSION 1.2.1 LANGUAGES Fortran )
 
 ## Ecbuild integration
 set( ECBUILD_DEFAULT_BUILD_TYPE Release )
@@ -38,10 +38,7 @@ find_package( MPI REQUIRED COMPONENTS Fortran )
 find_package( NetCDF REQUIRED COMPONENTS Fortran )
 
 # NCEP spectral library (optional)
-find_package(ip 5)
-if(NOT ip_FOUND)
-  find_package(sp)
-endif()
+find_package( sp QUIET )
 
 ################################################################################
 # Sources

--- a/src/gsibec/CMakeLists.txt
+++ b/src/gsibec/CMakeLists.txt
@@ -20,9 +20,7 @@ target_link_libraries( ${PROJECT_NAME} PUBLIC MPI::MPI_Fortran )
 target_link_libraries( ${PROJECT_NAME} PUBLIC ${LAPACK_LIBRARIES} )
 
 # NCEP spectral library
-if( ip_FOUND )
-    target_link_libraries( gsibec PUBLIC ip::ip_d)
-elseif( sp_FOUND )
+if( sp_FOUND )
     target_link_libraries( gsibec PUBLIC sp::sp_d)
 endif()
 

--- a/src/gsibec/gsi/CMakeLists.txt
+++ b/src/gsibec/gsi/CMakeLists.txt
@@ -99,7 +99,7 @@ xhat_vordivmod.f90
 )
 
 # Stubs for sp lib if package is not found
-if( NOT ip_FOUND AND NOT sp_FOUND )
+if( NOT sp_FOUND )
   list( APPEND gsi_src_files_list stub_sp.f90 )
 endif()
 

--- a/src/gsibec/gsi/README
+++ b/src/gsibec/gsi/README
@@ -28,13 +28,11 @@ balmod
    TO DO FOR SABER CONNECTION
 ++++++++++++++++++++++++++++++++++++++++++++++++
 - replace kinds w/ OOPS kinds
-- complete bringing back hybrid capability: 4d does something but not quite correct
+- complete bringing back hybrid capability: need 4d still
 - bring in hybrid capability for NCEP
 
 Other TO DOs
 ------------
 - revise items above
 - fill in halo for var comming from saber
-- need to put back call to turbl in calctends
-- need to encapsulate namelists (might be able to do it piecemeal)
-- remove test_nymd/nhms
+- fill in isli properly

--- a/src/gsibec/gsi/calctends.F90
+++ b/src/gsibec/gsi/calctends.F90
@@ -406,7 +406,6 @@ subroutine calctends(mype,teta,pri,guess,xderivative,yderivative,tendency)
 
   character(len=*),parameter::myname_=myname//'*init_vars_'
   integer(i_kind) ier,istatus
-  integer(i_kind) icw,ioz,iq,ip3d
 
 !NOTE: this is not general - and in many ways it's wired just as the original
 !      code. However, this can be easily generalized by a little re-write

--- a/src/gsibec/gsi/control_vectors.f90
+++ b/src/gsibec/gsi/control_vectors.f90
@@ -80,6 +80,8 @@ use constants, only: zero, one, two, three, zero_quad, tiny_r_kind
 use mpeu_util, only: get_lun => luavail
 use mpeu_util, only: warn
 use mpl_allreducemod, only: mpl_allreduce
+use hybrid_ensemble_parameters, only: l_hyb_ens
+use hybrid_ensemble_parameters, only: grd_ens
 use constants, only : max_varname_length
 
 use m_rerank, only : rerank
@@ -150,10 +152,8 @@ character(len=*),parameter:: myname='control_vectors'
 
 integer(i_kind) :: nclen,nclen1,nsclen,npclen,ntclen,nrclen,nsubwin,nval_len
 integer(i_kind) :: latlon11,latlon1n,lat2,lon2,nsig,n_ens
-integer(i_kind) :: enlat2,enlon2,ennsig,enlatlon11
 integer(i_kind) :: nval_lenz_en
 logical :: lsqrtb,lcalc_gfdl_cfrac  
-logical :: l_hyb_ens
 
 integer(i_kind) :: m_vec_alloc, max_vec_alloc, m_allocs, m_deallocs
 
@@ -200,7 +200,7 @@ contains
 ! ----------------------------------------------------------------------
 subroutine setup_control_vectors(ksig,klat,klon,katlon11,katlon1n, &
                                  ksclen,kpclen,ktclen,kclen,ksubwin,kval_len,ldsqrtb,k_ens,&
-                                 kval_lenz_en,kenlat,kenlon,kensig,kenlatlon11,lhybens)
+                                 kval_lenz_en)
 !$$$  subprogram documentation block
 !                .      .    .                                       .
 ! subprogram:    setup_control_vectors
@@ -241,18 +241,11 @@ subroutine setup_control_vectors(ksig,klat,klon,katlon11,katlon1n, &
   integer(i_kind)          , intent(in   ) :: ksig,klat,klon,katlon11,katlon1n, &
                                  ksclen,kpclen,ktclen,kclen,ksubwin,kval_len,k_ens,&
                                  kval_lenz_en
-  integer(i_kind)          , intent(in   ) :: kensig,kenlat,kenlon,kenlatlon11
   logical                  , intent(in   ) :: ldsqrtb
-  logical                  , intent(in   ) :: lhybens
 
-  l_hyb_ens = lhybens
   nsig=ksig
   lat2=klat
   lon2=klon
-  ennsig=kensig
-  enlat2=kenlat
-  enlon2=kenlon
-  enlatlon11=kenlatlon11
   latlon11=katlon11
   latlon1n=katlon1n
   nsclen=ksclen
@@ -445,7 +438,7 @@ subroutine allocate_cv(ycv)
 ! program history log:
 !   2009-08-04  lueken - added subprogram doc block
 !   2009-09-20  parrish - add optional allocation of hybrid ensemble control variable a_en
-!   2010-02-20  parrish - add ens dims as part of changes for dual-resolution
+!   2010-02-20  parrish - add structure variable grd_ens as part of changes for dual-resolution
 !                           hybrid ensemble system.
 !   2010-02-25  zhu     - use nrf_var and nrf_3d to specify the order control variables
 !   2010-05-01  todling - update to use gsi_bundle
@@ -499,11 +492,11 @@ subroutine allocate_cv(ycv)
   n_aens=0
   if (l_hyb_ens) then
       ALLOCATE(ycv%aens(nsubwin,n_ens))
-         call GSI_GridCreate(ycv%grid_aens,enlat2,enlon2,ennsig)
+         call GSI_GridCreate(ycv%grid_aens,grd_ens%lat2,grd_ens%lon2,grd_ens%nsig)
          if (lsqrtb) then
             n_aens=nval_lenz_en
          else
-            n_aens=enlatlon11*ennsig
+            n_aens=grd_ens%latlon11*grd_ens%nsig
          endif
   endif
 

--- a/src/gsibec/gsi/en_perts_io.f90
+++ b/src/gsibec/gsi/en_perts_io.f90
@@ -1,4 +1,4 @@
-subroutine en_perts_get_from_save_fulldomain(epts)
+subroutine en_perts_get_from_save_fulldomain
 !$$$  subprogram documentation block
 !                .      .    .                                       .
 ! subprogram:    en_perts_get_from_save  get content of en_perts from saved
@@ -21,7 +21,7 @@ subroutine en_perts_get_from_save_fulldomain(epts)
 !$$$ end documentation block
 
   use gridmod, only: regional
-  use hybrid_ensemble_parameters, only: gsi_enperts
+  use hybrid_ensemble_parameters, only: en_perts
   use hybrid_ensemble_parameters, only: n_ens,grd_ens
   use control_vectors, only: cvars2d,cvars3d,nc2d,nc3d
   use gsi_bundlemod, only: gsi_bundle
@@ -36,8 +36,6 @@ subroutine en_perts_get_from_save_fulldomain(epts)
   use m_mpimod, only: mpi_rtype,mpi_info_null,mpi_offset_kind
 
   implicit none
-
-  type(gsi_enperts) :: epts
 
   type(sub2grid_info) grd_arw
   real(r_single),pointer,dimension(:,:,:):: w3
@@ -126,7 +124,7 @@ subroutine en_perts_get_from_save_fulldomain(epts)
 
      do ic3=1,nc3d
 
-        call gsi_bundlegetpointer(epts%en_perts(n,1),trim(cvars3d(ic3)),w3,istatus)
+        call gsi_bundlegetpointer(en_perts(n,1),trim(cvars3d(ic3)),w3,istatus)
         if(istatus/=0) then
            write(6,*)' error retrieving pointer to ',trim(cvars3d(ic3)),' for ensemble member ',n
            call stop2(999)
@@ -144,7 +142,7 @@ subroutine en_perts_get_from_save_fulldomain(epts)
 
      do ic2=1,nc2d
 
-        call gsi_bundlegetpointer(epts%en_perts(n,1),trim(cvars2d(ic2)),w2,istatus)
+        call gsi_bundlegetpointer(en_perts(n,1),trim(cvars2d(ic2)),w2,istatus)
         if(istatus/=0) then
            write(6,*)' error retrieving pointer to ',trim(cvars2d(ic2)),' for ensemble member ',n
            call stop2(999)
@@ -164,7 +162,7 @@ subroutine en_perts_get_from_save_fulldomain(epts)
 
 end subroutine en_perts_get_from_save_fulldomain
 
-subroutine en_perts_get_from_save(epts)
+subroutine en_perts_get_from_save
 !$$$  subprogram documentation block
 !                .      .    .                                       .
 ! subprogram:    en_perts_get_from_save  get content of en_perts from saved
@@ -186,7 +184,7 @@ subroutine en_perts_get_from_save(epts)
 !
 !$$$ end documentation block
 
-  use hybrid_ensemble_parameters, only: gsi_enperts
+  use hybrid_ensemble_parameters, only: en_perts,ps_bar
   use hybrid_ensemble_parameters, only: n_ens
   use control_vectors, only: cvars2d,cvars3d,nc2d,nc3d
   use gsi_bundlemod, only: gsi_bundle
@@ -198,7 +196,6 @@ subroutine en_perts_get_from_save(epts)
   use mpeu_util, only: die
   implicit none
 
-  type(gsi_enperts) :: epts
   real(r_single),pointer,dimension(:,:,:):: w3
   real(r_single),pointer,dimension(:,:):: w2
 
@@ -220,11 +217,11 @@ subroutine en_perts_get_from_save(epts)
         write(6,*)' error in ensemble number. read in ',nn,' looking for ',n
         call stop2(999)
      endif
-     read(iunit) epts%ps_bar(:,:,1)
+     read(iunit) ps_bar(:,:,1)
 !
      do ic3=1,nc3d
 
-        call gsi_bundlegetpointer(epts%en_perts(n,1),trim(cvars3d(ic3)),w3,istatus)
+        call gsi_bundlegetpointer(en_perts(n,1),trim(cvars3d(ic3)),w3,istatus)
         if(istatus/=0) then
            write(6,*)' error retrieving pointer to ',trim(cvars3d(ic3)),' for ensemble member ',n
            call stop2(999)
@@ -241,7 +238,7 @@ subroutine en_perts_get_from_save(epts)
 
      do ic2=1,nc2d
 
-        call gsi_bundlegetpointer(epts%en_perts(n,1),trim(cvars2d(ic2)),w2,istatus)
+        call gsi_bundlegetpointer(en_perts(n,1),trim(cvars2d(ic2)),w2,istatus)
         if(istatus/=0) then
            write(6,*)' error retrieving pointer to ',trim(cvars2d(ic2)),' for ensemble member ',n
            call stop2(999)
@@ -262,7 +259,7 @@ subroutine en_perts_get_from_save(epts)
 
 end subroutine en_perts_get_from_save
 
-subroutine en_perts_save(epts)
+subroutine en_perts_save
 !$$$  subprogram documentation block
 !                .      .    .                                       .
 ! subprogram:    en_perts_save  save content in en_perts to a file.
@@ -283,7 +280,7 @@ subroutine en_perts_save(epts)
 !
 !$$$ end documentation block
 
-  use hybrid_ensemble_parameters, only: gsi_enperts
+  use hybrid_ensemble_parameters, only: en_perts,ps_bar
   use hybrid_ensemble_parameters, only: n_ens
   use control_vectors, only: cvars2d,cvars3d,nc2d,nc3d
   use gsi_bundlemod, only: gsi_bundle
@@ -294,7 +291,6 @@ subroutine en_perts_save(epts)
   use mpeu_util, only: die
   implicit none
 
-  type(gsi_enperts) :: epts
   real(r_single),pointer,dimension(:,:,:):: w3
   real(r_single),pointer,dimension(:,:):: w2
 
@@ -312,11 +308,11 @@ subroutine en_perts_save(epts)
   do n=1,n_ens
 !
      write(iunit) n
-     write(iunit) epts%ps_bar(:,:,1)
+     write(iunit) ps_bar(:,:,1)
 !
      do ic3=1,nc3d
 
-        call gsi_bundlegetpointer(epts%en_perts(n,1),trim(cvars3d(ic3)),w3,istatus)
+        call gsi_bundlegetpointer(en_perts(n,1),trim(cvars3d(ic3)),w3,istatus)
         if(istatus/=0) then
            write(6,*)' error retrieving pointer to ',trim(cvars3d(ic3)),' for ensemble member ',n
            call stop2(999)
@@ -328,7 +324,7 @@ subroutine en_perts_save(epts)
      end do
      do ic2=1,nc2d
 
-        call gsi_bundlegetpointer(epts%en_perts(n,1),trim(cvars2d(ic2)),w2,istatus)
+        call gsi_bundlegetpointer(en_perts(n,1),trim(cvars2d(ic2)),w2,istatus)
         if(istatus/=0) then
            write(6,*)' error retrieving pointer to ',trim(cvars2d(ic2)),' for ensemble member ',n
            call stop2(999)

--- a/src/gsibec/gsi/ensctl2state.F90
+++ b/src/gsibec/gsi/ensctl2state.F90
@@ -1,4 +1,4 @@
-subroutine ensctl2state(epts,xhat,mval,eval)
+subroutine ensctl2state(xhat,mval,eval)
 !$$$  subprogram documentation block
 !                .      .    .                                       .
 ! subprogram:    ensctl2state
@@ -30,7 +30,6 @@ use m_kinds, only: r_kind,i_kind
 use control_vectors, only: control_vector,cvars3d
 use gsi_4dvar, only: ibin_anl
 use hybrid_ensemble_parameters, only: uv_hyb_ens,dual_res,ntlevs_ens,q_hyb_ens
-use hybrid_ensemble_parameters, only: gsi_enperts
 use hybrid_ensemble_isotropic, only: ensemble_forward_model,ensemble_forward_model_dual_res
 use gsi_bundlemod, only: gsi_bundlecreate
 use gsi_bundlemod, only: gsi_bundle
@@ -53,7 +52,6 @@ use gridmod, only: nems_nmmb_regional
 implicit none
 
 ! Declare passed variables
-type(gsi_enperts)   , intent(inout) :: epts
 type(control_vector), intent(in   ) :: xhat
 type(gsi_bundle)    , intent(in   ) :: mval
 type(gsi_bundle)    , intent(inout) :: eval(ntlevs_ens)
@@ -171,9 +169,9 @@ do jj=1,ntlevs_ens
 !  For 4densvar, this is the "3D/Time-invariant contribution from static B"
 
    if(dual_res) then
-      call ensemble_forward_model_dual_res(wbundle_c,xhat%aens(1,:),epts,jj)
+      call ensemble_forward_model_dual_res(wbundle_c,xhat%aens(1,:),jj)
    else
-      call ensemble_forward_model(wbundle_c,xhat%aens(1,:),epts,jj)
+      call ensemble_forward_model(wbundle_c,xhat%aens(1,:),jj)
    end if
 
 !  Get pointers to required state variables
@@ -181,7 +179,7 @@ do jj=1,ntlevs_ens
    call gsi_bundlegetpointer (eval(jj),'tv'  ,sv_tv,  istatus)
    call gsi_bundlegetpointer (eval(jj),'q'   ,sv_q ,  istatus)
    call gsi_bundlegetpointer (eval(jj),'prse',sv_prse,istatus)
-   call gsi_bundlegetpointer (wbundle_c,'q'  ,cv_rh ,istatus)
+   call gsi_bundlegetpointer (wbundle_c,'q'  ,cv_rh  ,istatus)
    call gsi_bundlegetpointer (eval(jj),'u'   ,sv_u,   istatus)
    call gsi_bundlegetpointer (eval(jj),'v'   ,sv_v,   istatus)
    call gsi_bundlegetpointer (eval(jj),'tsen',sv_tsen,istatus)

--- a/src/gsibec/gsi/ensctl2state_ad.F90
+++ b/src/gsibec/gsi/ensctl2state_ad.F90
@@ -1,4 +1,4 @@
-subroutine ensctl2state_ad(epts,eval,mval,grad)
+subroutine ensctl2state_ad(eval,mval,grad)
 !$$$  subprogram documentation block
 !                .      .    .                                       .
 ! subprogram:    ensctl2state_ad
@@ -27,7 +27,6 @@ use m_kinds, only: r_kind,i_kind
 use control_vectors, only: control_vector,cvars3d
 use gsi_4dvar, only: ibin_anl
 use hybrid_ensemble_parameters, only: uv_hyb_ens,dual_res,ntlevs_ens,q_hyb_ens
-use hybrid_ensemble_parameters, only: gsi_enperts
 use hybrid_ensemble_isotropic, only: ensemble_forward_model_ad
 use hybrid_ensemble_isotropic, only: ensemble_forward_model_ad_dual_res
 use gsi_bundlemod, only: gsi_bundlecreate
@@ -52,7 +51,6 @@ use gridmod, only: nems_nmmb_regional
 implicit none
 
 ! Declare passed variables
-type(gsi_enperts)   , intent(in)    :: epts
 type(control_vector), intent(inout) :: grad
 type(gsi_bundle)    , intent(inout) :: mval
 type(gsi_bundle)    , intent(in   ) :: eval(ntlevs_ens)
@@ -269,9 +267,9 @@ do jj=1,ntlevs_ens
 !$omp end parallel sections
 
    if(dual_res) then
-      call ensemble_forward_model_ad_dual_res(wbundle_c,grad%aens(1,:),epts,jj)
+      call ensemble_forward_model_ad_dual_res(wbundle_c,grad%aens(1,:),jj)
    else
-      call ensemble_forward_model_ad(wbundle_c,grad%aens(1,:),epts,jj)
+      call ensemble_forward_model_ad(wbundle_c,grad%aens(1,:),jj)
    end if
 
 end do

--- a/src/gsibec/gsi/get_gefs_ensperts_dualres.F90
+++ b/src/gsibec/gsi/get_gefs_ensperts_dualres.F90
@@ -1,4 +1,4 @@
-subroutine get_gefs_ensperts_dualres (epts,nymd,nhms,tau)
+subroutine get_gefs_ensperts_dualres (tau)
 !$$$  subprogram documentation block
 !                .      .    .                                       .
 ! subprogram:    get_gefs_ensperts_dualres copy of get_gefs_ensperts for dual resolution
@@ -51,10 +51,10 @@ subroutine get_gefs_ensperts_dualres (epts,nymd,nhms,tau)
   use mpeu_util, only: die
   use gridmod, only: idsl5
   use hybrid_ensemble_parameters, only: n_ens,write_ens_sprd,oz_univ_static,ntlevs_ens
+  use hybrid_ensemble_parameters, only: nymd,nhms
   use hybrid_ensemble_parameters, only: sst_staticB
   use hybrid_ensemble_parameters, only: bens_recenter
-  use hybrid_ensemble_parameters, only: gsi_enperts
-  use hybrid_ensemble_parameters, only: test_nymd,test_nhms
+  use hybrid_ensemble_parameters, only: en_perts,ps_bar,nelen
   use constants,only: zero,zero_single,half,fv,rd_over_cp,one,qcmin
   use m_mpimod, only: gsi_mpi_comm_world,mype,npe
   use m_kinds, only: r_kind,i_kind,r_single
@@ -77,9 +77,6 @@ subroutine get_gefs_ensperts_dualres (epts,nymd,nhms,tau)
 #endif /* USE_ALL_ORIGINAL */
   implicit none
 
-  type(gsi_enperts) :: epts
-  integer(i_kind),intent(in) :: nymd ! yyyymmdd
-  integer(i_kind),intent(in) :: nhms ! hhmmss
   integer(i_kind),intent(in) :: tau
 
   real(r_kind),pointer,dimension(:,:)   :: ps
@@ -104,29 +101,27 @@ subroutine get_gefs_ensperts_dualres (epts,nymd,nhms,tau)
   integer(i_kind) ipc3d(nc3d),ipc2d(nc2d)
   integer(i_kind) ier
 ! integer(i_kind) il,jl
-  logical ice,hydrometeor,ihavetv,ihaveq
+  logical ice,hydrometeor 
   type(sub2grid_info) :: grd_tmp
 
 ! Create perturbations grid and get variable names from perturbations
-  if(epts%en_perts(1,1)%grid%im/=grd_ens%lat2.or. &
-     epts%en_perts(1,1)%grid%jm/=grd_ens%lon2.or. &
-     epts%en_perts(1,1)%grid%km/=grd_ens%nsig ) then
+  if(en_perts(1,1)%grid%im/=grd_ens%lat2.or. &
+     en_perts(1,1)%grid%jm/=grd_ens%lon2.or. &
+     en_perts(1,1)%grid%km/=grd_ens%nsig ) then
      if (mype==0) then
         write(6,*) 'get_gefs_ensperts_dualres: grd_ens ', grd_ens%lat2,grd_ens%lon2,grd_ens%nsig
-        write(6,*) 'get_gefs_ensperts_dualres: pertgrid', epts%en_perts(1,1)%grid%im, &
-                                                          epts%en_perts(1,1)%grid%jm, &
-                                                          epts%en_perts(1,1)%grid%km
+        write(6,*) 'get_gefs_ensperts_dualres: pertgrid', en_perts(1,1)%grid%im, en_perts(1,1)%grid%jm, en_perts(1,1)%grid%km
         write(6,*) 'get_gefs_ensperts_dualres: inconsistent dims, aborting ...'
      endif
      call stop2(999)
  endif
 
-  call gsi_bundlegetpointer (epts%en_perts(1,1),cvars3d,ipc3d,istatus)
+  call gsi_bundlegetpointer (en_perts(1,1),cvars3d,ipc3d,istatus)
   if(istatus/=0) then
     write(6,*) ' get_gefs_ensperts_dualres',': cannot find 3d pointers'
     call stop2(999)
   endif
-  call gsi_bundlegetpointer (epts%en_perts(1,1),cvars2d,ipc2d,istatus)
+  call gsi_bundlegetpointer (en_perts(1,1),cvars2d,ipc2d,istatus)
   if(istatus/=0) then
     write(6,*) ' get_gefs_ensperts_dualres',': cannot find 2d pointers'
     call stop2(999)
@@ -136,9 +131,9 @@ subroutine get_gefs_ensperts_dualres (epts,nymd,nhms,tau)
   kap1=rd_over_cp+one
   kapr=one/rd_over_cp
 
-  im=epts%en_perts(1,1)%grid%im
-  jm=epts%en_perts(1,1)%grid%jm
-  km=epts%en_perts(1,1)%grid%km
+  im=en_perts(1,1)%grid%im
+  jm=en_perts(1,1)%grid%jm
+  km=en_perts(1,1)%grid%km
 
   ! Create temporary communication information for read ensemble routines
   call gsi_enscoupler_create_sub2grid_info(grd_tmp,km,npe,grd_ens)
@@ -146,7 +141,7 @@ subroutine get_gefs_ensperts_dualres (epts,nymd,nhms,tau)
   ! Allocate bundle to hold mean of ensemble members
   allocate(en_bar(ntlevs_ens))
   do m=1,ntlevs_ens
-     call gsi_bundlecreate(en_bar(m),epts%en_perts(1,1)%grid,'ensemble',istatus,names2d=cvars2d,names3d=cvars3d)
+     call gsi_bundlecreate(en_bar(m),en_perts(1,1)%grid,'ensemble',istatus,names2d=cvars2d,names3d=cvars3d)
      if ( istatus /= 0 ) &
         call die('get_gefs_ensperts_dualres',': trouble creating en_bar bundle, istatus =',istatus)
   end do
@@ -154,7 +149,7 @@ subroutine get_gefs_ensperts_dualres (epts,nymd,nhms,tau)
   ! Allocate bundle used for reading members
   allocate(en_read(n_ens))
   do n=1,n_ens
-     call gsi_bundlecreate(en_read(n),epts%en_perts(1,1)%grid,'ensemble member',istatus,names2d=cvars2d,names3d=cvars3d)
+     call gsi_bundlecreate(en_read(n),en_perts(1,1)%grid,'ensemble member',istatus,names2d=cvars2d,names3d=cvars3d)
      if ( istatus /= 0 ) &
         call die('get_gefs_ensperts_dualres',': trouble creating en_read bundle, istatus =',istatus)
   end do
@@ -168,11 +163,7 @@ subroutine get_gefs_ensperts_dualres (epts,nymd,nhms,tau)
 
      en_bar(m)%values=zero
 
-     if (ntlevs_ens>1) then
-       call gsi_enscoupler_get_user_Nens(grd_tmp,n_ens,test_nymd(m),test_nhms(m),tau,en_read,iret)
-     else
-       call gsi_enscoupler_get_user_Nens(grd_tmp,n_ens,nymd,nhms,tau,en_read,iret)
-     endif
+     call gsi_enscoupler_get_user_Nens(grd_tmp,n_ens,nymd(m),nhms(m),tau,en_read,iret)
 
      ! Check read return code.  Revert to static B if read error detected
      if ( iret /= 0 ) then
@@ -186,49 +177,46 @@ subroutine get_gefs_ensperts_dualres (epts,nymd,nhms,tau)
 
      n_ens_loop: do n=1,n_ens
 
-       epts%en_perts(n,m)%valuesr4=zero
+       en_perts(n,m)%valuesr4=zero
 
        if (.not.q_hyb_ens) then !use RH
-         call gsi_bundlegetpointer(en_read(n),'ps',ps,ier)
-         call gsi_bundlegetpointer(en_read(n),'t' ,tv,ier);ihavetv=ier==0
-         call gsi_bundlegetpointer(en_read(n),'q' ,q ,ier);ihaveq =ier==0
+         call gsi_bundlegetpointer(en_read(n),'ps',ps,ier);istatus=ier
+         call gsi_bundlegetpointer(en_read(n),'t' ,tv,ier);istatus=istatus+ier
+         call gsi_bundlegetpointer(en_read(n),'q' ,q ,ier);istatus=istatus+ier
 ! Compute RH
 ! Get 3d pressure field now on interfaces
          allocate(pri(im,jm,km+1))
-!        call general_getprs_glb(ps,tv,pri)
-         call general_getprs_glb(ps,pri)
-         if(ihavetv .and. ihaveq) then
-           allocate(prsl(im,jm,km),tsen(im,jm,km),qs(im,jm,km))
+         call general_getprs_glb(ps,tv,pri)
+         allocate(prsl(im,jm,km),tsen(im,jm,km),qs(im,jm,km))
 ! Get sensible temperature and 3d layer pressure
-           if (idsl5 /= 2) then
+         if (idsl5 /= 2) then
 !$omp parallel do schedule(dynamic,1) private(k,j,i)
-              do k=1,km
-                 do j=1,jm
-                    do i=1,im
-                       prsl(i,j,k)=((pri(i,j,k)**kap1-pri(i,j,k+1)**kap1)/&
-                              (kap1*(pri(i,j,k)-pri(i,j,k+1))))**kapr
-                       tsen(i,j,k)= tv(i,j,k)/(one+fv*max(zero,q(i,j,k)))
-                    end do
-                 end do
-              end do
-           else
+            do k=1,km
+               do j=1,jm
+                  do i=1,im
+                     prsl(i,j,k)=((pri(i,j,k)**kap1-pri(i,j,k+1)**kap1)/&
+                            (kap1*(pri(i,j,k)-pri(i,j,k+1))))**kapr
+                     tsen(i,j,k)= tv(i,j,k)/(one+fv*max(zero,q(i,j,k)))
+                  end do
+               end do
+            end do
+         else
 !$omp parallel do schedule(dynamic,1) private(k,j,i)
-              do k=1,km
-                 do j=1,jm
-                    do i=1,im
-                       prsl(i,j,k)=(pri(i,j,k)+pri(i,j,k+1))*half
-                       tsen(i,j,k)= tv(i,j,k)/(one+fv*max(zero,q(i,j,k)))
-                    end do
-                 end do
-              end do
-           end if
-           ice=.true.
-           iderivative=0
-           call genqsat(qs,tsen,prsl,im,jm,km,ice,iderivative)
-           deallocate(tsen)
-           deallocate(prsl)
-         endif ! ihavetv/q
+            do k=1,km
+               do j=1,jm
+                  do i=1,im
+                     prsl(i,j,k)=(pri(i,j,k)+pri(i,j,k+1))*half
+                     tsen(i,j,k)= tv(i,j,k)/(one+fv*max(zero,q(i,j,k)))
+                  end do
+               end do
+            end do
+         end if
          deallocate(pri)
+
+         ice=.true.
+         iderivative=0
+         call genqsat(qs,tsen,prsl,im,jm,km,ice,iderivative)
+         deallocate(tsen,prsl)
        end if
 
 !_$omp parallel do schedule(dynamic,1) private(i,k,j,ic3,rh)
@@ -244,7 +232,7 @@ subroutine get_gefs_ensperts_dualres (epts,nymd,nhms,tau)
              write(6,*)' error retrieving pointer to ',trim(cvars3d(ic3)),' from read in member ',m
              call stop2(999)
           end if
-          call gsi_bundlegetpointer(epts%en_perts(n,m),trim(cvars3d(ic3)),w3,istatus)
+          call gsi_bundlegetpointer(en_perts(n,m),trim(cvars3d(ic3)),w3,istatus)
           if(istatus/=0) then
              write(6,*)' error retrieving pointer to ',trim(cvars3d(ic3)),' for ensemble member ',n
              call stop2(999)
@@ -299,7 +287,7 @@ subroutine get_gefs_ensperts_dualres (epts,nymd,nhms,tau)
           end do
 
        end do !c3d
-       if (allocated(qs)) deallocate(qs)
+       if (.not.q_hyb_ens) deallocate(qs)
 
 !_$omp parallel do schedule(dynamic,1) private(i,j,ic2,ipic)
        do ic2=1,nc2d
@@ -309,7 +297,7 @@ subroutine get_gefs_ensperts_dualres (epts,nymd,nhms,tau)
              write(6,*)' error retrieving pointer to ',trim(cvars2d(ic2)),' from read in member ',m
              call stop2(999)
           end if
-          call gsi_bundlegetpointer(epts%en_perts(n,m),trim(cvars2d(ic2)),w2,istatus)
+          call gsi_bundlegetpointer(en_perts(n,m),trim(cvars2d(ic2)),w2,istatus)
           if(istatus/=0) then
              write(6,*)' error retrieving pointer to ',trim(cvars2d(ic2)),' for ens-pert member ',n
              call stop2(999)
@@ -367,7 +355,7 @@ subroutine get_gefs_ensperts_dualres (epts,nymd,nhms,tau)
 !_RTodling: deactive thread to be safe when spread upd/d or written out
 !_$omp parallel do schedule(dynamic,1) private(i,j,k,n,m,ic2,ic3,ipic,x2)
   do m=1,ntlevs_ens
-     do i=1,epts%nelen
+     do i=1,nelen
         en_bar(m)%values(i)=en_bar(m)%values(i)*bar_norm
      end do
 #ifdef USE_ALL_ORIGINAL
@@ -379,7 +367,7 @@ subroutine get_gefs_ensperts_dualres (epts,nymd,nhms,tau)
 ! Before converting to perturbations, get ensemble spread
      !-- if (m == 1 .and. write_ens_sprd )  call ens_spread_dualres(en_bar(1),1)
      !!! the follwing call is not thread/$omp safe -> omp deactivted above.
-     if (write_ens_sprd)  call ens_spread_dualres(en_bar(m),m,nymd,nhms)
+     if (write_ens_sprd)  call ens_spread_dualres(en_bar(m),m,nymd(m),nhms(m))
 
 
      call gsi_bundlegetpointer(en_bar(m),'ps',x2,istatus)
@@ -388,28 +376,28 @@ subroutine get_gefs_ensperts_dualres (epts,nymd,nhms,tau)
 
      do j=1,jm
         do i=1,im
-           epts%ps_bar(i,j,m)=x2(i,j)
+           ps_bar(i,j,m)=x2(i,j)
         end do
      end do
 
 ! Convert ensemble members to perturbations
 
      do n=1,n_ens
-        do i=1,epts%nelen
-           epts%en_perts(n,m)%valuesr4(i)=epts%en_perts(n,m)%valuesr4(i)-en_bar(m)%values(i)
+        do i=1,nelen
+           en_perts(n,m)%valuesr4(i)=en_perts(n,m)%valuesr4(i)-en_bar(m)%values(i)
         end do
 !       Control level of contribution from each variable in the CV
 !       rank-2 fields
         do ic2=1,nc2d
            ipic=ipc2d(ic2)
            if (be2d(ipic)<zero) cycle
-           epts%en_perts(n,m)%r2(ipic)%qr4 = be2d(ipic)*epts%en_perts(n,m)%r2(ipic)%qr4
+           en_perts(n,m)%r2(ipic)%qr4 = be2d(ipic)*en_perts(n,m)%r2(ipic)%qr4
         end do
 !       rank-3 fields
         do ic3=1,nc3d
            ipic=ipc3d(ic3)
            if (be3d(ipic)<zero) cycle
-           epts%en_perts(n,m)%r3(ipic)%qr4 = be3d(ipic)*epts%en_perts(n,m)%r3(ipic)%qr4
+           en_perts(n,m)%r3(ipic)%qr4 = be3d(ipic)*en_perts(n,m)%r3(ipic)%qr4
         end do
         if(.not. q_hyb_ens) then
           do ic3=1,nc3d
@@ -418,16 +406,16 @@ subroutine get_gefs_ensperts_dualres (epts,nymd,nhms,tau)
                 do k=1,km
                    do j=1,jm
                       do i=1,im
-                         epts%en_perts(n,m)%r3(ipic)%qr4(i,j,k) = min(epts%en_perts(n,m)%r3(ipic)%qr4(i,j,k),1._r_single)
-                         epts%en_perts(n,m)%r3(ipic)%qr4(i,j,k) = max(epts%en_perts(n,m)%r3(ipic)%qr4(i,j,k),-1._r_single)
+                         en_perts(n,m)%r3(ipic)%qr4(i,j,k) = min(en_perts(n,m)%r3(ipic)%qr4(i,j,k),1._r_single)
+                         en_perts(n,m)%r3(ipic)%qr4(i,j,k) = max(en_perts(n,m)%r3(ipic)%qr4(i,j,k),-1._r_single)
                       end do
                    end do
                 end do
              end if
           end do
         end if
-        do i=1,epts%nelen
-           epts%en_perts(n,m)%valuesr4(i)=epts%en_perts(n,m)%valuesr4(i)*sig_norm
+        do i=1,nelen
+           en_perts(n,m)%valuesr4(i)=en_perts(n,m)%valuesr4(i)*sig_norm
         end do
      end do
   end do ! ntlevs
@@ -488,7 +476,7 @@ subroutine get_gefs_ensperts_dualres (epts,nymd,nhms,tau)
   return
 end subroutine get_gefs_ensperts_dualres
 
-subroutine ens_spread_dualres(epts,en_bar,ibin,nymd,nhms)
+subroutine ens_spread_dualres(en_bar,ibin,nymd,nhms)
 !$$$  subprogram documentation block
 !                .      .    .                                       .
 ! subprogram:    ens_spread_dualres  output ensemble spread for diagnostics
@@ -525,7 +513,7 @@ subroutine ens_spread_dualres(epts,en_bar,ibin,nymd,nhms)
   use m_mpimod, only: mype
   use m_kinds, only: r_single,r_kind,i_kind
   use hybrid_ensemble_parameters, only: n_ens,grd_ens,grd_anl,p_e2a,uv_hyb_ens
-  use hybrid_ensemble_parameters, only: gsi_enperts
+  use hybrid_ensemble_parameters, only: en_perts,nelen
   use general_sub2grid_mod, only: sub2grid_info,general_sub2grid_create_info,general_sube2suba
   use constants, only:  zero,two,half,one
   use control_vectors, only: cvars2d,cvars3d,nc2d,nc3d
@@ -539,7 +527,6 @@ subroutine ens_spread_dualres(epts,en_bar,ibin,nymd,nhms)
   use gsi_bundlemod, only: gsi_gridcreate
   implicit none
 
-  type(gsi_enperts),intent(in):: epts
   type(gsi_bundle),intent(in):: en_bar
   integer(i_kind),intent(in):: ibin,nymd,nhms
 
@@ -577,13 +564,13 @@ subroutine ens_spread_dualres(epts,en_bar,ibin,nymd,nhms)
 
   sube%values=zero
   do n=1,n_ens
-     do i=1,epts%nelen
+     do i=1,nelen
         sube%values(i)=sube%values(i) &
-           +(epts%en_perts(n,ibin)%valuesr4(i)-en_bar%values(i))*(epts%en_perts(n,ibin)%valuesr4(i)-en_bar%values(i))
+           +(en_perts(n,ibin)%valuesr4(i)-en_bar%values(i))*(en_perts(n,ibin)%valuesr4(i)-en_bar%values(i))
      end do
   end do
 
-  do i=1,epts%nelen
+  do i=1,nelen
     sube%values(i) = sqrt(sp_norm*sube%values(i))
   end do
 
@@ -610,7 +597,7 @@ subroutine ens_spread_dualres(epts,en_bar,ibin,nymd,nhms)
   end do
 
   if(grd_ens%latlon1n == grd_anl%latlon1n) then
-     do i=1,epts%nelen
+     do i=1,nelen
         suba%values(i)=sube%values(i)
      end do
   else
@@ -620,7 +607,9 @@ subroutine ens_spread_dualres(epts,en_bar,ibin,nymd,nhms)
      allocate(vector(num_fields))
      vector=.false.
      do ic3=1,nc3d
-        if(trim(cvars3d(ic3))=='sf'.or.trim(cvars3d(ic3))=='vp') then
+        if(trim(cvars3d(ic3))=='sf'.or.trim(cvars3d(ic3))=='vp') then !  RTodling: this is not meaningful
+                                                                      !            since are dealing w/ spread
+                                                                      !            not the physical u/v
            do k=1,grd_ens%nsig
               vector((ic3-1)*grd_ens%nsig+k)=uv_hyb_ens
            end do
@@ -864,8 +853,7 @@ subroutine write_spread_dualres(nymd,nhms,bundle)
   return
 end subroutine write_spread_dualres
 
-!subroutine general_getprs_glb(ps,tv,prs)
-subroutine general_getprs_glb(ps,prs)
+subroutine general_getprs_glb(ps,tv,prs)
 ! subprogram:    getprs       get 3d pressure or 3d pressure deriv
 !   prgmmr: kleist           org: np20                date: 2005-09-29
 !
@@ -900,7 +888,6 @@ subroutine general_getprs_glb(ps,prs)
 !$$$ end documentation block
 
   use m_kinds,only: r_kind,i_kind
-  use mpeu_util,only: die
   use constants,only: zero,half,one_tenth,rd_over_cp,one
   use gridmod,only: nsig,ak5,bk5,ck5,tref5,idvc5
 #ifdef USE_ALL_ORIGINAL
@@ -912,7 +899,7 @@ subroutine general_getprs_glb(ps,prs)
 
 ! Declare passed variables
   real(r_kind),dimension(grd_ens%lat2,grd_ens%lon2)       ,intent(in   ) :: ps
-! real(r_kind),dimension(grd_ens%lat2,grd_ens%lon2,nsig)  ,intent(in   ) :: tv
+  real(r_kind),dimension(grd_ens%lat2,grd_ens%lon2,nsig)  ,intent(in   ) :: tv
   real(r_kind),dimension(grd_ens%lat2,grd_ens%lon2,nsig+1),intent(  out) :: prs
 
 ! Declare local variables
@@ -993,7 +980,7 @@ subroutine general_getprs_glb(ps,prs)
         do k=2,nsig
            do j=1,grd_ens%lon2
               do i=1,grd_ens%lat2
-!                trk=(half*(tv(i,j,k-1)+tv(i,j,k))/tref5(k))**kapr
+                 trk=(half*(tv(i,j,k-1)+tv(i,j,k))/tref5(k))**kapr
                  prs(i,j,k)=ak5(k)+(bk5(k)*ps(i,j))+(ck5(k)*trk)
               end do
            end do

--- a/src/gsibec/gsi/gsimod.F90
+++ b/src/gsibec/gsi/gsimod.F90
@@ -25,7 +25,7 @@
   use jfunc, only: tendsflag
 
   use gsi_4dvar, only: setup_4dvar,init_4dvar,clean_4dvar
-  use gsi_4dvar, only: l4densvar,nmn_obsbin,ens_nstarthr
+  use gsi_4dvar, only: l4densvar,nmn_obsbin
 
   use state_vectors, only: init_anasv,final_anasv
   use control_vectors, only: init_anacv,final_anacv,nrf,nvars,nrf_3d,cvars3d,cvars2d,&
@@ -80,7 +80,6 @@
                          readin_beta,use_localization_grid,use_gfs_ens,q_hyb_ens,i_en_perts_io, &
                          l_ens_in_diff_time,ensemble_path,ens_fast_read,sst_staticB,&
                          bens_recenter,upd_ens_spread,upd_ens_localization,ens_fname_tmpl,&
-                         test_nymd,test_nhms,&
                          EnsSource
 
   use gsi_io, only: init_io, verbose
@@ -364,7 +363,8 @@
        cwoption,&
        qoption,&
        verbose,&
-       l4densvar,nmn_obsbin,ens_nstarthr,&
+       l4densvar,&
+       nmn_obsbin,&
        mockbkg
 
 ! GRIDOPTS (grid setup variables,including regional specific variables):
@@ -485,7 +485,6 @@
                 grid_ratio_ens, ens_fname_tmpl, &
                 oz_univ_static,write_ens_sprd,use_localization_grid,use_gfs_ens, &
                 i_en_perts_io,l_ens_in_diff_time,ensemble_path,ens_fast_read,sst_staticB,&
-                test_nymd,test_nhms,&
                 bens_recenter,upd_ens_spread,upd_ens_localization,EnsSource
    CONTAINS
 
@@ -588,7 +587,6 @@
 
 !_RT call gsi_4dcoupler_setservices(rc=ier)
 !_RT if(ier/=0) call die(myname_,'gsi_4dcoupler_setServices(), rc =',ier)
-
 
   call setup_4dvar(mype)
 

--- a/src/gsibec/gsi/guess_grids.f90
+++ b/src/gsibec/gsi/guess_grids.f90
@@ -52,9 +52,8 @@ logical, parameter ::  tsensible = .false.   ! jfunc: here set as in jfunc
                           !        var in cv is tv to be tv and t
 logical, parameter ::  use_compress = .true.   ! wired for now
 
-! For now turned into wired-in parameters
-integer(i_kind),parameter :: nfldsig =  1
-integer(i_kind),parameter :: ntguessig = 1
+integer(i_kind) :: nfldsig
+integer(i_kind) :: ntguessig
 
 real(r_kind),allocatable,dimension(:,:,:,:):: ges_prsl
 real(r_kind),allocatable,dimension(:,:,:,:):: ges_prsi
@@ -79,17 +78,17 @@ interface gsiguess_set
   module procedure guess_basics3_
 end interface gsiguess_set
 
-interface gsiguess_bkgcov_init  ! WARNING: this does not belog here
+interface gsiguess_bkgcov_init  ! WARNING: this does not belong here
   module procedure bkgcov_init_
 end interface gsiguess_bkgcov_init
 
-interface gsiguess_bkgcov_final ! WARNING: this does not belog here
+interface gsiguess_bkgcov_final ! WARNING: this does not belong here
   module procedure bkgcov_final_
 end interface gsiguess_bkgcov_final
 
 logical, save :: gesgrid_initialized_ = .false.
 logical, save :: gesgrid_iamset_ = .false.
-logical :: debug_guess=.true.
+logical :: debug_guess=.false.
 
 character(len=*), parameter :: myname="guess_grids"
 contains
@@ -149,7 +148,9 @@ subroutine other_set_(need)
   ges_prsi=zero
   tropprs=zero
   fact_tv=one
-  it = size(GSI_MetGuess_Bundle)
+  if (nfldsig /= size(GSI_MetGuess_Bundle)) then
+     call die (myname_,': inconsistent time index in metguess',99)
+  endif
   ! better fix units here?
   if (present(need)) then
     if(mype==0) then
@@ -173,12 +174,6 @@ subroutine other_set_(need)
           need='filled-'//need
        endwhere
     endif
-    if (any(need=='cw')) then
-       call load_guess_cw_
-       where(need=='cw')
-          need='filled-'//need
-       endwhere
-    endif
   else
     call load_guess_tsen_(mock=.true.)
   endif
@@ -196,32 +191,34 @@ subroutine other_set_(need)
     if (any(need=='vor').or.any(need=='div')) then
 !      if(.not.cdiff_created()) call create_cdiff_coefs()
 !      if(.not.cdiff_initialized()) call inisph(rearth,rlats(2),wgtlats(2),nlon,nlat-2)
-       ier=0
-       call GSI_BundleGetPointer ( GSI_MetGuess_Bundle(it), 'u', ges_u, &
-                                   istatus );ier=ier+istatus
-       call GSI_BundleGetPointer ( GSI_MetGuess_Bundle(it), 'v', ges_v, &
-                                   istatus );ier=ier+istatus
-       call GSI_BundleGetPointer ( GSI_MetGuess_Bundle(it), 'vor', ges_vor, &
-                                   istatus );ier=ier+istatus
-       call GSI_BundleGetPointer ( GSI_MetGuess_Bundle(it), 'div', ges_div, &
-                                   istatus );ier=ier+istatus
-       if(ier==0) then
-          call xhat_vordiv_calc2 (ges_u,ges_v,ges_vor,ges_div)
-       endif
-       where(need=='vor')
-          need='filled-'//need
-       endwhere
-       where(need=='div')
-          need='filled-'//need
-       endwhere
-!      call write_bkgvars_grid(ges_u,ges_v,ges_u,ges_u(:,:,1),&
-!                             'wind.grd',mype) ! debug
-!      call write_bkgvars_grid(ges_div,ges_vor,ges_div,ges_div(:,:,1),&
-!                             'divo.grd',mype) ! debug
+       do it=1,nfldsig
+         ier=0
+         call GSI_BundleGetPointer ( GSI_MetGuess_Bundle(it), 'u', ges_u, &
+                                     istatus );ier=ier+istatus
+         call GSI_BundleGetPointer ( GSI_MetGuess_Bundle(it), 'v', ges_v, &
+                                     istatus );ier=ier+istatus
+         call GSI_BundleGetPointer ( GSI_MetGuess_Bundle(it), 'vor', ges_vor, &
+                                     istatus );ier=ier+istatus
+         call GSI_BundleGetPointer ( GSI_MetGuess_Bundle(it), 'div', ges_div, &
+                                     istatus );ier=ier+istatus
+         if(ier==0) then
+            call xhat_vordiv_calc2 (ges_u,ges_v,ges_vor,ges_div)
+         endif
+         where(need=='vor')
+            need='filled-'//need
+         endwhere
+         where(need=='div')
+            need='filled-'//need
+         endwhere
+!        call write_bkgvars_grid(ges_u,ges_v,ges_vor,ges_div(:,:,1),&
+!                               'wind.grd',mype) ! debug
+         enddo
     endif
   endif
 ! fill in land-water-ice mask
-  call lwi_mask_(it)
+  do it=1,nfldsig
+     call lwi_mask_(it)
+  enddo
 
   gesgrid_iamset_ = .true.
 end subroutine other_set_
@@ -776,7 +773,7 @@ end subroutine final_
      endif
      ic=ic+1; debugvar(:,:,ic) = tskin
      ic=ic+1; debugvar(:,:,ic) = z
-     call write_bkgvars_grid(debugvar,debugvar,debugvar,ps,'skin.grd',mype) ! debug
+     call write_bkgvars_grid(debugvar,debugvar,debugvar,tskin,'skin.grd',mype) ! debug
      deallocate(debugvar)
   endif
 
@@ -833,7 +830,7 @@ end subroutine final_
 
   subroutine load_guess_tv_
   implicit none
-  character(len=*), parameter :: myname_ = myname//'*load_guess_tv_'
+  character(len=*), parameter :: myname_ = myname//'*get_guess_tv_'
   real(r_kind),dimension(:,:,:),pointer::tsen=>NULL()
   real(r_kind),dimension(:,:,:),pointer::tv=>NULL()
   real(r_kind),dimension(:,:,:),pointer::q =>NULL()
@@ -867,27 +864,6 @@ end subroutine final_
     if(mype==0) call tell (myname_, ': warning, tv pointer not set, could be an issue')
   endif
   end subroutine load_guess_tv_
-
-  subroutine load_guess_cw_
-  implicit none
-  character(len=*), parameter :: myname_ = myname//'*load_guess_cw_'
-  real(r_kind),dimension(:,:,:),pointer::cw=>NULL()
-  real(r_kind),dimension(:,:,:),pointer::qi=>NULL()
-  real(r_kind),dimension(:,:,:),pointer::ql=>NULL()
-  integer jj,istatus,ier
-  do jj=1,nfldsig
-     call gsi_bundlegetpointer(gsi_metguess_bundle(jj),'cw',cw,ier)
-     if (ier/=0) call die(myname_, ': expecting CW in met guess')
-     istatus=0
-     call gsi_bundlegetpointer(gsi_metguess_bundle(jj),'qi',qi,ier); istatus=ier+istatus
-     call gsi_bundlegetpointer(gsi_metguess_bundle(jj),'ql',ql,ier); istatus=ier+istatus
-     if(istatus==0) then 
-       cw = qi+ql
-     else
-       cw = zero
-     endif
-  enddo
-  end subroutine load_guess_cw_
 
 !-------------------------------------------------------------------------
 !    NOAA/NCEP, National Centers for Environmental Prediction GSI        !
@@ -1048,37 +1024,37 @@ end subroutine final_
   enddo
   end subroutine guess_basics0_
 !--------------------------------------------------------
-  subroutine guess_basics2_(vname,var)
+  subroutine guess_basics2_(vname,islot,var)
   character(len=*),intent(in) :: vname
+  integer(i_kind), intent(in) :: islot
   real(r_kind),dimension(:,:) :: var
   character(len=*), parameter :: myname_ = myname//'*guess_basics2_'
   real(r_kind),dimension(:,:),pointer::ptr
   integer jj,ier
-  do jj=1,nfldsig
-     call gsi_bundlegetpointer(gsi_metguess_bundle(jj),trim(vname),ptr,ier)
-     if (ier/=0) then
-       call die(myname_,'pointer to '//trim(vname)//" not found",ier)
-     endif
-     ptr=var
-     if ( trim(vname) == 'ps' ) ptr=kPa_per_Pa*ptr ! RT_TBD: is this the best place for this?
-     if ( trim(vname) == 'z'  ) ptr=ptr/grav       ! RT_TBD: is this the best place for this?
-  enddo
+  jj=islot
+  call gsi_bundlegetpointer(gsi_metguess_bundle(jj),trim(vname),ptr,ier)
+  if (ier/=0) then
+    call die(myname_,'pointer to '//trim(vname)//" not found",ier)
+  endif
+  ptr=var
+  if ( trim(vname) == 'ps' ) ptr=kPa_per_Pa*ptr ! RT_TBD: is this the best place for this?
+  if ( trim(vname) == 'z'  ) ptr=ptr/grav       ! RT_TBD: is this the best place for this?
   end subroutine guess_basics2_
 !--------------------------------------------------------
-  subroutine guess_basics3_(vname,var)
+  subroutine guess_basics3_(vname,islot,var)
   character(len=*),intent(in)   :: vname
+  integer(i_kind), intent(in) :: islot
   real(r_kind),dimension(:,:,:) :: var
   character(len=*), parameter :: myname_ = myname//'*guess_basics3_'
   real(r_kind),dimension(:,:,:),pointer::ptr
   character(len=80) :: uvar
   integer jj,ier
-  do jj=1,nfldsig
-     call gsi_bundlegetpointer(gsi_metguess_bundle(jj),trim(vname),ptr,ier)
-     if (ier/=0) then
-       call die(myname_,'pointer to '//trim(vname)//" not found",ier)
-     endif
-     ptr=var
-  enddo
+  jj=islot
+  call gsi_bundlegetpointer(gsi_metguess_bundle(jj),trim(vname),ptr,ier)
+  if (ier/=0) then
+    call die(myname_,'pointer to '//trim(vname)//" not found",ier)
+  endif
+  ptr=var
   if ( trim(vname) == 'oz' ) then
       call gsi_metguess_get ( 'usrvar::o3ppmv', uvar, ier )
       if (trim(uvar)=='o3ppmv') then

--- a/src/gsibec/gsi/hybrid_ensemble_isotropic.F90
+++ b/src/gsibec/gsi/hybrid_ensemble_isotropic.F90
@@ -59,6 +59,7 @@ module hybrid_ensemble_isotropic
 !   sub normal_new_factorization_rf_z     - normalize localization recursive filter (z direction)
 !   sub normal_new_factorization_rf_x     - normalize localization recursive filter (x direction)
 !   sub normal_new_factorization_rf_y     - normalize localization recursive filter (y direction)
+!   sub create_ensemble                   - allocate space for ensemble perturbations
 !   sub load_ensemble                     - read/generate ensemble perturbations
 !   sub rescale_ensemble_rh_perturbations - for internal generated perturbations only, normalize by ges q
 !   sub ensemble_forward_model            - add ensemble contribution to analysis increment
@@ -114,7 +115,9 @@ module hybrid_ensemble_isotropic
   public :: normal_new_factorization_rf_z
   public :: normal_new_factorization_rf_x
   public :: normal_new_factorization_rf_y
+  public :: create_ensemble
   public :: load_ensemble
+  public :: destroy_ensemble
   public :: rescale_ensemble_rh_perturbations
   public :: ensemble_forward_model
   public :: ensemble_forward_model_dual_res
@@ -190,7 +193,7 @@ module hybrid_ensemble_isotropic
 
 contains
 
-subroutine init_rf_z(epts,z_len)
+subroutine init_rf_z(z_len)
 !$$$  subprogram documentation block
 !                .      .    .                                       .
 ! subprogram:    init_rf_z    initialize vertical recursive filter
@@ -238,11 +241,10 @@ subroutine init_rf_z(epts,z_len)
 #endif /* USE_ALL_ORIGINAL */
   use constants, only: half,one,rd_over_cp,zero,one_tenth,ten,two
   use hybrid_ensemble_parameters, only: grd_ens
-  use hybrid_ensemble_parameters, only: gsi_enperts
+  use hybrid_ensemble_parameters, only: ps_bar
 
   implicit none
 
-  type(gsi_enperts) :: epts
   real(r_kind)   ,intent(in) :: z_len(grd_ens%nsig)
 
   integer(i_kind) k,nxy,i,ii,jj,j,l
@@ -305,17 +307,17 @@ subroutine init_rf_z(epts,z_len)
                  if (wrf_nmm_regional.or.nems_nmmb_regional.or.cmaq_regional) then
                     p_interface(k)= one_tenth* &
                           (eta1_ll(k)*pdtop_ll + &
-                           eta2_ll(k)*(ten*epts%ps_bar(ii,jj,1)-pdtop_ll-pt_ll) + &
+                           eta2_ll(k)*(ten*ps_bar(ii,jj,1)-pdtop_ll-pt_ll) + &
                            pt_ll)
                  endif
                  if (fv3_regional) then
-                    p_interface(k)=eta1_ll(k)+ eta2_ll(k)*epts%ps_bar(ii,jj,1)
+                    p_interface(k)=eta1_ll(k)+ eta2_ll(k)*ps_bar(ii,jj,1)
                  endif
                  if (twodvar_regional) then
-                    p_interface(k)=one_tenth*(eta1_ll(k)*(ten*epts%ps_bar(ii,jj,1)-pt_ll)+pt_ll)
+                    p_interface(k)=one_tenth*(eta1_ll(k)*(ten*ps_bar(ii,jj,1)-pt_ll)+pt_ll)
                  endif
                  if (wrf_mass_regional) then
-                    p_interface(k)=one_tenth*(eta1_ll(k)*(ten*epts%ps_bar(ii,jj,1)-pt_ll)+&
+                    p_interface(k)=one_tenth*(eta1_ll(k)*(ten*ps_bar(ii,jj,1)-pt_ll)+&
                                               eta2_ll(k) + pt_ll)
                  endif
                  ln_p_int(k)=log(max(p_interface(k),0.0001_r_kind))
@@ -324,7 +326,7 @@ subroutine init_rf_z(epts,z_len)
            else
 #endif /* USE_ALL_ORIGINAL  */
               do k=1,nsig+1
-                 p_interface(k)=ak5(k)+(bk5(k)*epts%ps_bar(ii,jj,1))
+                 p_interface(k)=ak5(k)+(bk5(k)*ps_bar(ii,jj,1))
                  ln_p_int(k)=log(max(p_interface(k),0.0001_r_kind))
               enddo
 #ifdef USE_ALL_ORIGINAL
@@ -1081,7 +1083,69 @@ subroutine normal_new_factorization_rf_y
   return
 end subroutine normal_new_factorization_rf_y
 
-  subroutine load_ensemble (epts,nymd,nhms,tau)
+  subroutine create_ensemble
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    create_ensemble        allocate space for ensembles
+!   prgmmr: parrish          org: np22                date: 2009-06-16
+!
+! abstract: allocate space for ensemble perturbations used with the 
+!             hybrid ensemble option.
+!
+! program history log:
+!   2009-06-16  parrish
+!   2010-02-20  parrish  modifications for dual resolution
+!   2011-02-28  parrish - introduce more complete use of gsi_bundlemod to eliminate hard-wired variables
+!   2011-08-31  todling - revisit en_perts (single-prec) in light of extended bundle
+!
+!   input argument list:
+!
+!   output argument list:
+!
+! attributes:
+!   language: f90
+!   machine:  ibm RS/6000 SP
+!
+!$$$
+    use hybrid_ensemble_parameters, only: n_ens,grd_ens,ntlevs_ens
+    use hybrid_ensemble_parameters, only: nelen,en_perts,ps_bar
+
+    implicit none
+
+    type(gsi_grid)  :: grid_ens
+
+    integer(i_kind) n,istatus,m
+    character(len=*),parameter::myname_=trim(myname)//'*create_ensemble'
+
+    nelen=grd_ens%latlon11*(max(0,nc3d)*grd_ens%nsig+max(0,nc2d))
+!   create ensemble perturbations bundles (using newly added r_single capability
+
+    allocate(en_perts(n_ens,ntlevs_ens))
+    call gsi_gridcreate(grid_ens,grd_ens%lat2,grd_ens%lon2,grd_ens%nsig)
+ 
+    do m=1,ntlevs_ens
+       do n=1,n_ens
+          call gsi_bundlecreate(en_perts(n,m),grid_ens,'ensemble perts',istatus, &
+                                names2d=cvars2d,names3d=cvars3d,bundle_kind=r_single)
+          if(istatus/=0) then
+             write(6,*)trim(myname_),': trouble creating en_perts bundle'
+             call stop2(999)
+          endif
+       enddo
+    enddo
+
+
+    allocate(ps_bar(grd_ens%lat2,grd_ens%lon2,ntlevs_ens) )
+    if(debug) then
+       write(6,*)' in create_ensemble, grd_ens%latlon11,grd_ens%latlon1n,n_ens,ntlevs_ens=', &
+                                 grd_ens%latlon11,grd_ens%latlon1n,n_ens,ntlevs_ens
+       write(6,*)' in create_ensemble, total bytes allocated=',4*nelen*n_ens*ntlevs_ens
+    end if
+    return
+
+  end subroutine create_ensemble
+
+  subroutine load_ensemble (tau)
 !$$$  subprogram documentation block
 !                .      .    .                                       .
 ! subprogram:    load_ensemble    read/generate ensemble perturbations
@@ -1119,8 +1183,9 @@ end subroutine normal_new_factorization_rf_y
     use hybrid_ensemble_parameters, only: n_ens,generate_ens,grd_ens,grd_anl,ntlevs_ens, &
                                           pseudo_hybens,regional_ensemble_option,&
                                           i_en_perts_io
-    use hybrid_ensemble_parameters, only: gsi_enperts
+    use hybrid_ensemble_parameters, only: nelen,en_perts,ps_bar
     use hybrid_ensemble_parameters, only: write_ens_sprd
+    use hybrid_ensemble_parameters, only: nymd,nhms
     use gsi_enscouplermod, only: gsi_enscoupler_put_gsi_ens
     use m_mpimod, only: mype
     use get_pseudo_ensperts_mod, only: get_pseudo_ensperts_class
@@ -1132,8 +1197,6 @@ end subroutine normal_new_factorization_rf_y
 
     implicit none
 
-    type(gsi_enperts) :: epts
-    integer,intent(in) :: nymd,nhms
     integer,intent(in) :: tau
 
     type(get_pseudo_ensperts_class) :: pseudo_enspert
@@ -1144,14 +1207,12 @@ end subroutine normal_new_factorization_rf_y
     type(gsi_bundle),allocatable:: en_bar(:)
     type(gsi_bundle):: bundle_anl,bundle_ens
     type(gsi_grid)  :: grid_anl,grid_ens
-    integer(i_kind) i,j,n,ii,m,nelen
+    integer(i_kind) i,j,n,ii,m
     integer(i_kind) istatus
     real(r_kind),allocatable:: seed(:,:)
     real(r_kind),pointer,dimension(:,:)   :: cv_ps=>NULL()
     real(r_kind) sig_norm,bar_norm
     character(len=*),parameter::myname_=trim(myname)//'*load_ensemble'
-
-    nelen=epts%nelen
 
 !      create simple regular grid
 
@@ -1203,7 +1264,7 @@ end subroutine normal_new_factorization_rf_y
           do n=1,n_ens
              call generate_one_ensemble_perturbation(bundle_anl,bundle_ens,seed)
              do ii=1,nelen
-                epts%en_perts(n,m)%valuesr4(ii)=bundle_ens%values(ii)
+                en_perts(n,m)%valuesr4(ii)=bundle_ens%values(ii)
                 en_bar(m)%values(ii)=en_bar(m)%values(ii)+bundle_ens%values(ii)
              enddo
           enddo
@@ -1212,7 +1273,7 @@ end subroutine normal_new_factorization_rf_y
           call gsi_bundlegetpointer (en_bar(m),'ps' ,cv_ps ,istatus)
           do j=1,grd_ens%lon2
              do i=1,grd_ens%lat2
-                epts%ps_bar(i,j,m)=cv_ps(i,j)*bar_norm
+                ps_bar(i,j,m)=cv_ps(i,j)*bar_norm
              enddo
           enddo
        enddo
@@ -1234,16 +1295,16 @@ end subroutine normal_new_factorization_rf_y
        do m=1,ntlevs_ens
           do n=1,n_ens
              do ii=1,nelen
-                epts%en_perts(n,m)%valuesr4(ii)=(epts%en_perts(n,m)%valuesr4(ii)-en_bar(m)%values(ii)*bar_norm)*sig_norm
+                en_perts(n,m)%valuesr4(ii)=(en_perts(n,m)%valuesr4(ii)-en_bar(m)%values(ii)*bar_norm)*sig_norm
              enddo
-             call gsi_enscoupler_put_gsi_ens(grd_ens,n,m,epts%en_perts(n,m),istatus)
+             call gsi_enscoupler_put_gsi_ens(grd_ens,n,m,en_perts(n,m),istatus)
              if(istatus/=0) then
                  write(6,*)trim(myname_),': trouble writing perts'
                  call stop2(999)
              endif
           enddo
 
-          if (write_ens_sprd)  call ens_spread_dualres(en_bar(m),m)
+          if (write_ens_sprd)  call ens_spread_dualres(en_bar(m),m,nymd(m),nhms(m))
 
           call gsi_bundledestroy(en_bar(m),istatus)
           if(istatus/=0) then
@@ -1260,7 +1321,7 @@ end subroutine normal_new_factorization_rf_y
 !            read in ensembles
        if (.not.regional) then
 
-          call get_gefs_ensperts_dualres(epts,nymd,nhms,tau)
+          call get_gefs_ensperts_dualres(tau)
 
        else
 
@@ -1302,14 +1363,14 @@ end subroutine normal_new_factorization_rf_y
 !                             GEFS ensemble perturbations in TC vortex area
 !                             are replaced with TC vortex library perturbations
                 if (pseudo_hybens) then
-                   call pseudo_enspert%get_pseudo_ensperts(epts%en_perts,nelen)
+                   call pseudo_enspert%get_pseudo_ensperts(en_perts,nelen)
                 end if
              case(2)
 
 !     regional_ensemble_option = 2: ensembles are WRF NMM (HWRF) format
 
 #ifdef USE_ALL_ORIGINAL
-                call wrf_nmm_enspert%get_wrf_nmm_ensperts(epts%en_perts,nelen,region_lat_ens,region_lon_ens,epts%ps_bar)
+                call wrf_nmm_enspert%get_wrf_nmm_ensperts(en_perts,nelen,region_lat_ens,region_lon_ens,ps_bar)
 #endif /* USE_ALL_ORIGINAL */
 
              case(3)
@@ -1317,7 +1378,7 @@ end subroutine normal_new_factorization_rf_y
 !     regional_ensemble_option = 3: ensembles are ARW netcdf format.
 
 #ifdef USE_ALL_ORIGINAL
-                call wrf_mass_enspert%get_wrf_mass_ensperts(epts%en_perts,nelen,epts%ps_bar)
+                call wrf_mass_enspert%get_wrf_mass_ensperts(en_perts,nelen,ps_bar)
 #endif /* USE_ALL_ORIGINAL */
 
              case(4)
@@ -1572,7 +1633,7 @@ end subroutine normal_new_factorization_rf_y
     
   end subroutine fix_belt
 
-  subroutine rescale_ensemble_rh_perturbations(epts)
+  subroutine rescale_ensemble_rh_perturbations
 !$$$  subprogram documentation block
 !                .      .    .                                       .
 ! subprogram:    rescale_ensemble_rh_perturbations
@@ -1599,18 +1660,16 @@ end subroutine normal_new_factorization_rf_y
     use m_kinds, only: r_kind,i_kind
     use gridmod, only: regional
     use hybrid_ensemble_parameters, only: n_ens,grd_ens,grd_anl,grd_a1,grd_e1,p_e2a,ntlevs_ens
-    use hybrid_ensemble_parameters, only: gsi_enperts
+    use hybrid_ensemble_parameters, only: en_perts
     use general_sub2grid_mod, only: general_suba2sube
     use berror, only: qvar3d
     implicit none
-
-    type(gsi_enperts) :: epts 
 
     integer(i_kind) i,j,k,n,istatus,m
     real(r_kind) qvar3d_ens(grd_ens%lat2,grd_ens%lon2,grd_ens%nsig,1)
     real(r_single),pointer,dimension(:,:,:):: w3=>NULL()
 
-    call gsi_bundlegetpointer(epts%en_perts(1,1),'q',w3,istatus)
+    call gsi_bundlegetpointer(en_perts(1,1),'q',w3,istatus)
     if(istatus/=0) then
        write(6,*)' rh variable not available, skip subroutine rescale_ensemble_rh_perturbations'
        return
@@ -1625,7 +1684,7 @@ end subroutine normal_new_factorization_rf_y
     do m=1,ntlevs_ens
 !$omp parallel do schedule(dynamic,1) private(n,i,j,k,w3,istatus)
        do n=1,n_ens
-          call gsi_bundlegetpointer(epts%en_perts(n,m),'q',w3,istatus)
+          call gsi_bundlegetpointer(en_perts(n,m),'q',w3,istatus)
           if(istatus/=0) then
              write(6,*)' error retrieving pointer to rh variable for ensemble number ',n
              call stop2(999)
@@ -1643,7 +1702,52 @@ end subroutine normal_new_factorization_rf_y
  
   end subroutine rescale_ensemble_rh_perturbations
 
-  subroutine ensemble_forward_model(cvec,a_en,epts,ibin)
+  subroutine destroy_ensemble
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    destroy_ensemble       deallocate space for ensembles
+!   prgmmr: parrish          org: np22                date: 2009-06-16
+!
+! abstract: deallocate space for ensemble perturbations used with the 
+!             hybrid ensemble option.
+!
+! program history log:
+!   2009-06-16  parrish
+!   2011-02-28  parrish, replace specific ensemble perturbation arrays with pseudo-bundle en_perts array
+!
+!   input argument list:
+!
+!   output argument list:
+!
+! attributes:
+!   language: f90
+!   machine:  ibm RS/6000 SP
+!
+!$$$
+    use hybrid_ensemble_parameters, only: l_hyb_ens,n_ens,ntlevs_ens
+    use hybrid_ensemble_parameters, only: en_perts,ps_bar
+    implicit none
+
+    integer(i_kind) istatus,n,m
+
+    if(l_hyb_ens) then
+       do m=1,ntlevs_ens
+          do n=1,n_ens
+             call gsi_bundleunset(en_perts(n,m),istatus)
+             if(istatus/=0) then
+                write(6,*)'in destroy_ensemble: trouble destroying en_perts bundle'
+                call stop2(999)
+             endif
+          enddo
+       enddo
+       deallocate(ps_bar)
+       deallocate(en_perts)
+    end if
+    return
+
+  end subroutine destroy_ensemble
+
+  subroutine ensemble_forward_model(cvec,a_en,ibin)
 !$$$  subprogram documentation block
 !                .      .    .                                       .
 ! subprogram:    ensemble_forward_model  add ensemble part to anl vars
@@ -1681,13 +1785,12 @@ end subroutine normal_new_factorization_rf_y
 !
 !$$$
     use hybrid_ensemble_parameters, only: n_ens,pwgtflg,pwgt
-    use hybrid_ensemble_parameters, only: gsi_enperts
+    use hybrid_ensemble_parameters, only: en_perts
     use constants, only: zero
 
     implicit none
     type(gsi_bundle),intent(inout) :: cvec
     type(gsi_bundle),intent(in)    :: a_en(n_ens)
-    type(gsi_enperts),intent(in)   :: epts
     integer,intent(in)             :: ibin
 
     character(len=*),parameter :: myname_=trim(myname)//'*ensemble_forward_model'
@@ -1735,7 +1838,7 @@ end subroutine normal_new_factorization_rf_y
              do j=1,jm
                 do i=1,im
                    cvec%r3(ipic)%q(i,j,k)=cvec%r3(ipic)%q(i,j,k) &
-                         +a_en(n)%r3(ipx)%q(i,j,k)*epts%en_perts(n,ibin)%r3(ipic)%qr4(i,j,k)
+                         +a_en(n)%r3(ipx)%q(i,j,k)*en_perts(n,ibin)%r3(ipic)%qr4(i,j,k)
                 enddo
              enddo
           enddo
@@ -1766,7 +1869,7 @@ end subroutine normal_new_factorization_rf_y
                    do k=1,km_tmp
                       do i=1,im
                          cvec%r2(ipic)%q(i,j)=cvec%r2(ipic)%q(i,j) &
-                            +a_en(n)%r3(ipx)%q(i,j,k)*epts%en_perts(n,ibin)%r2(ipic)%qr4(i,j)*pwgt(i,j,k)
+                            +a_en(n)%r3(ipx)%q(i,j,k)*en_perts(n,ibin)%r2(ipic)%qr4(i,j)*pwgt(i,j,k)
                       enddo
                    enddo
                 enddo
@@ -1778,7 +1881,7 @@ end subroutine normal_new_factorization_rf_y
                 do j=1,jm
                    do i=1,im
                       cvec%r2(ipic)%q(i,j)=cvec%r2(ipic)%q(i,j) &
-                         +a_en(n)%r3(ipx)%q(i,j,1)*epts%en_perts(n,ibin)%r2(ipic)%qr4(i,j)
+                         +a_en(n)%r3(ipx)%q(i,j,1)*en_perts(n,ibin)%r2(ipic)%qr4(i,j)
                    enddo
                 enddo
              enddo ! enddo n_ens
@@ -1790,7 +1893,7 @@ end subroutine normal_new_factorization_rf_y
 
   end subroutine ensemble_forward_model
 
-  subroutine ensemble_forward_model_dual_res(cvec,a_en,epts,ibin)
+  subroutine ensemble_forward_model_dual_res(cvec,a_en,ibin)
 !$$$  subprogram documentation block
 !                .      .    .                                       .
 ! subprogram:    ensemble_forward_model_dual_res  use for dualres option
@@ -1832,7 +1935,7 @@ end subroutine normal_new_factorization_rf_y
 !$$$
     use hybrid_ensemble_parameters, only: n_ens,pwgtflg,pwgt
     use hybrid_ensemble_parameters, only: grd_ens,grd_anl,p_e2a
-    use hybrid_ensemble_parameters, only: gsi_enperts
+    use hybrid_ensemble_parameters, only: en_perts
     use general_sub2grid_mod, only: general_sube2suba
     use gridmod,only: regional
     use constants, only: zero
@@ -1840,7 +1943,6 @@ end subroutine normal_new_factorization_rf_y
 
     type(gsi_bundle),intent(inout) :: cvec
     type(gsi_bundle),intent(in)    :: a_en(n_ens)
-    type(gsi_enperts),intent(in)   :: epts
     integer,intent(in)             :: ibin
 
     character(len=*),parameter::myname_=trim(myname)//'*ensemble_forward_model_dual_res'
@@ -1896,7 +1998,7 @@ end subroutine normal_new_factorization_rf_y
              do j=1,jm
                 do i=1,im
                    work_ens%r3(ipic)%q(i,j,k)=work_ens%r3(ipic)%q(i,j,k) &
-                      +a_en(n)%r3(ipx)%q(i,j,k)*epts%en_perts(n,ibin)%r3(ipic)%qr4(i,j,k)
+                      +a_en(n)%r3(ipx)%q(i,j,k)*en_perts(n,ibin)%r3(ipic)%qr4(i,j,k)
                 enddo
              enddo
           enddo
@@ -1926,7 +2028,7 @@ end subroutine normal_new_factorization_rf_y
                    do j=1,jm
                       do i=1,im
                          work_ens%r2(ipic)%q(i,j)=work_ens%r2(ipic)%q(i,j) &
-                            +a_en(n)%r3(ipx)%q(i,j,k)*epts%en_perts(n,ibin)%r2(ipic)%qr4(i,j)*pwgt(i,j,k)
+                            +a_en(n)%r3(ipx)%q(i,j,k)*en_perts(n,ibin)%r2(ipic)%qr4(i,j)*pwgt(i,j,k)
                       enddo
                    enddo
                 enddo
@@ -1938,7 +2040,7 @@ end subroutine normal_new_factorization_rf_y
                 do j=1,jm
                    do i=1,im
                       work_ens%r2(ipic)%q(i,j)=work_ens%r2(ipic)%q(i,j) &
-                         +a_en(n)%r3(ipx)%q(i,j,1)*epts%en_perts(n,ibin)%r2(ipic)%qr4(i,j)
+                         +a_en(n)%r3(ipx)%q(i,j,1)*en_perts(n,ibin)%r2(ipic)%qr4(i,j)
                    enddo
                 enddo
              enddo ! enddo n_ens
@@ -1968,7 +2070,7 @@ end subroutine normal_new_factorization_rf_y
 
   end subroutine ensemble_forward_model_dual_res
 
-  subroutine ensemble_forward_model_ad(cvec,a_en,epts,ibin)
+  subroutine ensemble_forward_model_ad(cvec,a_en,ibin)
 !$$$  subprogram documentation block
 !                .      .    .                                       .
 ! subprogram:    ensemble_forward_model  add ensemble part to anl vars
@@ -2006,12 +2108,11 @@ end subroutine normal_new_factorization_rf_y
 !$$$
 
     use hybrid_ensemble_parameters, only: n_ens,pwgtflg,pwgt
-    use hybrid_ensemble_parameters, only: gsi_enperts
+    use hybrid_ensemble_parameters, only: en_perts
     implicit none
 
     type(gsi_bundle),intent(inout) :: cvec
     type(gsi_bundle),intent(inout) :: a_en(n_ens)
-    type(gsi_enperts),intent(in)   :: epts
     integer,intent(in)             :: ibin
 
     character(len=*),parameter :: myname_=trim(myname)//'*ensemble_forward_model_ad'
@@ -2052,7 +2153,7 @@ end subroutine normal_new_factorization_rf_y
              do j=1,jm
                 do i=1,im
                       a_en(n)%r3(ipx)%q(i,j,k)=a_en(n)%r3(ipx)%q(i,j,k) &
-                            +cvec%r3(ipic)%q(i,j,k)*epts%en_perts(n,ibin)%r3(ipic)%qr4(i,j,k)
+                            +cvec%r3(ipic)%q(i,j,k)*en_perts(n,ibin)%r3(ipic)%qr4(i,j,k)
                 enddo
              enddo
           enddo
@@ -2074,7 +2175,7 @@ end subroutine normal_new_factorization_rf_y
                    do j=1,jm
                       do i=1,im
                          a_en(n)%r3(ipx)%q(i,j,k)=a_en(n)%r3(ipx)%q(i,j,k) &
-                            +cvec%r2(ipic)%q(i,j)*epts%en_perts(n,ibin)%r2(ipic)%qr4(i,j)*pwgt(i,j,k)
+                            +cvec%r2(ipic)%q(i,j)*en_perts(n,ibin)%r2(ipic)%qr4(i,j)*pwgt(i,j,k)
                       enddo
                    enddo
                 enddo
@@ -2084,7 +2185,7 @@ end subroutine normal_new_factorization_rf_y
                 do j=1,jm
                    do i=1,im
                       a_en(n)%r3(ipx)%q(i,j,1)=a_en(n)%r3(ipx)%q(i,j,1) &
-                         +cvec%r2(ipic)%q(i,j)*epts%en_perts(n,ibin)%r2(ipic)%qr4(i,j)
+                         +cvec%r2(ipic)%q(i,j)*en_perts(n,ibin)%r2(ipic)%qr4(i,j)
                    enddo
                 enddo
  
@@ -2094,7 +2195,7 @@ end subroutine normal_new_factorization_rf_y
     return
   end subroutine ensemble_forward_model_ad
 
-  subroutine ensemble_forward_model_ad_dual_res(cvec,a_en,epts,ibin)
+  subroutine ensemble_forward_model_ad_dual_res(cvec,a_en,ibin)
 !$$$  subprogram documentation block
 !                .      .    .                                       .
 ! subprogram:    ensemble_forward_model_ad_dual_res  use for dualres option
@@ -2137,7 +2238,7 @@ end subroutine normal_new_factorization_rf_y
 !$$$
     use hybrid_ensemble_parameters, only: n_ens,pwgtflg,pwgt
     use hybrid_ensemble_parameters, only: n_ens,grd_ens,grd_anl,p_e2a
-    use hybrid_ensemble_parameters, only: gsi_enperts
+    use hybrid_ensemble_parameters, only: en_perts
     use general_sub2grid_mod, only: general_sube2suba_ad
     use gridmod,only: regional
     use constants, only: zero
@@ -2145,7 +2246,6 @@ end subroutine normal_new_factorization_rf_y
 
     type(gsi_bundle),intent(inout) :: cvec
     type(gsi_bundle),intent(inout) :: a_en(n_ens)
-    type(gsi_enperts),intent(in)   :: epts
     integer,intent(in)             :: ibin
 
     character(len=*),parameter::myname_=trim(myname)//'*ensemble_forward_model_ad_dual_res'
@@ -2209,7 +2309,7 @@ end subroutine normal_new_factorization_rf_y
              do j=1,jm
                 do i=1,im
                    a_en(n)%r3(ipx)%q(i,j,k)=a_en(n)%r3(ipx)%q(i,j,k) &
-                            +work_ens%r3(ipic)%q(i,j,k)*epts%en_perts(n,ibin)%r3(ipic)%qr4(i,j,k)
+                            +work_ens%r3(ipic)%q(i,j,k)*en_perts(n,ibin)%r3(ipic)%qr4(i,j,k)
                 enddo
              enddo
           enddo
@@ -2231,7 +2331,7 @@ end subroutine normal_new_factorization_rf_y
                    do j=1,jm
                       do i=1,im
                          a_en(n)%r3(ipx)%q(i,j,k)=a_en(n)%r3(ipx)%q(i,j,k) &
-                            +work_ens%r2(ipic)%q(i,j)*epts%en_perts(n,ibin)%r2(ipic)%qr4(i,j)*pwgt(i,j,k)
+                            +work_ens%r2(ipic)%q(i,j)*en_perts(n,ibin)%r2(ipic)%qr4(i,j)*pwgt(i,j,k)
                       enddo
                    enddo
                 enddo
@@ -2241,7 +2341,7 @@ end subroutine normal_new_factorization_rf_y
                 do j=1,jm
                    do i=1,im
                       a_en(n)%r3(ipx)%q(i,j,1)=a_en(n)%r3(ipx)%q(i,j,1) &
-                         +work_ens%r2(ipic)%q(i,j)*epts%en_perts(n,ibin)%r2(ipic)%qr4(i,j)
+                         +work_ens%r2(ipic)%q(i,j)*en_perts(n,ibin)%r2(ipic)%qr4(i,j)
                    enddo
                 enddo
 
@@ -2651,7 +2751,7 @@ subroutine sqrt_beta_s_mult_bundle(grady)
            if(sst_staticB) then
               cycle
            else
-              if(j==1.and.mype==0) write(6,*) myname_, ': scale static SST B-error by ', sqrt_beta_s(1)
+              if(mype==0) write(6,*) myname_, ': scale static SST B-error by ', sqrt_beta_s(1)
            endif
         endif
         do i=1,lat2
@@ -3949,7 +4049,7 @@ subroutine hybens_grid_setup
   return
 end subroutine hybens_grid_setup
 
-subroutine hybens_localization_setup(epts)
+subroutine hybens_localization_setup
 !$$$  subprogram documentation block
 !                .      .    .                                       .
 ! subprogram:    hybens_localization_setup   setup for hybrid localization
@@ -3987,13 +4087,10 @@ subroutine hybens_localization_setup(epts)
    use hybrid_ensemble_parameters, only: readin_beta,beta_s,beta_e,beta_s0,sqrt_beta_s,sqrt_beta_e
    use hybrid_ensemble_parameters, only: readin_localization,create_hybens_localization_parameters, &
                                          vvlocal,s_ens_h,s_ens_hv,s_ens_v,s_ens_vv
-   use hybrid_ensemble_parameters, only: gsi_enperts
    use gsi_io, only: verbose
    use guess_grids, only: gsiguess_get_ref_gesprs
 
    implicit none
-
-   type(gsi_enperts) :: epts
 
    integer(i_kind),parameter   :: lunin = 47
    character(len=40),parameter :: fname = 'hybens_info'
@@ -4091,7 +4188,7 @@ subroutine hybens_localization_setup(epts)
 
    ! Set up localization filters
 
-   call init_rf_z(epts,s_ens_vv)
+   call init_rf_z(s_ens_vv)
    call normal_new_factorization_rf_z
 
    if ( regional ) then ! convert s_ens_h from km to grid units.
@@ -5084,7 +5181,6 @@ subroutine setup_pwgt
 !$$$ end documentation block
 
    use m_kinds, only: r_kind,i_kind
-   use mpeu_util, only: die
    use constants,only: zero,one
    use m_mpimod, only: mype,gsi_mpi_comm_world,mpi_rtype,mpi_sum
    use gridmod, only: lat2,lon2,nsig,regional
@@ -5094,7 +5190,7 @@ subroutine setup_pwgt
 
    implicit none
 
-   character(len=*),parameter :: myname_=myname//'*setup_pwgt'
+   character(len=*),parameter :: myname='setup_pwgt::'
    integer(i_kind) :: i,j,k
    real(r_kind) :: tmp_sum
    real(r_kind),allocatable,dimension(:,:,:,:) :: wgvk_ens,wgvk_anl
@@ -5139,7 +5235,6 @@ subroutine setup_pwgt
             write(6,*) 'SETUP_PWGT: routine not built to load pwgt for global application'
             write(6,*) 'SETUP_PWGT: using defaults instead'
          endif
-         call die(myname_,': feature not implemented for GLOBAL, abort')
 
       endif ! if ( regional )
 
@@ -5150,14 +5245,11 @@ subroutine setup_pwgt
 end subroutine setup_pwgt
 
 #ifdef USE_ALL_ORIGINAL
-subroutine ens_iterate_update(nymd,nhms,jiter)
+subroutine ens_iterate_update(jiter)
   use hybrid_ensemble_parameters, only: destroy_hybens_localization_parameters
   use hybrid_ensemble_parameters, only: bens_recenter
-  use hybrid_ensemble_parameters, only: gsi_create_ensemble
-  use hybrid_ensemble_parameters, only: gsi_destroy_ensemble
   use m_revBens, only: update_spread
   implicit none
-  integer(i_kind),intent(in) :: nymd,nhms
   integer(i_kind),intent(in) :: jiter
 
   if (jiter<2) return
@@ -5165,15 +5257,15 @@ subroutine ens_iterate_update(nymd,nhms,jiter)
 ! unload ensemble
   call destroy_hybens_localization_parameters
   call hybens_localization_unsetup
-  call gsi_destroy_ensemble
+  call destroy_ensemble
 
 ! set recentering of ensemble around analysis
   bens_recenter = .true.   ! use alternative mean as ensemble mean to calc Bens
   update_spread = .true.   ! use analysis as recenter field, updating spread on the fly
 
 ! reload ensemble but this time use analysis for recentering
-  call gsi_create_ensemble
-  call load_ensemble(nymd,nhms,-1)
+  call create_ensemble
+  call load_ensemble(-1)
   call hybens_localization_setup
 
 end subroutine ens_iterate_update

--- a/src/gsibec/gsi/hybrid_ensemble_parameters.f90
+++ b/src/gsibec/gsi/hybrid_ensemble_parameters.f90
@@ -248,10 +248,6 @@ module hybrid_ensemble_parameters
   use general_specmod, only: spec_vars
   use egrid2agrid_mod, only: egrid2agrid_parm
   use gsi_bundlemod, only: gsi_bundle
-  use gsi_bundlemod, only: gsi_grid
-  use gsi_bundlemod, only: gsi_gridcreate
-  use gsi_bundlemod, only: gsi_bundlecreate
-  use gsi_bundlemod, only: gsi_bundleunset
 
   implicit none
 
@@ -291,6 +287,8 @@ module hybrid_ensemble_parameters
   public :: l_ens_in_diff_time
   public :: ensemble_path
   public :: ens_fname_tmpl
+  public :: nelen
+  public :: en_perts,ps_bar
   public :: region_lat_ens,region_lon_ens
   public :: region_dx_ens,region_dy_ens
   public :: ens_fast_read
@@ -299,11 +297,7 @@ module hybrid_ensemble_parameters
   public :: upd_ens_spread
   public :: upd_ens_localization
   public :: EnsSource
-  public :: test_nymd,test_nhms
-
-  public :: gsi_enperts
-  public :: gsi_create_ensemble
-  public :: gsi_destroy_ensemble
+  public :: nymd,nhms
 
   logical l_hyb_ens,uv_hyb_ens,q_hyb_ens,oz_univ_static,sst_staticB
   logical bens_recenter,upd_ens_spread,upd_ens_localization
@@ -324,7 +318,6 @@ module hybrid_ensemble_parameters
   logical ens_fast_read
   integer(i_kind) i_en_perts_io
   integer(i_kind) n_ens,nlon_ens,nlat_ens,jcap_ens,jcap_ens_test
-  integer(i_kind) :: test_nymd(7),test_nhms(7)
   real(r_kind) beta_s0,s_ens_h,s_ens_v,grid_ratio_ens
   type(sub2grid_info),save :: grd_ens,grd_loc,grd_sploc,grd_anl,grd_e1,grd_a1
   type(spec_vars),save :: sp_ens,sp_loc
@@ -346,31 +339,21 @@ module hybrid_ensemble_parameters
   character(len=512),save :: ens_fname_tmpl
   character(len=80) :: EnsSource
 
+  integer, allocatable :: nymd(:),nhms(:)
+
 ! following is for storage of ensemble perturbations:
 
 !   def en_perts            - array of ensemble perturbations
 !   def nelen               - length of one ensemble perturbation vector
 
-  type gsi_enperts
-    integer(i_kind) nelen
-    type(gsi_bundle),allocatable :: en_perts(:,:)
-    real(r_single),dimension(:,:,:),allocatable:: ps_bar
-  end type gsi_enperts
+  integer(i_kind) nelen
+  type(gsi_bundle),save,allocatable :: en_perts(:,:)
+  real(r_single),dimension(:,:,:),allocatable:: ps_bar
 
 !    following is for interpolation of global ensemble to regional ensemble grid
 
   real(r_kind),allocatable:: region_lat_ens(:,:),region_lon_ens(:,:)
   real(r_kind),allocatable:: region_dx_ens(:,:),region_dy_ens(:,:)
-
-  character(len=*),parameter :: myname = 'hybrid_ensemble_parameters'
-  logical, parameter :: debug = .true.
-
-  interface gsi_create_ensemble
-    module procedure create_ensemble_
-  end interface
-  interface gsi_destroy_ensemble
-    module procedure destroy_ensemble_
-  end interface
 
 contains
 
@@ -447,8 +430,6 @@ subroutine init_hybrid_ensemble_parameters
   upd_ens_localization=.false.  ! update localization when upd_ens_spread=.t.
 
   EnsSource = 'NULL'
-  test_nymd = -1
-  test_nhms = -1
 
 end subroutine init_hybrid_ensemble_parameters
 
@@ -477,113 +458,5 @@ subroutine destroy_hybens_localization_parameters
   deallocate(sqrt_beta_s,sqrt_beta_e,pwgt)
 
 end subroutine destroy_hybens_localization_parameters
-
-
-  subroutine create_ensemble_(cvars2d,cvars3d,epts)
-!$$$  subprogram documentation block
-!                .      .    .                                       .
-! subprogram:    create_ensemble        allocate space for ensembles
-!   prgmmr: parrish          org: np22                date: 2009-06-16
-!
-! abstract: allocate space for ensemble perturbations used with the 
-!             hybrid ensemble option.
-!
-! program history log:
-!   2009-06-16  parrish
-!   2010-02-20  parrish  modifications for dual resolution
-!   2011-02-28  parrish - introduce more complete use of gsi_bundlemod to eliminate hard-wired variables
-!   2011-08-31  todling - revisit en_perts (single-prec) in light of extended bundle
-!
-!   input argument list:
-!
-!   output argument list:
-!
-! attributes:
-!   language: f90
-!   machine:  ibm RS/6000 SP
-!
-!$$$
-    implicit none
-
-    character(len=*), intent(in) :: cvars2d(:),cvars3d(:)
-    type(gsi_enperts) :: epts
-
-    type(gsi_grid) :: grid_ens
-    integer(i_kind) n,istatus,m
-    integer(i_kind) nc2d,nc3d
-    character(len=*),parameter::myname_=trim(myname)//'*create_ensemble'
-
-    nc2d=size(cvars2d); nc3d=size(cvars3d)
-    epts%nelen=grd_ens%latlon11*(max(0,nc3d)*grd_ens%nsig+max(0,nc2d))
-!   create ensemble perturbations bundles (using newly added r_single capability
-
-    allocate(epts%en_perts(n_ens,ntlevs_ens))
-    call gsi_gridcreate(grid_ens,grd_ens%lat2,grd_ens%lon2,grd_ens%nsig)
- 
-    do m=1,ntlevs_ens
-       do n=1,n_ens
-          call gsi_bundlecreate(epts%en_perts(n,m),grid_ens,'ensemble perts',istatus, &
-                                names2d=cvars2d,names3d=cvars3d,bundle_kind=r_single)
-          if(istatus/=0) then
-             write(6,*)trim(myname_),': trouble creating en_perts bundle'
-             call stop2(999)
-          endif
-       enddo
-    enddo
-
-
-    allocate(epts%ps_bar(grd_ens%lat2,grd_ens%lon2,ntlevs_ens) )
-    if(debug) then
-       write(6,*)' in create_ensemble, grd_ens%latlon11,grd_ens%latlon1n,n_ens,ntlevs_ens=', &
-                                 grd_ens%latlon11,grd_ens%latlon1n,n_ens,ntlevs_ens
-       write(6,*)' in create_ensemble, total bytes allocated=',4*epts%nelen*n_ens*ntlevs_ens
-    end if
-    return
-
-  end subroutine create_ensemble_
-
-  subroutine destroy_ensemble_(epts)
-!$$$  subprogram documentation block
-!                .      .    .                                       .
-! subprogram:    destroy_ensemble       deallocate space for ensembles
-!   prgmmr: parrish          org: np22                date: 2009-06-16
-!
-! abstract: deallocate space for ensemble perturbations used with the 
-!             hybrid ensemble option.
-!
-! program history log:
-!   2009-06-16  parrish
-!   2011-02-28  parrish, replace specific ensemble perturbation arrays with pseudo-bundle en_perts array
-!
-!   input argument list:
-!
-!   output argument list:
-!
-! attributes:
-!   language: f90
-!   machine:  ibm RS/6000 SP
-!
-!$$$
-    implicit none
-
-    type(gsi_enperts) :: epts
-    integer(i_kind) istatus,n,m
-
-    if(l_hyb_ens) then
-       do m=1,ntlevs_ens
-          do n=1,n_ens
-             call gsi_bundleunset(epts%en_perts(n,m),istatus)
-             if(istatus/=0) then
-                write(6,*)'in destroy_ensemble: trouble destroying en_perts bundle'
-                call stop2(999)
-             endif
-          enddo
-       enddo
-       deallocate(epts%ps_bar)
-       deallocate(epts%en_perts)
-    end if
-    return
-
-  end subroutine destroy_ensemble_
 
 end module hybrid_ensemble_parameters

--- a/src/gsibec/gsi/m_gsibec.F90
+++ b/src/gsibec/gsi/m_gsibec.F90
@@ -11,12 +11,15 @@ use m_mpimod, only: setworld
 
 use gsi_4dvar, only: nsubwin
 use gsi_4dvar, only: lsqrtb
+use hybrid_ensemble_parameters, only: ntlevs_ens
+use hybrid_ensemble_parameters, only: nymd,nhms
 use jfunc, only: nsclen,npclen,ntclen
 use jfunc, only: mockbkg
 use jfunc, only: jouter_def
 use gridmod, only: lon2,lat2,lat1,lon1,nsig
 
 use guess_grids, only: nfldsig
+use guess_grids, only: ntguessig
 use guess_grids, only: gsiguess_init
 use guess_grids, only: gsiguess_final
 use guess_grids, only: gsiguess_set
@@ -28,6 +31,7 @@ use state_vectors, only: allocate_state,deallocate_state
 use control_vectors, only: control_vector
 use control_vectors, only: allocate_cv,deallocate_cv
 use control_vectors, only: assignment(=)
+use control_vectors, only: cvars3d
 use control_vectors, only: prt_control_norms
 use control_vectors, only: inquire_cv
 use control_vectors, only: cvars2d, cvars3d
@@ -38,17 +42,16 @@ use gsi_bundlemod, only: gsi_bundle
 use gsi_bundlemod, only: gsi_bundlegetpointer
 use gsi_bundlemod, only: gsi_bundleprint
 use gsi_bundlemod, only: assignment(=)
+use gsi_bundlemod, only: self_add
 
 use gsimod, only: gsimain_initialize
 use gsimod, only: gsimain_finalize
 
 use m_berror_stats,only : berror_stats
 use berror, only: simcv,bkgv_write_cv,bkgv_write_sv
-use hybrid_ensemble_parameters,only: l_hyb_ens
-use hybrid_ensemble_parameters,only: ntlevs_ens
+use hybrid_ensemble_parameters,only : l_hyb_ens
 use hybrid_ensemble_isotropic, only: hybens_grid_setup
-use hybrid_ensemble_parameters, only: gsi_create_ensemble
-use hybrid_ensemble_parameters, only: gsi_enperts
+use hybrid_ensemble_isotropic, only: create_ensemble
 use hybrid_ensemble_isotropic, only: bkerror_a_en
 use hybrid_ensemble_isotropic, only: ensemble_forward_model_ad
 use hybrid_ensemble_isotropic, only: ensemble_forward_model
@@ -127,16 +130,17 @@ logical,save :: gsibec_iamset_ = .false.
 
 character(len=*), parameter :: myname ="m_gsibec"
 contains
-  subroutine init_(cv,epts,vgrid,bkgmock,nmlfile,befile,&
-                   layout,jouter,comm)
+  subroutine init_(cv,vgrid,bkgmock,nmlfile,befile,layout, &
+                   jouter,inymd,inhms,&
+                   comm)
 
   logical, intent(out) :: cv
-  type(gsi_enperts), intent(inout) :: epts
   logical, optional, intent(in)  :: vgrid
   logical, optional, intent(out) :: bkgmock
   character(len=*),optional,intent(in) :: nmlfile
   character(len=*),optional,intent(in) :: befile
   integer,optional,intent(in) :: layout(2) ! 1=nx, 2=ny
+  integer,optional,intent(in) :: inymd(:),inhms(:)
   integer,optional,intent(out):: jouter
   integer,optional,intent(in) :: comm
 
@@ -173,10 +177,25 @@ contains
      call befname_(befile,0)
   endif
   call gsimain_initialize(nmlfile=nmlfile)
+
+  nfldsig=1 
+  ntguessig=1
+  if (present(inymd) .and. present(inhms)) then
+      if (size(inymd)/=ntlevs_ens) then
+         print *, 'nymd,ntlevs ', size(inymd), ntlevs_ens
+         call die(myname,'inconsistent number of time slots ier =',99)
+      endif
+      allocate(nymd(ntlevs_ens),nhms(ntlevs_ens))
+      nymd = inymd
+      nhms = inhms
+      nfldsig=ntlevs_ens 
+      ntguessig=(ntlevs_ens+1)/2
+  endif
+
   call set_(vgrid=vgrid)
   if(l_hyb_ens) then
     call hybens_grid_setup()
-    call gsi_create_ensemble(cvars2d,cvars3d,epts)
+    call create_ensemble()
   endif
   call set_pointer_()
 
@@ -198,16 +217,18 @@ contains
 ! call gsiguess_bkgcov_init()  ! not where I want for this to be
   end subroutine init_guess_
 !--------------------------------------------------------
-  subroutine set_guess2_(varname,var)
+  subroutine set_guess2_(varname,islot,var)
   character(len=*),intent(in) :: varname
+  integer(i_kind),intent(in) :: islot
   real(r_kind),intent(in) :: var(:,:)
-  call gsiguess_set(varname,var) 
+  call gsiguess_set(varname,islot,var) 
   end subroutine set_guess2_
 !--------------------------------------------------------
-  subroutine set_guess3_(varname,var)
+  subroutine set_guess3_(varname,islot,var)
   character(len=*),intent(in) :: varname
+  integer(i_kind),intent(in) :: islot
   real(r_kind),intent(in) :: var(:,:,:)
-  call gsiguess_set(varname,var) 
+  call gsiguess_set(varname,islot,var) 
   end subroutine set_guess3_
 !--------------------------------------------------------
   subroutine final_(closempi)
@@ -479,9 +500,7 @@ contains
     CALL setup_control_vectors(nsig,lat2,lon2,latlon11,latlon1n, &
                                nsclen,npclen,ntclen,nclen,nsubwin,&
                                nval_len,lsqrtb,n_ens, &
-                               nval_lenz_enz,&
-                               grd_ens%lat2,grd_ens%lon2,grd_ens%nsig,&
-                               grd_ens%latlon11,l_hyb_ens)
+                               nval_lenz_enz)
     CALL setup_predictors(nrclen,nsclen,npclen,ntclen)
     CALL setup_state_vectors(latlon11,latlon1n,nvals_len,lat2,lon2,nsig)
 
@@ -638,12 +657,11 @@ contains
 
   end subroutine be_cv_space0_
 
-  subroutine be_cv_space1_(gradx,internalcv,bypassbe,epts)
+  subroutine be_cv_space1_(gradx,internalcv,bypassbe)
 
-  type(control_vector)  :: gradx
+  type(control_vector) :: gradx
   logical,optional,intent(in) :: internalcv
   logical,optional,intent(in) :: bypassbe
-  type(gsi_enperts),optional,intent(in) :: epts
 
   type(control_vector) :: grady
 
@@ -672,9 +690,9 @@ contains
      call bkerror(gradx,grady, &
                   1,nsclen,npclen,ntclen)
      if (l_hyb_ens) then
-        call ensemble_forward_model_ad(gradx%step(1),gradx%aens(1,:),epts,1)
+        call ensemble_forward_model_ad(gradx%step(1),gradx%aens(1,:),1)
         call bkerror_a_en(gradx,grady)
-        call ensemble_forward_model(grady%step(1),grady%aens(1,:),epts,1)
+        call ensemble_forward_model(grady%step(1),grady%aens(1,:),1)
      endif
   endif
 
@@ -695,6 +713,8 @@ contains
   subroutine be_sv_space0_
 
   type(gsi_bundle), allocatable :: mval(:)
+  type(control_vector) :: gradx,grady
+  type(predictors)     :: sbias
   integer ii
 
 ! start work space
@@ -703,9 +723,41 @@ contains
       call allocate_state(mval(ii))
       mval(ii) = zero
   end do
+  call allocate_preds(sbias)
 
-  call be_sv_space1_(mval,internalsv=.true.)
+  call allocate_cv(gradx)
+  call allocate_cv(grady)
+  gradx=zero
+  grady=zero
 
+! get test vector (mval)
+! call get_state_perts_ (mval(1))
+!
+  call set_silly_(mval(1))
+  call gsi2model_units_ad_(mval(1))
+
+  call control2state_ad(mval,sbias,gradx)
+
+! apply B to input (transformed) vector
+  call bkerror(gradx,grady, &
+               1,nsclen,npclen,ntclen)
+  if (l_hyb_ens) then
+     call bkerror_a_en(gradx,grady)
+  endif
+
+  call control2state(grady,mval,sbias)
+
+! if so write out fields from gsi (in GSI units)
+  if(bkgv_write_sv/='null') &
+  call write_bundle(mval(1),bkgv_write_sv)
+
+! convert back to model units (just for consistency here)
+  call gsi2model_units_(mval(1))
+
+! clean up work space
+  call deallocate_cv(gradx)
+  call deallocate_cv(grady)
+  call deallocate_preds(sbias)
   do ii=nsubwin,1,-1
       call deallocate_state(mval(ii))
   end do
@@ -713,27 +765,25 @@ contains
 
   end subroutine be_sv_space0_
 !--------------------------------------------------------
-  subroutine be_sv_space1_(mval,internalsv,bypassbe,epts)
+  subroutine be_sv_space1_(sval,internalsv,bypassbe)
 
-  type(gsi_bundle) :: mval(nsubwin)
+  type(gsi_bundle) :: sval(:)
   logical,optional,intent(in) :: internalsv
   logical,optional,intent(in) :: bypassbe
-  type(gsi_enperts),optional,intent(in) :: epts
 
-  character(len=*), parameter :: myname_ = myname//'*be_sv_space1_'
-  type(gsi_bundle),allocatable :: eval(:)
   type(control_vector) :: gradx,grady
   type(predictors)     :: sbias
+  type(gsi_bundle),allocatable :: eval(:)
+  type(gsi_bundle),allocatable :: mval(:)
   logical bypassbe_
   integer ii,ier
 
   if (nsubwin/=1) then
      if(ier/=0) call die(myname,'cannot handle this nsubwin =',nsubwin)
   endif
-! if (ntlevs_ens/=1) then
-!    if(ier/=0) call die(myname,'cannot handle this ntlevs_ens =',ntlevs_ens)
-! endif
-  allocate(eval(ntlevs_ens))
+  if (ntlevs_ens/=size(sval)) then
+     if(ier/=0) call die(myname,'inconsistent size of sval; ntlevs_ens =',ntlevs_ens)
+  endif
 
   bypassbe_ = .false.
   if (present(bypassbe)) then
@@ -742,10 +792,15 @@ contains
 
 ! start work space
   if (l_hyb_ens) then
+     allocate(eval(ntlevs_ens))
      do ii=1,ntlevs_ens
        call allocate_state(eval(ii))
     end do
   endif
+  allocate(mval(nsubwin))
+  do ii=1,nsubwin
+    call allocate_state(mval(ii))
+  end do
   call allocate_preds(sbias)
   call allocate_cv(gradx)
   call allocate_cv(grady)
@@ -753,16 +808,30 @@ contains
   grady=zero
 
 ! get test vector (mval)
+! call get_state_perts_ (mval(1))
   if (present(internalsv)) then
-     if (internalsv) call set_silly_(mval(1))
+     if (internalsv) then
+        do ii=1,ntlevs_ens
+          call set_silly_(sval(ii))
+        end do
+     endif
   endif
 
 ! convert from model to gsi units
-  call gsi2model_units_ad_(mval(1))
+  do ii=1,ntlevs_ens
+     call gsi2model_units_ad_(sval(ii))
+  end do
 
   if (l_hyb_ens) then
-     eval(1)=mval(1)
-     call ensctl2state_ad(epts,eval,mval(1),gradx)
+     do ii=1,ntlevs_ens
+        eval(ii)=sval(ii)
+     end do
+     call ensctl2state_ad(eval,mval(1),gradx)
+  else
+     mval(1)=sval(1)
+     do ii=2,ntlevs_ens
+        call self_add(mval(1),sval(ii))
+     end do
   endif
   call control2state_ad(mval,sbias,gradx)
 
@@ -771,7 +840,7 @@ contains
     grady=gradx
   else
     call bkerror(gradx,grady, &
-                 nsubwin,nsclen,npclen,ntclen)
+                 1,nsclen,npclen,ntclen)
     if (l_hyb_ens) then
        call bkerror_a_en(gradx,grady)
     endif
@@ -779,16 +848,24 @@ contains
 
   call control2state(grady,mval,sbias)
   if (l_hyb_ens) then
-     call ensctl2state(epts,grady,mval(1),eval)
-     mval(1)=eval(1)
+     call ensctl2state(grady,mval(1),eval)
+     do ii=1,ntlevs_ens
+        sval(ii)=eval(ii)
+     end do
+  else
+     do ii=1,ntlevs_ens
+        sval(ii)=mval(1)
+     enddo
   end if
 
 ! if so write out fields from gsi (in GSI units)
   if(bkgv_write_sv/='null') &
-  call write_bundle(mval(1),bkgv_write_sv)
+  call write_bundle(sval(ntguessig),bkgv_write_sv)
 
 ! convert from gsi to model units
-  call gsi2model_units_(mval(1))
+  do ii=1,ntlevs_ens
+     call gsi2model_units_(sval(ii))
+  end do
 
 ! clean up work space
   call deallocate_cv(gradx)
@@ -798,8 +875,12 @@ contains
      do ii=ntlevs_ens,1,-1
        call deallocate_state(eval(ii))
     end do
+    deallocate(eval)
   endif
-  deallocate(eval)
+  do ii=nsubwin,1,-1
+    call deallocate_state(mval(ii))
+  end do
+  deallocate(mval)
 
   end subroutine be_sv_space1_
 !--------------------------------------------------------
@@ -881,6 +962,8 @@ contains
   end subroutine gsi2model_units_ad_
 !--------------------------------------------------------
   subroutine final_guess_
+  if(allocated(nymd)) deallocate(nymd)
+  if(allocated(nhms)) deallocate(nhms)
   call gsiguess_final()
   end subroutine final_guess_
 end module m_gsibec

--- a/src/gsibec/gsi/m_rf.f90
+++ b/src/gsibec/gsi/m_rf.f90
@@ -22,8 +22,7 @@ use hybrid_ensemble_parameters, only: l_hyb_ens
 use hybrid_ensemble_parameters, only: destroy_hybens_localization_parameters
 use hybrid_ensemble_isotropic, only: load_ensemble
 use hybrid_ensemble_isotropic, only: hybens_localization_setup
-use hybrid_ensemble_parameters, only: gsi_enperts
-use hybrid_ensemble_parameters, only: gsi_destroy_ensemble
+use hybrid_ensemble_isotropic, only: destroy_ensemble
 
 use mpeu_util, only: getindex
 use mpeu_util, only: die
@@ -37,11 +36,7 @@ interface rf_unset; module procedure unset_; end interface
 
 character(len=*), parameter :: myname = 'm_rf'
 contains
-  subroutine set_ (epts,nymd,nhms)
-  implicit none
-  type(gsi_enperts) :: epts
-  integer(i_kind), intent(in) :: nymd,nhms
- 
+  subroutine set_ ()
   character(len=*), parameter :: mynmae_ = myname//'*set_'
   integer(i_kind) msig,mlat,mlon
   logical good
@@ -59,16 +54,14 @@ contains
   call prewgt(mype)
 ! If hybrid covariance
   if(l_hyb_ens) then
-     call load_ensemble(epts,nymd,nhms,-1)
-     call hybens_localization_setup(epts)
+     call load_ensemble(-1)
+     call hybens_localization_setup
   end if
   end subroutine set_
-  subroutine unset_(epts)
-  implicit none
-  type(gsi_enperts) :: epts
+  subroutine unset_
   if (l_hyb_ens) then
     call destroy_hybens_localization_parameters
-    call gsi_destroy_ensemble(epts)
+    call destroy_ensemble
   endif
   call destroy_smooth_polcas ! the set is called in prewgt - gsi typically has inconsistent set/unset
   call destroy_berror_vars

--- a/src/gsibec/gsigeos/geos_StateIO.F90
+++ b/src/gsibec/gsigeos/geos_StateIO.F90
@@ -32,7 +32,6 @@ integer(i_kind),    intent(in   ) :: nymd,nhms
 integer(i_kind),    intent(in   ) :: iwhat
 integer(i_kind),optional,intent(in ) :: tau   ! time interval in hours
 character(len=*), parameter :: myname_ = myname//'get_1state_'
-print *, 'DEBUG: get_1state_ - getting here '
 end subroutine get_1state_
 subroutine get_Nstate_(xx,sgrid,nymd,nhms,tau)
 use constants, only: zero

--- a/test/mains/test_gsi_bkerror.F90
+++ b/test/mains/test_gsi_bkerror.F90
@@ -8,7 +8,6 @@ use m_gsibec, only: gsibec_final_guess
 use m_gsibec, only: gsibec_final
 
 use guess_grids, only: gsiguess_bkgcov_init
-use hybrid_ensemble_parameters, only: gsi_enperts
 
 use mpeu_util, only: die
 use m_mpimod, only: gsi_mpi_comm_world
@@ -22,7 +21,6 @@ character(len=*), parameter :: myname = "test_gsi_berror"
 character(len=MAXSTR) :: nml, bef
 integer :: mype,ier
 logical :: cv
-type(gsi_enperts) :: epts
 
 call mpi_init(ier)
 call setworld()
@@ -33,7 +31,7 @@ if(ier/=0) then
   call die(trim(myname),'fail reading cmd line, try again',ier)
 endif
 
-call gsibec_init(cv,epts,nmlfile=nml,befile=bef,vgrid=.true.)
+call gsibec_init(cv,nmlfile=nml,befile=bef,vgrid=.true.)
 call gsibec_init_guess()
 call gsiguess_bkgcov_init()
 


### PR DESCRIPTION
The version in develop had changes that at some point accommodate a particular way of doing hybrid 4dEnVar in JEDI. That way eventually got revised and fell more along the lines of how GSIBEC originally handled a 4d case. This version presently used in JEDI is 1.2.1 - which had been sitting on a side branch ... so what this does is being 1.2.1 back to develop (overriding 1.1.3).

This is zero diff to what is in 1.1.3 when running 3d cases - and unknown when running 4d - though I know for a fact that what is being put in develop (coming from 1.2.1) results in a sane 4d version.