### PR TITLE
TLNMC machinery re-instated

### DIFF
--- a/cmake/gsibec_compiler_flags.cmake
+++ b/cmake/gsibec_compiler_flags.cmake
@@ -1,7 +1,7 @@
 # Compiler definitions
 # --------------------
 # add_definitions( -D_REAL8_ -DLINUX -Dfunder -DFortranByte=char -DFortranInt=int -I/usr/local/intel/2020/compilers_and_libraries_2020.0.166/linux/mpi/intel64/include )
-add_definitions( -D_JEDI_ -D_REAL8_ -DLINUX -Dfunder -DFortranByte=char -DFortranInt=int )
+add_definitions( -D_JEDI_ -D_REAL8_ -DTLNMC -DLINUX -Dfunder -DFortranByte=char -DFortranInt=int )
 
 if( NOT CMAKE_BUILD_TYPE MATCHES "Debug" )
   add_definitions( -DNDEBUG )

--- a/src/gsibec/gsi/CMakeLists.txt
+++ b/src/gsibec/gsi/CMakeLists.txt
@@ -95,6 +95,26 @@ tv_to_tsen.f90
 write_bkgvars_grid.F90
 m_gbc4saber.f90
 xhat_vordivmod.f90
+)
+
+list(APPEND gsitlnmc_src_files_list
+calctends_ad.F90
+calctends_tl.F90
+calctends_no_ad.F90
+calctends_no_tl.F90
+get_semimp_mats.f90
+mod_strong.f90
+mod_vtrans.F90
+psichi2uvt_reg.f90
+psichi2uv_reg.f90
+rtlnmc_version3.f90
+strong_bal_correction.f90
+strong_baldiag_inc.f90
+strong_fast_global_mod.f90
+turblmod.f90
+turbl_ad.f90
+turbl_tl.f90
+zrnmi_mod.f90
 
 )
 
@@ -106,6 +126,7 @@ endif()
 set( gsi_src_files
 
 ${gsi_src_files_list}
+${gsitlnmc_src_files_list}
 
 PARENT_SCOPE
 )

--- a/src/gsibec/gsi/balmod.F90
+++ b/src/gsibec/gsi/balmod.F90
@@ -74,9 +74,11 @@ module balmod
   public :: destroy_balance_vars_reg
   public :: prebal_reg
   public :: locatelat_reg
+#endif /* USE_ALL_ORIGINAL */
+#ifdef TLNMC
   public :: strong_bk
   public :: strong_bk_ad
-#endif /* USE_ALL_ORIGINAL */
+#endif /* TLNMC */
   public :: prebal
   public :: balance
   public :: tbalance
@@ -404,10 +406,10 @@ contains
 !$$$
     use constants, only: one,half
     use gridmod, only: regional,lat2,nsig,lon2
-#ifdef USE_ALL_ORIGINAL
+#ifdef TLNMC
     use gsi_4dvar, only: lsqrtb
     use mod_strong, only: tlnmc_option
-#endif /* USE_ALL_ORIGINAL */
+#endif /* TLNMC */
     implicit none
     
 !   Declare passed variables
@@ -528,13 +530,13 @@ contains
 
 !!   Strong balance constraint
 !!   Pass uvflag=.false.
-#ifdef USE_ALL_ORIGINAL
+#ifdef TLNMC
      if(lsqrtb) then
         call strong_bk(st,vp,p,t,.false.)
       else
         if(tlnmc_option==1 .or. tlnmc_option==4) call strong_bk(st,vp,p,t,.false.)
      endif
-#endif /* USE_ALL_ORIGINAL */
+#endif /* TLNMC */
 
 
 
@@ -601,10 +603,10 @@ contains
 !$$$
     use constants,   only: one,half
     use gridmod,     only: regional,lon2,lat2,nsig
-#ifdef USE_ALL_ORIGINAL
+#ifdef TLNMC
     use gsi_4dvar,   only: lsqrtb
     use mod_strong,  only: tlnmc_option
-#endif /* USE_ALL_ORIGINAL */
+#endif /* TLNMC */
     implicit none
 
 !   Declare passed variables
@@ -620,13 +622,13 @@ contains
   
 !  Adjoint of strong balance constraint
 !  pass uvflag=.false.
-#ifdef USE_ALL_ORIGINAL
+#ifdef TLNMC
     if(lsqrtb) then
        call strong_bk_ad(st,vp,p,t,.false.)
     else
        if(tlnmc_option==1 .or. tlnmc_option==4) call strong_bk_ad(st,vp,p,t,.false.)
     endif
-#endif /* USE_ALL_ORIGINAL */
+#endif /* TLNMC */
 
 !   REGIONAL BRANCH
     if (regional) then
@@ -860,7 +862,7 @@ contains
     return
 end subroutine locatelat_reg
   
-#ifdef USE_ALL_ORIGINAL
+#ifdef TLNMC
 subroutine strong_bk(st,vp,p,t,uvflag)
 !$$$  subprogram documentation block
 !                .      .    .                                       .
@@ -1006,6 +1008,6 @@ subroutine strong_bk_ad(st,vp,p,t,uvflag)
 
   return
 end subroutine strong_bk_ad
-#endif /* USE_ALL_ORIGINAL */
+#endif /* TLNMC */
 
 end module balmod

--- a/src/gsibec/gsi/calctends_ad.F90
+++ b/src/gsibec/gsi/calctends_ad.F90
@@ -1,0 +1,658 @@
+subroutine calctends_ad(fields,fields_dt,mype)
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    calctends_ad         adjoint of calctends_tl
+!   prgmmr: kleist           org: np20                date: 2005-09-29
+!
+! abstract: adjoint of routine that compute tendencies for u,v,Tv,prs
+!
+! program history log:
+!   2005-09-29  kleist
+!   2005-10-17  kleist - changes to improve computational efficiency
+!   2005-11-21  kleist - add tracer tendencies, use new module
+!   2006-01-31  kleist - add indices to sum* variables being initialized in loop
+!   2006-04-12  treadon - replace sigi with bk5
+!   2006-04-21  kleist - add divergence tendency bits
+!   2006-07-31  kleist - changes to use ps instead of ln(ps)
+!   2006-09-21  kleist - add rescaling to divergence tendency formulation
+!   2007-03-13  kleist - move jcrescale_ad (and related code) into if (divtflg) block
+!   2007-04-16  kleist - move constraint specific items elsewhere
+!   2007-05-08  kleist - add bits for fully generalized vertical coordinate
+!   2007-06-21  rancic - add pbl 
+!   2007-07-26  cucurull - add 3d pressure pri in argument list;
+!                          move getprs_ad outside calctends_ad;
+!                          call getprs_horiz_ad; remove ps from argument
+!                          list
+!   2007-08-08  derber - optimize
+!   2008-06-05  safford - rm unused var "nnn" and unused uses
+!   2009-08-20  parrish - replace curvfct with curvx, curvy.  this allows tendency computation to
+!                          work for any general orthogonal coordinate.
+!   2010-11-03  derber - moved threading calculations to gridmod and modified
+!   2011-05-01  todling - cwmr no longer in guess-grids; use metguess bundle now
+!   2011-12-02  zhu     - add safe-guard for the case when there is no entry in the metguess table
+!   2013-01-23  parrish - change t_t from intent(in) to intent(inout) (flagged by WCOSS intel debug compile)
+!   2013-10-19  todling - revamp interface (pass all in bundles); derivatives and
+!                         guess fields also in bundles
+!   2013-10-28  todling - rename p3d to prse
+!
+! usage:
+!   input argument list:
+!    fields    - bundle holding relevant fields
+!    fields_dt - bundle holding related time tendencies
+!     mype     - mpi integer task id
+!
+!   output argument list:
+!    fields    - bundle holding fields
+!
+!   notes:
+!     adjoint check performed succesfully on 2005-09-29 by d. kleist
+!
+! attributes:
+!   language: f90
+!   machine:  ibm RS/6000 SP
+!
+!$$$
+  use m_kinds,only: r_kind,i_kind
+  use gridmod, only: lat2,lon2,nsig,istart,nlat,idvc5,bk5,&
+      eta2_ll,nthreads,jtstart,jtstop,regional
+#ifdef USE_ALL_ORIGINAL
+  use gridmod, only: wrf_nmm_regional,nems_nmmb_regional
+#endif /* USE_ALL_ORIGINAL */
+  use constants, only: zero,half,two,rd,rcp
+  use derivsmod, only: cwgues
+  use tendsmod, only: what9,prsth9,r_prsum9,prdif9,r_prdif9,pr_xsum9,pr_xdif9,&
+      pr_ysum9,pr_ydif9,curvx,curvy,coriolis
+  use guess_grids, only: ntguessig,&
+      ges_teta,ges_prsi
+  use gsi_metguess_mod, only: gsi_metguess_get,gsi_metguess_bundle
+  use gsi_bundlemod, only: gsi_bundlegetpointer
+  use gsi_bundlemod, only: gsi_bundle
+  use mpeu_util, only: die
+  use derivsmod, only: gsi_xderivative_bundle
+  use derivsmod, only: gsi_yderivative_bundle
+  implicit none
+
+! Declare passed variables
+  type(gsi_bundle) :: fields
+  type(gsi_bundle) :: fields_dt
+  type(gsi_bundle) :: derivativex
+  type(gsi_bundle) :: derivativey
+  integer(i_kind),intent(in) :: mype
+
+! Declare local variables
+  character(len=*),parameter::myname='calctends_ad'
+  real(r_kind),dimension(:,:,:),pointer :: u_t,v_t,u,v,t,q,oz,cw
+  real(r_kind),dimension(:,:,:),pointer :: t_t
+  real(r_kind),dimension(:,:,:),pointer :: q_t,oz_t,cw_t
+  real(r_kind),dimension(:,:,:),pointer :: p_t
+  real(r_kind),dimension(:,:,:),pointer :: pri
+
+  real(r_kind),dimension(lat2,lon2,nsig+1):: prsth,what
+  real(r_kind),dimension(lat2,lon2,nsig):: prsum,prdif,pr_xsum,pr_xdif,pr_ysum,&
+       pr_ydif
+
+  real(r_kind),dimension(lat2,lon2):: ps_x,ps_y
+  real(r_kind),dimension(lat2,lon2,nsig):: t_thor9
+  real(r_kind),dimension(lat2,lon2):: sumkm1,sumvkm1,sum2km1,sum2vkm1
+  real(r_kind) tmp,tmp2,tmp3,var,sumk,sumvk,sum2k,sum2vk
+  integer(i_kind) i,j,k,ix,it,kk,istatus,n_actual_clouds,ier
+
+  real(r_kind),pointer,dimension(:,:,:) :: ges_u=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_v=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_tv=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_q =>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_oz=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_cwmr=>NULL()
+
+  real(r_kind),pointer,dimension(:,:,:) :: ges_u_lon=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_v_lon=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_tv_lon=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_q_lon =>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_oz_lon=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_cw_lon=>NULL()
+
+  real(r_kind),pointer,dimension(:,:,:) :: ges_u_lat=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_v_lat=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_tv_lat=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_q_lat =>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_oz_lat=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_cw_lat=>NULL()
+
+  real(r_kind),pointer,dimension(:,:,:) :: u_x=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: v_x=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: t_x=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: q_x =>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: oz_x=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: cw_x=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: pri_x=>NULL()
+
+  real(r_kind),pointer,dimension(:,:,:) :: u_y=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: v_y=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: t_y=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: q_y =>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: oz_y=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: cw_y=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: pri_y=>NULL()
+
+  it=ntguessig
+
+  ier=0
+  call gsi_bundlegetpointer(fields,'u',   u,   istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(fields,'v',   v,   istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(fields,'tv',  t,   istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(fields,'q',   q,   istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(fields,'oz' , oz,  istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(fields,'cw' , cw,  istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(fields,'prse',pri, istatus);ier=istatus+ier
+  if(ier/=0) then
+     write(6,*) myname,': pointers not found on input, ier=', ier
+     call stop2(999)
+  endif
+
+  ier=0
+  call gsi_bundlegetpointer(derivativex,'u',   u_x,   istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(derivativex,'v',   v_x,   istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(derivativex,'tv',  t_x,   istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(derivativex,'q',   q_x,   istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(derivativex,'oz' , oz_x,  istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(derivativex,'cw' , cw_x,  istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(derivativex,'prse',pri_x, istatus);ier=istatus+ier
+  if(ier/=0) then
+     write(6,*) myname,': x deriv. pointers not found on input, ier=', ier
+     call stop2(999)
+  endif
+  ier=0
+  call gsi_bundlegetpointer(derivativey,'u',   u_y,   istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(derivativey,'v',   v_y,   istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(derivativey,'tv',  t_y,   istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(derivativey,'q',   q_y,   istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(derivativey,'oz' , oz_y,  istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(derivativey,'cw' , cw_y,  istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(derivativey,'prse',pri_y, istatus);ier=istatus+ier
+  if(ier/=0) then
+     write(6,*) myname,': y deriv. pointers not found on input, ier=', ier
+     call stop2(999)
+  endif
+
+  call gsi_bundlegetpointer(fields_dt,'u',   u_t, istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(fields_dt,'v',   v_t, istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(fields_dt,'tv',  t_t, istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(fields_dt,'q',   q_t, istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(fields_dt,'oz' , oz_t,istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(fields_dt,'cw' , cw_t,istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(fields_dt,'prse', p_t,istatus);ier=istatus+ier
+  if(ier/=0) then
+     write(6,*) myname,': pointers not found on tendency, ier=', ier
+     call stop2(999)
+  endif
+
+  ier=0
+  call gsi_bundlegetpointer(gsi_metguess_bundle(it),'u' ,ges_u, istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_metguess_bundle(it),'v' ,ges_v, istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_metguess_bundle(it),'tv',ges_tv,istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_metguess_bundle(it),'q', ges_q ,istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_metguess_bundle(it),'oz',ges_oz,istatus);ier=istatus+ier
+  if(ier/=0) then
+     write(6,*) myname, ': pointers not found in met-guess, ier=', ier
+     call stop2(999)
+  endif
+
+  ier=0
+  call gsi_bundlegetpointer(gsi_xderivative_bundle(it),'u' ,ges_u_lon, istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_xderivative_bundle(it),'v' ,ges_v_lon, istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_xderivative_bundle(it),'tv',ges_tv_lon,istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_xderivative_bundle(it),'q', ges_q_lon ,istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_xderivative_bundle(it),'oz',ges_oz_lon,istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_xderivative_bundle(it),'cw',ges_cw_lon,istatus);ier=istatus+ier
+  if(ier/=0) then
+     write(6,*) myname, ': pointers not found in lon-derivatives, ier=', ier
+     call stop2(999)
+  endif
+
+  ier=0
+  call gsi_bundlegetpointer(gsi_yderivative_bundle(it),'u' ,ges_u_lat, istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_yderivative_bundle(it),'v' ,ges_v_lat, istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_yderivative_bundle(it),'tv',ges_tv_lat,istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_yderivative_bundle(it),'q', ges_q_lat ,istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_yderivative_bundle(it),'oz',ges_oz_lat,istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_yderivative_bundle(it),'cw',ges_cw_lat,istatus);ier=istatus+ier
+  if(ier/=0) then
+     write(6,*) myname, ': pointers not found in lat-derivatives, ier=', ier
+     call stop2(999)
+  endif
+
+! Get pointer to could water mixing ratio
+  call gsi_metguess_get('clouds::3d',n_actual_clouds,ier)
+  if (n_actual_clouds>0) then
+     call gsi_bundlegetpointer (gsi_metguess_bundle(it),'cw',ges_cwmr,istatus)
+     if (istatus/=0) then 
+        if (regional) then 
+           ges_cwmr => cwgues   ! temporily, revise after moist physics is ready
+        else
+           call die('setuppcp','cannot get pointer to cwmr, istatus =',istatus)
+        end if
+     end if
+  else
+     ges_cwmr => cwgues
+  end if
+
+!  loop over threads
+!$omp parallel do schedule(dynamic,1) private(i,j,k,kk,tmp,tmp2,ix,&
+!$omp                  tmp3,sumk,sumvk,sum2k,sum2vk,var)
+  do kk=1,nthreads
+
+!   zero arrays
+
+    do k=1,nsig+1
+      do j=jtstart(kk),jtstop(kk)
+        do i=1,lat2
+           what(i,j,k)=zero
+           prsth(i,j,k)=zero
+           pri(i,j,k)=zero
+        end do
+      end do
+    end do
+    do k=1,nsig
+      do j=jtstart(kk),jtstop(kk)
+        do i=1,lat2
+           prsum(i,j,k)=zero
+           prdif(i,j,k)=zero
+           pr_xsum(i,j,k)=zero
+           pr_xdif(i,j,k)=zero
+           pr_ysum(i,j,k)=zero
+           pr_ydif(i,j,k)=zero
+           u_x(i,j,k)=zero
+           u_y(i,j,k)=zero
+           v_x(i,j,k)=zero
+           v_y(i,j,k)=zero
+           t_x(i,j,k)=zero
+           t_y(i,j,k)=zero
+           q_x(i,j,k)=zero
+           q_y(i,j,k)=zero
+           cw_x(i,j,k)=zero
+           cw_y(i,j,k)=zero
+           oz_x(i,j,k)=zero
+           oz_y(i,j,k)=zero
+        end do
+      end do
+    end do
+    do j=jtstart(kk),jtstop(kk)
+      do i=1,lat2
+        sumkm1(i,j)=zero
+        sumvkm1(i,j)=zero
+        sum2km1(i,j)=zero
+        sum2vkm1(i,j)=zero
+        ps_x(i,j)=zero
+        ps_y(i,j)=zero
+      end do
+    end do
+
+    do k=nsig,1,-1
+      do j=jtstart(kk),jtstop(kk)
+        do i=1,lat2
+           if(k < nsig) then
+              tmp2=half*what9(i,j,k+1)*r_prdif9(i,j,k)
+              tmp = - q_t (i,j,k)*(ges_q   (i,j,k)-ges_q   (i,j,k+1)) - &
+                      oz_t(i,j,k)*(ges_oz  (i,j,k)-ges_oz  (i,j,k+1)) - &
+                      cw_t(i,j,k)*(ges_cwmr(i,j,k)-ges_cwmr (i,j,k+1))
+              q (i,j,k  ) = q (i,j,k  ) - q_t (i,j,k)*tmp2
+              q (i,j,k+1) = q (i,j,k+1) + q_t (i,j,k)*tmp2
+              oz(i,j,k  ) = oz(i,j,k  ) - oz_t(i,j,k)*tmp2
+              oz(i,j,k+1) = oz(i,j,k+1) + oz_t(i,j,k)*tmp2
+              cw(i,j,k  ) = cw(i,j,k  ) - cw_t(i,j,k)*tmp2
+              cw(i,j,k+1) = cw(i,j,k+1) + cw_t(i,j,k)*tmp2
+              prdif(i,j,k) = prdif(i,j,k)+(tmp2*r_prdif9(i,j,k))* &
+                  (((ges_q   (i,j,k)-ges_q   (i,j,k+1))*q_t (i,j,k)) + &
+                   ((ges_oz  (i,j,k)-ges_oz  (i,j,k+1))*oz_t(i,j,k)) + &
+                   ((ges_cwmr(i,j,k)-ges_cwmr(i,j,k+1))*cw_t(i,j,k)) )
+              what(i,j,k+1) = what(i,j,k+1)+(half*tmp*r_prdif9(i,j,k))
+           end if
+
+           if(k > 1)then
+              tmp2=half*what9(i,j,k)*r_prdif9(i,j,k)
+              tmp= - q_t (i,j,k)*(ges_q   (i,j,k-1)-ges_q   (i,j,k)) - &
+                     oz_t(i,j,k)*(ges_oz  (i,j,k-1)-ges_oz  (i,j,k)) - &
+                     cw_t(i,j,k)*(ges_cwmr(i,j,k-1)-ges_cwmr (i,j,k))
+              q (i,j,k-1) = q (i,j,k-1) - q_t (i,j,k)*tmp2
+              q (i,j,k  ) = q (i,j,k  ) + q_t (i,j,k)*tmp2
+              oz(i,j,k-1) = oz(i,j,k-1) - oz_t(i,j,k)*tmp2
+              oz(i,j,k  ) = oz(i,j,k  ) + oz_t(i,j,k)*tmp2
+              cw(i,j,k-1) = cw(i,j,k-1) - cw_t(i,j,k)*tmp2
+              cw(i,j,k  ) = cw(i,j,k  ) + cw_t(i,j,k)*tmp2
+
+              prdif(i,j,k) = prdif(i,j,k) + (tmp2*r_prdif9(i,j,k))* &
+                  (((ges_q   (i,j,k-1)-ges_q   (i,j,k))*q_t (i,j,k)) + &
+                   ((ges_oz  (i,j,k-1)-ges_oz  (i,j,k))*oz_t(i,j,k)) + &
+                   ((ges_cwmr(i,j,k-1)-ges_cwmr (i,j,k))*cw_t(i,j,k)) )
+              what(i,j,k) = what(i,j,k)+(half*tmp*r_prdif9(i,j,k))
+           end if
+
+!   adjoint of tracer advective terms
+
+           u(i,j,k) = u(i,j,k) - q_t(i,j,k)*ges_q_lon(i,j,k) -  &
+              oz_t(i,j,k)*ges_oz_lon(i,j,k) - cw_t(i,j,k)*ges_cw_lon(i,j,k)
+           v(i,j,k) = v(i,j,k) - q_t(i,j,k)*ges_q_lat(i,j,k) -  &
+              oz_t(i,j,k)*ges_oz_lat(i,j,k) - cw_t(i,j,k)*ges_cw_lat(i,j,k)
+           q_x (i,j,k) = q_x (i,j,k) - q_t (i,j,k)*ges_u(i,j,k)
+           q_y (i,j,k) = q_y (i,j,k) - q_t (i,j,k)*ges_v(i,j,k)
+           oz_x(i,j,k) = oz_x(i,j,k) - oz_t(i,j,k)*ges_u(i,j,k)
+           oz_y(i,j,k) = oz_y(i,j,k) - oz_t(i,j,k)*ges_v(i,j,k)
+           cw_x(i,j,k) = cw_x(i,j,k) - cw_t(i,j,k)*ges_u(i,j,k)
+           cw_y(i,j,k) = cw_y(i,j,k) - cw_t(i,j,k)*ges_v(i,j,k)
+        end do
+      end do
+    end do
+
+!   adjoint of sum 2d individual terms into 3d tendency arrays
+!   because of sum arrays/dependencies, have to go from nsig --> 1
+
+#ifdef USE_ALL_ORIGINAL
+    if(.not.wrf_nmm_regional.and..not.nems_nmmb_regional)then
+#endif /* USE_ALL_ORIGINAL */
+      do k=1,nsig
+        do j=jtstart(kk),jtstop(kk)
+           do i=1,lat2
+              ix=istart(mype+1)+i-2
+              if (ix == 1 .or. ix == nlat) then
+                 u_t(i,j,k)=zero ; v_t(i,j,k)=zero
+              end if
+           end do
+        end do
+      end do                         
+#ifdef USE_ALL_ORIGINAL
+    end if
+#endif /* USE_ALL_ORIGINAL */
+
+    call turbl_ad(ges_prsi(1,1,1,it),ges_tv,ges_teta(1,1,1,it),&
+                u,v,pri,t,u_t,v_t,t_t,jtstart(kk),jtstop(kk))
+
+    do k=nsig,1,-1               
+
+
+!   vertical summation terms for u,v
+
+      do j=jtstart(kk),jtstop(kk)
+        do i=1,lat2
+           sumk  =sumkm1  (i,j) - u_t   (i,j,k)
+           sumvk =sumvkm1 (i,j) - v_t   (i,j,k)
+           sum2k =sum2km1 (i,j) - rd*u_t(i,j,k) 
+           sum2vk=sum2vkm1(i,j) - rd*v_t(i,j,k)
+ 
+           sumkm1(i,j)   = -u_t   (i,j,k)
+           sumvkm1(i,j)  = -v_t   (i,j,k)
+           sum2km1(i,j)  = -rd*u_t(i,j,k)
+           sum2vkm1(i,j) = -rd*v_t(i,j,k)
+
+! arrays tmp2 and tmp3 are from basic state variables
+
+           tmp2=rd*ges_tv(i,j,k)*r_prsum9(i,j,k)
+           tmp3=prdif9(i,j,k)*r_prsum9(i,j,k)
+           t_y(i,j,k) = t_y(i,j,k) + sum2vk*tmp3
+           var=sum2vk*r_prsum9(i,j,k)
+           prdif(i,j,k) = prdif(i,j,k) + ges_tv_lat(i,j,k)*var
+           prsum(i,j,k) = prsum(i,j,k) - ges_tv_lat(i,j,k)*tmp3*var
+           sum2vkm1(i,j)=sum2vkm1(i,j)+sum2vk
+ 
+           t_x  (i,j,k) = t_x  (i,j,k) + sum2k*tmp3
+           var=sum2k*r_prsum9(i,j,k)
+           prdif(i,j,k) = prdif(i,j,k) + ges_tv_lon(i,j,k)*var
+           prsum(i,j,k) = prsum(i,j,k) - ges_tv_lon(i,j,k)*tmp3*var
+           sum2km1(i,j) = sum2km1(i,j) + sum2k    
+
+           pr_ydif(i,j,k) = pr_ydif(i,j,k) + tmp2*sumvk
+           pr_ysum(i,j,k) = pr_ysum(i,j,k) - tmp2*tmp3*sumvk
+           var=tmp2*sumvk*r_prsum9(i,j,k)
+           prsum  (i,j,k) = prsum  (i,j,k) + tmp3*var*pr_ysum9(i,j,k)
+           prdif  (i,j,k) = prdif  (i,j,k) - var*pr_ysum9(i,j,k)
+
+! tmp is a reused variable
+
+           tmp = sumvk*( pr_ydif9(i,j,k) - (pr_ysum9(i,j,k)*tmp3) )
+           prsum(i,j,k) = prsum(i,j,k) - var* &
+              ( pr_ydif9(i,j,k) - (pr_ysum9(i,j,k)*tmp3) )
+           sumvkm1(i,j) = sumvkm1(i,j)+ sumvk
+
+           pr_xdif(i,j,k) = pr_xdif(i,j,k) + tmp2*sumk
+           pr_xsum(i,j,k) = pr_xsum(i,j,k) - tmp2*tmp3*sumk
+           var=tmp2*sumk*r_prsum9(i,j,k)
+           prsum  (i,j,k) = prsum  (i,j,k) + tmp3*var*pr_xsum9(i,j,k)
+           prdif  (i,j,k) = prdif  (i,j,k) - var*pr_xsum9(i,j,k)
+           tmp = tmp + sumk*( pr_xdif9(i,j,k) - &
+              (pr_xsum9(i,j,k)*tmp3) )
+           prsum(i,j,k) = prsum(i,j,k) - var* &
+              ( pr_xdif9(i,j,k) - (pr_xsum9(i,j,k)*tmp3) )
+           sumkm1 (i,j) = sumkm1 (i,j) + sumk
+
+           t(i,j,k) = t(i,j,k) + rd*tmp*r_prsum9(i,j,k)
+        end do
+      end do
+
+! adjoint of vertical flux terms
+
+      do j=jtstart(kk),jtstop(kk)
+        do i=1,lat2
+           if(k < nsig) then
+              tmp2=half*what9(i,j,k+1)*r_prdif9(i,j,k)
+
+              tmp = -u_t(i,j,k)*(ges_u (i,j,k)-ges_u (i,j,k+1)) - &
+                     v_t(i,j,k)*(ges_v (i,j,k)-ges_v (i,j,k+1)) - &
+                     t_t(i,j,k)*(ges_tv(i,j,k)-ges_tv(i,j,k+1))    
+
+              t(i,j,k  ) = t(i,j,k  ) - t_t(i,j,k)*tmp2
+              t(i,j,k+1) = t(i,j,k+1) + t_t(i,j,k)*tmp2
+              u(i,j,k  ) = u(i,j,k  ) - u_t(i,j,k)*tmp2
+              u(i,j,k+1) = u(i,j,k+1) + u_t(i,j,k)*tmp2
+              v(i,j,k  ) = v(i,j,k  ) - v_t(i,j,k)*tmp2
+              v(i,j,k+1) = v(i,j,k+1) + v_t(i,j,k)*tmp2
+
+              prdif(i,j,k) = prdif(i,j,k) + (tmp2*r_prdif9(i,j,k))* &
+                ( ((ges_tv(i,j,k)-ges_tv(i,j,k+1))*t_t(i,j,k)) + &
+                  ((ges_u (i,j,k)-ges_u (i,j,k+1))*u_t(i,j,k)) + &
+                  ((ges_v (i,j,k)-ges_v (i,j,k+1))*v_t(i,j,k)) )
+
+              what(i,j,k+1) = what(i,j,k+1) + half*tmp*r_prdif9(i,j,k)
+           end if
+           if(k > 1) then
+              tmp2=half*what9(i,j,k)*r_prdif9(i,j,k)
+
+              tmp = - u_t(i,j,k)*(ges_u (i,j,k-1)-ges_u (i,j,k)) - &
+                      v_t(i,j,k)*(ges_v (i,j,k-1)-ges_v (i,j,k)) - &
+                      t_t(i,j,k)*(ges_tv(i,j,k-1)-ges_tv(i,j,k)) 
+ 
+              t(i,j,k-1) = t(i,j,k-1) - t_t(i,j,k)*tmp2
+              t(i,j,k  ) = t(i,j,k  ) + t_t(i,j,k)*tmp2
+              u(i,j,k-1) = u(i,j,k-1) - u_t(i,j,k)*tmp2
+              u(i,j,k  ) = u(i,j,k  ) + u_t(i,j,k)*tmp2
+              v(i,j,k-1) = v(i,j,k-1) - v_t(i,j,k)*tmp2
+              v(i,j,k  ) = v(i,j,k  ) + v_t(i,j,k)*tmp2
+ 
+              prdif(i,j,k) = prdif(i,j,k) + (tmp2*r_prdif9(i,j,k))* &
+                ( ((ges_tv(i,j,k-1)-ges_tv(i,j,k))*t_t(i,j,k)) + &
+                  ((ges_u (i,j,k-1)-ges_u (i,j,k))*u_t(i,j,k)) + &
+                  ((ges_v (i,j,k-1)-ges_v (i,j,k))*v_t(i,j,k)) )
+
+              what(i,j,k) = what(i,j,k) + half*tmp*r_prdif9(i,j,k)
+           end if
+
+!       Now finish up with adjoint of the rest of the terms
+!       tmp is now a basic state variable, whereas tmp2 is used in computation
+
+           tmp=rd*ges_tv(i,j,k)*r_prsum9(i,j,k)
+
+           pr_ysum(i,j,k) = pr_ysum(i,j,k) - tmp*v_t(i,j,k)
+           prsum  (i,j,k) = prsum  (i,j,k) + tmp*v_t(i,j,k)*pr_ysum9(i,j,k)* &
+              r_prsum9(i,j,k)
+
+           tmp2 = - v_t(i,j,k)*pr_ysum9(i,j,k)
+
+           pr_xsum(i,j,k) = pr_xsum(i,j,k) - tmp*u_t(i,j,k)
+           prsum  (i,j,k) = prsum  (i,j,k) + tmp*u_t(i,j,k)*pr_xsum9(i,j,k)* &
+              r_prsum9(i,j,k)
+
+           tmp2 = tmp2 - u_t(i,j,k)*pr_xsum9(i,j,k)
+
+           t(i,j,k) = t(i,j,k) + rd*tmp2*r_prsum9(i,j,k)
+
+
+
+           u(i,j,k) = u(i,j,k) - v_t(i,j,k)*(ges_v_lon(i,j,k) - two*curvy(i,j)* &
+               ges_u(i,j,k) + coriolis(i,j))
+           v_x(i,j,k) = v_x(i,j,k) - v_t(i,j,k)*ges_u(i,j,k)
+           v(i,j,k) = v(i,j,k) - v_t(i,j,k)*(ges_v_lat(i,j,k) - two*curvy(i,j)* &
+               ges_v(i,j,k))
+           v_y(i,j,k) = v_y(i,j,k) - v_t(i,j,k)*ges_v(i,j,k)
+
+           u(i,j,k) = u(i,j,k) - u_t(i,j,k)*(ges_u_lon(i,j,k) - two*curvx(i,j)* &
+               ges_u(i,j,k))
+           u_x(i,j,k) = u_x(i,j,k) - u_t(i,j,k)*ges_u(i,j,k)
+           v(i,j,k) = v(i,j,k) - u_t(i,j,k)*(ges_u_lat(i,j,k) - two*curvx(i,j)* &
+               ges_v(i,j,k) - coriolis(i,j))
+           u_y(i,j,k) = u_y(i,j,k) - u_t(i,j,k)*ges_v(i,j,k)
+
+        end do  !end do i
+      end do    !end do j
+    end do      !end do k
+
+!   adjoint of calculating full three-dimensional dp/dt
+
+    do k=1,nsig+1
+      do j=jtstart(kk),jtstop(kk)
+        do i=1,lat2
+           prsth(i,j,k)=prsth(i,j,k) + p_t(i,j,k)
+           what (i,j,k)=what (i,j,k) - p_t(i,j,k)
+        end do
+      end do
+    end do
+
+!   adjoint of calculation of vertical velocity
+    if ( (.not.regional) .AND. (idvc5==3)) then
+
+!     Basic state horizontal temperature tendency
+
+!     Get horizontal part of temperature tendency for vertical velocity term
+
+      do k=1,nsig
+        do j=jtstart(kk),jtstop(kk)
+           do i=1,lat2
+              tmp=-rd*ges_tv(i,j,k)*r_prsum9(i,j,k)
+              t_thor9(i,j,k)=-ges_u(i,j,k)*ges_tv_lon(i,j,k) - &
+                   ges_v(i,j,k)*ges_tv_lat(i,j,k)
+              t_thor9(i,j,k)=t_thor9(i,j,k) -tmp*rcp * ( ges_u(i,j,k)*pr_xsum9(i,j,k) + &
+                   ges_v(i,j,k)*pr_ysum9 (i,j,k) + &
+                   prsth9(i,j,k) + prsth9(i,j,k+1) )
+           end do
+        end do
+      end do
+      call getvvel_ad(t,t_t,t_thor9,prsth,prdif,what,jtstart(kk),jtstop(kk))
+    else
+#ifdef USE_ALL_ORIGINAL
+      if (wrf_nmm_regional.or.nems_nmmb_regional) then
+        do k=2,nsig
+           do j=jtstart(kk),jtstop(kk)
+              do i=1,lat2
+                 prsth(i,j,1) = prsth(i,j,1) - eta2_ll (k)*what(i,j,k)
+                 prsth(i,j,k) = prsth(i,j,k) + what(i,j,k)
+              end do
+           end do
+        end do 
+      else
+#endif /* USE_ALL_ORIGINAL */
+        do k=2,nsig
+           do j=jtstart(kk),jtstop(kk)
+              do i=1,lat2
+                 prsth(i,j,1) = prsth(i,j,1) - bk5     (k)*what(i,j,k)
+                 prsth(i,j,k) = prsth(i,j,k) + what(i,j,k)
+              end do
+           end do
+        end do 
+#ifdef USE_ALL_ORIGINAL
+      end if
+#endif /* USE_ALL_ORIGINAL */
+    end if
+
+!   Horizontal Part of temperature tendency, now that adjoint of
+!   vertical velocity is done
+
+    do k=1,nsig
+      do j=jtstart(kk),jtstop(kk)
+        do i=1,lat2
+           tmp=rd*ges_tv(i,j,k)*r_prsum9(i,j,k)
+
+           tmp2 = t_t(i,j,k)*rcp*( ges_u(i,j,k)* &
+             pr_xsum9(i,j,k) + &
+             ges_v(i,j,k)*pr_ysum9   (i,j,k) + &
+             prsth9  (i,j,k)+prsth9(i,j,k+1) )
+           prsum(i,j,k) = prsum(i,j,k) - tmp2*tmp*r_prsum9(i,j,k)
+
+           var=t_t(i,j,k)*tmp*rcp
+           pr_xsum(i,j,k) = pr_xsum(i,j,k) + var*ges_u(i,j,k)
+           pr_ysum(i,j,k) = pr_ysum(i,j,k) + var*ges_v(i,j,k)
+           u(i,j,k) = u(i,j,k) + var*pr_xsum9(i,j,k)
+           v(i,j,k) = v(i,j,k) + var*pr_ysum9(i,j,k)
+           prsth(i,j,k)      = prsth(i,j,k)      + var
+           prsth(i,j,k+1) = prsth(i,j,k+1) + var
+        
+           t(i,j,k) = t(i,j,k) + rd*tmp2*r_prsum9(i,j,k)
+ 
+           u  (i,j,k) = u  (i,j,k) - t_t(i,j,k)*ges_tv_lon(i,j,k)
+           t_x(i,j,k) = t_x(i,j,k) - t_t(i,j,k)*ges_u (i,j,k)
+           v  (i,j,k) = v  (i,j,k) - t_t(i,j,k)*ges_tv_lat(i,j,k)
+           t_y(i,j,k) = t_y(i,j,k) - t_t(i,j,k)*ges_v (i,j,k)
+        end do
+      end do
+    end do
+
+!   adjoint of horizontal portion of pressure tendency
+
+    do k=1,nsig
+      do j=jtstart(kk),jtstop(kk)
+        do i=1,lat2
+           u      (i,j,k) = u      (i,j,k) - prsth(i,j,k)*pr_xdif9  (i,j,k)
+           pr_xdif(i,j,k) = pr_xdif(i,j,k) - prsth(i,j,k)*ges_u  (i,j,k)
+           v      (i,j,k) = v      (i,j,k) - prsth(i,j,k)*pr_ydif9  (i,j,k)
+           pr_ydif(i,j,k) = pr_ydif(i,j,k) - prsth(i,j,k)*ges_v  (i,j,k)
+           u_x    (i,j,k) = u_x    (i,j,k) - prsth(i,j,k)*(prdif9  (i,j,k))
+           v_y    (i,j,k) = v_y    (i,j,k) - prsth(i,j,k)*(prdif9  (i,j,k))
+           prdif  (i,j,k) = prdif  (i,j,k) - prsth(i,j,k)*(ges_u_lon(i,j,k) + &
+                         ges_v_lat(i,j,k))
+           prsth(i,j,k+1) = prsth(i,j,k+1) + prsth(i,j,k)
+        end do
+      end do
+    end do
+
+!   adjoint of pressure preliminaries
+
+    do k=1,nsig+1
+      do j=jtstart(kk),jtstop(kk)
+        do i=1,lat2
+           pri_x(i,j,k)=zero
+           pri_y(i,j,k)=zero
+        end do
+      end do
+    end do
+    do k=1,nsig
+      do j=jtstart(kk),jtstop(kk)
+        do i=1,lat2
+           pri  (i,j,k  )=pri  (i,j,k  ) + (prsum  (i,j,k)+prdif  (i,j,k))
+           pri  (i,j,k+1)=pri  (i,j,k+1) + (prsum  (i,j,k)-prdif  (i,j,k))
+           pri_x(i,j,k  )=pri_x(i,j,k  ) + (pr_xsum(i,j,k)+pr_xdif(i,j,k))
+           pri_x(i,j,k+1)=pri_x(i,j,k+1) + (pr_xsum(i,j,k)-pr_xdif(i,j,k))
+           pri_y(i,j,k  )=pri_y(i,j,k  ) + (pr_ysum(i,j,k)+pr_ydif(i,j,k))
+           pri_y(i,j,k+1)=pri_y(i,j,k+1) + (pr_ysum(i,j,k)-pr_ydif(i,j,k))
+        end do
+      end do
+    end do
+
+  end do
+
+! end of loop over threads
+
+  call getprs_horiz_ad(ps_x,ps_y,pri,pri_x,pri_y)
+
+! add contributions from derivatives
+
+  call tget_derivatives( &
+         fields,derivativex,derivativey)
+
+  return
+end subroutine calctends_ad

--- a/src/gsibec/gsi/calctends_no_ad.F90
+++ b/src/gsibec/gsi/calctends_no_ad.F90
@@ -1,0 +1,494 @@
+subroutine calctends_no_ad(st,vp,t,p,mype,u_t,v_t,t_t,p_t,uvflag)
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    calctends_ad         adjoint of calctends_tl
+!   prgmmr: kleist           org: np20                date: 2005-09-29
+!
+! abstract: adjoint of routine that compute tendencies for u,v,Tv,prs
+!
+! program history log:
+!   2005-09-29  kleist
+!   2005-10-17  kleist - changes to improve computational efficiency
+!   2005-11-21  kleist - add tracer tendencies, use new module
+!   2006-01-31  kleist - add indices to sum* variables being initialized in loop
+!   2006-04-12  treadon - replace sigi with bk5
+!   2006-04-21  kleist - add divergence tendency bits
+!   2006-07-31  kleist - changes to use ps instead of ln(ps)
+!   2006-09-21  kleist - add rescaling to divergence tendency formulation
+!   2007-03-13  kleist - move jcrescale_ad (and related code) into if (divtflg) block
+!   2007-04-16  kleist - move constraint specific items elsewhere
+!   2007-05-08  kleist - add bits for fully generalized vertical coordinate
+!   2007-06-21  rancic - add pbl 
+!   2007-07-26  cucurull - add 3d pressure pri in argument list;
+!                          move getprs_ad outside calctends_ad;
+!                          call getprs_horiz_ad; remove ps from argument
+!                          list
+!   2007-08-08  derber - optimize
+!   2008-06-05  safford - rm unused var "nnn" and unused uses
+!   2009-04-21  derber - remove call to getstvp and modify get_derivatives to include uv
+!   2009-08-20  parrish - replace curvfct with curvx, curvy.  this allows tendency computation to
+!                          work for any general orthogonal coordinate.
+!   2010-11-03  derber - moved threading calculations to gridmod and modified
+!   2012-02-08  kleist - add uvflag to argument list.
+!   2013-01-23  parrish - change t_t from intent(in) to intent(inout) (flagged by WCOSS intel debug compile)
+!   2013-10-19  todling - derivatives and guess fields now in bundles
+!
+! usage:
+!   input argument list:
+!     u        - zonal wind on subdomain
+!     v        - meridional wind on subdomain
+!     t        - virtual temperature on subdomain
+!     u_t      - time tendency of u
+!     v_t      - time tendency of v
+!     t_t      - time tendency of t
+!     p_t      - time tendency of 2d surface pressure
+!     mype     - mpi integer task id
+!
+!   output argument list:
+!     u        - zonal wind on subdomain
+!     v        - meridional wind on subdomain
+!     t        - virtual temperature on subdomain
+!     q        - q on subdomain
+!     oz       - ozone on subdomain
+!     cw       - cloud water mixing ratio on subdomain
+!
+!   notes:
+!     adjoint check performed succesfully on 2005-09-29 by d. kleist
+!
+! attributes:
+!   language: f90
+!   machine:  ibm RS/6000 SP
+!
+!$$$
+  use m_kinds,only: r_kind,i_kind
+  use gridmod, only: lat2,lon2,nsig,istart,nlat,idvc5,bk5,&
+      eta2_ll, nthreads,jtstart,jtstop,regional
+#ifdef USE_ALL_ORIGINAL
+  use gridmod, only: wrf_nmm_regional,nems_nmmb_regional
+#endif /* USE_ALL_ORIGINAL */
+  use constants, only: zero,half,two,rd,rcp
+  use tendsmod, only: what9,prsth9,r_prsum9,prdif9,r_prdif9,pr_xsum9,pr_xdif9,&
+      pr_ysum9,pr_ydif9,curvx,curvy,coriolis
+  use guess_grids, only: ntguessig,&
+      ges_teta,ges_prsi
+  use gsi_metguess_mod, only: gsi_metguess_bundle
+  use gsi_bundlemod, only: gsi_bundlegetpointer
+  use derivsmod, only: gsi_xderivative_bundle
+  use derivsmod, only: gsi_yderivative_bundle
+  implicit none
+
+! Declare passed variables
+  real(r_kind),dimension(lat2,lon2,nsig),intent(inout) :: u_t,v_t
+  real(r_kind),dimension(lat2,lon2,nsig),intent(inout) :: t_t
+  real(r_kind),dimension(lat2,lon2)     ,intent(in   ) :: p_t
+  real(r_kind),dimension(lat2,lon2,nsig),intent(inout) :: st,vp,t
+  real(r_kind),dimension(lat2,lon2)     ,intent(inout) :: p
+  integer(i_kind)                       ,intent(in   ) :: mype
+  logical                               ,intent(in   ) :: uvflag
+
+! Declare local variables
+  character(len=*),parameter::myname='calctends_no_ad'
+  real(r_kind),dimension(lat2,lon2,nsig):: u,v
+  real(r_kind),dimension(lat2,lon2,nsig+1):: pri
+  real(r_kind),dimension(lat2,lon2,nsig):: u_x,u_y,v_x,v_y,t_x,t_y
+  real(r_kind),dimension(lat2,lon2,nsig+1):: pri_x,pri_y,prsth,what
+  real(r_kind),dimension(lat2,lon2,nsig):: prsum,prdif,pr_xsum,pr_xdif,pr_ysum,&
+       pr_ydif
+
+  real(r_kind),dimension(lat2,lon2,nsig):: t_thor9
+  real(r_kind),dimension(lat2,lon2):: sumkm1,sumvkm1,sum2km1,sum2vkm1
+  real(r_kind) tmp,tmp2,tmp3,var,sumk,sumvk,sum2k,sum2vk
+  integer(i_kind) i,j,k,ix,it,kk,ier,istatus
+
+  real(r_kind),pointer,dimension(:,:,:) :: ges_u=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_v=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_tv=>NULL()
+
+  real(r_kind),pointer,dimension(:,:,:) :: ges_u_lon=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_v_lon=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_tv_lon=>NULL()
+
+  real(r_kind),pointer,dimension(:,:,:) :: ges_u_lat=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_v_lat=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_tv_lat=>NULL()
+
+  it=ntguessig
+
+  ier=0
+  call gsi_bundlegetpointer(gsi_metguess_bundle(it),'u' ,ges_u, istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_metguess_bundle(it),'v' ,ges_v, istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_metguess_bundle(it),'tv',ges_tv,istatus);ier=istatus+ier
+  if(ier/=0) then
+     write(6,*) myname, ': pointers not found in met-guess, ier=', ier
+     call stop2(999)
+  endif
+
+  ier=0
+  call gsi_bundlegetpointer(gsi_xderivative_bundle(it),'u' ,ges_u_lon, istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_xderivative_bundle(it),'v' ,ges_v_lon, istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_xderivative_bundle(it),'tv',ges_tv_lon,istatus);ier=istatus+ier
+  if(ier/=0) then
+     write(6,*) myname, ': pointers not found in lon-derivatives, ier=', ier
+     call stop2(999)
+  endif
+
+  ier=0
+  call gsi_bundlegetpointer(gsi_yderivative_bundle(it),'u' ,ges_u_lat, istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_yderivative_bundle(it),'v' ,ges_v_lat, istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_yderivative_bundle(it),'tv',ges_tv_lat,istatus);ier=istatus+ier
+  if(ier/=0) then
+     write(6,*) myname, ': pointers not found in lat-derivatives, ier=', ier
+     call stop2(999)
+  endif
+
+!$omp parallel do private(i,j,k,kk,tmp,tmp2,ix,&
+!$omp                  tmp3,sumk,sumvk,sum2k,sum2vk,var)
+
+  do kk=1,nthreads
+
+!   zero arrays
+    do k=1,nsig+1
+      do j=jtstart(kk),jtstop(kk)
+        do i=1,lat2
+           pri(i,j,k)=zero
+           pri_x(i,j,k)=zero
+           pri_y(i,j,k)=zero
+        end do
+      end do
+    end do
+
+!   Put p_t in prsth and what for adjoint of calculating 
+!   full three-dimensional dp/dt
+
+    do j=jtstart(kk),jtstop(kk)
+      do i=1,lat2
+        prsth(i,j,1)=   p_t(i,j)
+        what (i,j,1)= - p_t(i,j)
+      end do
+    end do
+    do k=1,nsig
+      do j=jtstart(kk),jtstop(kk)
+        do i=1,lat2
+           u(i,j,k)=zero
+           v(i,j,k)=zero
+           u_x(i,j,k)=zero
+           u_y(i,j,k)=zero
+           v_x(i,j,k)=zero
+           v_y(i,j,k)=zero
+           t_x(i,j,k)=zero
+           t_y(i,j,k)=zero
+           prsum(i,j,k)=zero
+           prdif(i,j,k)=zero
+           pr_xsum(i,j,k)=zero
+           pr_xdif(i,j,k)=zero
+           pr_ysum(i,j,k)=zero
+           pr_ydif(i,j,k)=zero
+           what(i,j,k+1)=zero
+           prsth(i,j,k+1)=zero
+        end do
+      end do
+    end do
+    do j=jtstart(kk),jtstop(kk)
+      do i=1,lat2
+        sumkm1(i,j)=zero
+        sumvkm1(i,j)=zero
+        sum2km1(i,j)=zero
+        sum2vkm1(i,j)=zero
+      end do
+    end do
+
+!   adjoint of sum 2d individual terms into 3d tendency arrays
+!   because of sum arrays/dependencies, have to go from nsig --> 1
+
+#ifdef USE_ALL_ORIGINAL
+    if(.not.wrf_nmm_regional.and..not.nems_nmmb_regional)then
+#endif /* USE_ALL_ORIGINAL */
+      do k=1,nsig
+        do j=jtstart(kk),jtstop(kk)
+           do i=1,lat2
+              ix=istart(mype+1)+i-2
+              if (ix == 1 .or. ix == nlat) then
+                 u_t(i,j,k)=zero ; v_t(i,j,k)=zero
+              end if
+           end do
+        end do
+      end do                         
+#ifdef USE_ALL_ORIGINAL
+    end if
+#endif /* USE_ALL_ORIGINAL */
+
+    call turbl_ad(ges_prsi(1,1,1,it),ges_tv,ges_teta(1,1,1,it),&
+                u,v,pri,t,u_t,v_t,t_t,jtstart(kk),jtstop(kk))
+
+    do k=nsig,1,-1               
+
+
+!     vertical summation terms for u,v
+
+      do j=jtstart(kk),jtstop(kk)
+        do i=1,lat2
+           sumk  =sumkm1  (i,j) - u_t   (i,j,k)
+           sumvk =sumvkm1 (i,j) - v_t   (i,j,k)
+           sum2k =sum2km1 (i,j) - rd*u_t(i,j,k) 
+           sum2vk=sum2vkm1(i,j) - rd*v_t(i,j,k)
+ 
+           sumkm1(i,j)   = -u_t   (i,j,k)
+           sumvkm1(i,j)  = -v_t   (i,j,k)
+           sum2km1(i,j)  = -rd*u_t(i,j,k)
+           sum2vkm1(i,j) = -rd*v_t(i,j,k)
+
+! arrays tmp2 and tmp3 are from basic state variables
+
+           tmp2=rd*ges_tv(i,j,k)*r_prsum9(i,j,k)
+           tmp3=prdif9(i,j,k)*r_prsum9(i,j,k)
+           t_y   (i,j,k)= t_y  (i,j,k) + sum2vk*tmp3
+           var=sum2vk*r_prsum9(i,j,k)
+           prdif (i,j,k)= prdif(i,j,k) + ges_tv_lat(i,j,k)*var
+           prsum (i,j,k)= prsum(i,j,k) - ges_tv_lat(i,j,k)*tmp3*var
+           sum2vkm1(i,j)=sum2vkm1(i,j) + sum2vk
+ 
+           t_x  (i,j,k) = t_x  (i,j,k) + sum2k*tmp3
+           var=sum2k*r_prsum9(i,j,k)
+           prdif(i,j,k) = prdif(i,j,k) + ges_tv_lon(i,j,k)*var
+           prsum(i,j,k) = prsum(i,j,k) - ges_tv_lon(i,j,k)*tmp3*var
+           sum2km1(i,j) = sum2km1(i,j) + sum2k    
+ 
+           pr_ydif(i,j,k) = pr_ydif(i,j,k) + tmp2*sumvk
+           pr_ysum(i,j,k) = pr_ysum(i,j,k) - tmp2*tmp3*sumvk
+           var=tmp2*sumvk*r_prsum9(i,j,k)
+           prsum  (i,j,k) = prsum  (i,j,k) + tmp3*var*pr_ysum9(i,j,k)
+           prdif  (i,j,k) = prdif  (i,j,k) - var*pr_ysum9(i,j,k)
+
+! tmp is a reused variable
+
+           tmp = sumvk*( pr_ydif9(i,j,k) - (pr_ysum9(i,j,k)*tmp3) )
+           prsum(i,j,k) = prsum(i,j,k) - var* &
+              ( pr_ydif9(i,j,k) - (pr_ysum9(i,j,k)*tmp3) )
+           sumvkm1(i,j)= sumvkm1(i,j)+ sumvk
+
+           pr_xdif(i,j,k) = pr_xdif(i,j,k) + tmp2*sumk
+           pr_xsum(i,j,k) = pr_xsum(i,j,k) - tmp2*tmp3*sumk
+           var=tmp2*sumk*r_prsum9(i,j,k)
+           prsum  (i,j,k) = prsum  (i,j,k) + tmp3*var*pr_xsum9(i,j,k)
+           prdif  (i,j,k) = prdif  (i,j,k) - var*pr_xsum9(i,j,k)
+           tmp = tmp + sumk*( pr_xdif9(i,j,k) - &
+              (pr_xsum9(i,j,k)*tmp3) )
+           prsum  (i,j,k) = prsum(i,j,k) - var* &
+              ( pr_xdif9(i,j,k) - (pr_xsum9(i,j,k)*tmp3) )
+           sumkm1   (i,j) = sumkm1 (i,j) + sumk
+
+           t(i,j,k) = t(i,j,k) + rd*tmp*r_prsum9(i,j,k)
+        end do
+      end do
+
+!     adjoint of vertical flux terms
+
+      do j=jtstart(kk),jtstop(kk)
+        do i=1,lat2
+           if(k < nsig) then
+              tmp2=half*what9(i,j,k+1)*r_prdif9(i,j,k)
+
+              tmp = -u_t(i,j,k)*(ges_u (i,j,k)-ges_u (i,j,k+1)) - &
+                     v_t(i,j,k)*(ges_v (i,j,k)-ges_v (i,j,k+1)) - &
+                     t_t(i,j,k)*(ges_tv(i,j,k)-ges_tv(i,j,k+1))    
+
+              t(i,j,k  ) = t(i,j,k  ) - t_t(i,j,k)*tmp2
+              t(i,j,k+1) = t(i,j,k+1) + t_t(i,j,k)*tmp2
+              u(i,j,k  ) = u(i,j,k  ) - u_t(i,j,k)*tmp2
+              u(i,j,k+1) = u(i,j,k+1) + u_t(i,j,k)*tmp2
+              v(i,j,k  ) = v(i,j,k  ) - v_t(i,j,k)*tmp2
+              v(i,j,k+1) = v(i,j,k+1) + v_t(i,j,k)*tmp2
+ 
+              prdif(i,j,k) = prdif(i,j,k) + (tmp2*r_prdif9(i,j,k))* &
+                ( ((ges_tv(i,j,k)-ges_tv(i,j,k+1))*t_t(i,j,k)) + &
+                  ((ges_u (i,j,k)-ges_u (i,j,k+1))*u_t(i,j,k)) + &
+                  ((ges_v (i,j,k)-ges_v (i,j,k+1))*v_t(i,j,k)) )
+
+              what(i,j,k+1) = what(i,j,k+1) + half*tmp*r_prdif9(i,j,k)
+           end if
+           if(k > 1) then
+              tmp2=half*what9(i,j,k)*r_prdif9(i,j,k)
+
+              tmp = - u_t(i,j,k)*(ges_u (i,j,k-1)-ges_u (i,j,k)) - &
+                      v_t(i,j,k)*(ges_v (i,j,k-1)-ges_v (i,j,k)) - &
+                      t_t(i,j,k)*(ges_tv(i,j,k-1)-ges_tv(i,j,k)) 
+ 
+              t(i,j,k-1) = t(i,j,k-1) - t_t(i,j,k)*tmp2
+              t(i,j,k  ) = t(i,j,k  ) + t_t(i,j,k)*tmp2
+              u(i,j,k-1) = u(i,j,k-1) - u_t(i,j,k)*tmp2
+              u(i,j,k  ) = u(i,j,k  ) + u_t(i,j,k)*tmp2
+              v(i,j,k-1) = v(i,j,k-1) - v_t(i,j,k)*tmp2
+              v(i,j,k  ) = v(i,j,k  ) + v_t(i,j,k)*tmp2
+ 
+              prdif(i,j,k) = prdif(i,j,k) + (tmp2*r_prdif9(i,j,k))* &
+                ( ((ges_tv(i,j,k-1)-ges_tv(i,j,k))*t_t(i,j,k)) + &
+                  ((ges_u (i,j,k-1)-ges_u (i,j,k))*u_t(i,j,k)) + &
+                  ((ges_v (i,j,k-1)-ges_v (i,j,k))*v_t(i,j,k)) )
+
+              what(i,j,k) = what(i,j,k) + half*tmp*r_prdif9(i,j,k)
+           end if
+
+!       Now finish up with adjoint of the rest of the terms
+!       tmp is now a basic state variable, whereas tmp2 is used in computation
+
+           tmp=rd*ges_tv(i,j,k)*r_prsum9(i,j,k)
+
+           pr_ysum(i,j,k) = pr_ysum(i,j,k) - tmp*v_t(i,j,k)
+           prsum  (i,j,k) = prsum  (i,j,k) + tmp*v_t(i,j,k)*pr_ysum9(i,j,k)* &
+              r_prsum9(i,j,k)
+
+           tmp2 = - v_t(i,j,k)*pr_ysum9(i,j,k)
+ 
+           pr_xsum(i,j,k) = pr_xsum(i,j,k) - tmp*u_t(i,j,k)
+           prsum  (i,j,k) = prsum  (i,j,k) + tmp*u_t(i,j,k)*pr_xsum9(i,j,k)* &
+              r_prsum9(i,j,k)
+           tmp2 = tmp2 - u_t(i,j,k)*pr_xsum9(i,j,k)
+ 
+           t(i,j,k) = t(i,j,k) + rd*tmp2*r_prsum9(i,j,k)
+
+           u  (i,j,k) = u  (i,j,k) - v_t(i,j,k)*(ges_v_lon(i,j,k) - two*curvy(i,j)* &
+               ges_u(i,j,k) + coriolis(i,j))
+           v_x(i,j,k) = v_x(i,j,k) - v_t(i,j,k)*ges_u(i,j,k)
+           v  (i,j,k) = v  (i,j,k) - v_t(i,j,k)*(ges_v_lat(i,j,k) - two*curvy(i,j)* &
+               ges_v(i,j,k))
+           v_y(i,j,k) = v_y(i,j,k) - v_t(i,j,k)*ges_v(i,j,k)
+ 
+           u  (i,j,k) = u  (i,j,k) - u_t(i,j,k)*(ges_u_lon(i,j,k) - two*curvx(i,j)* &
+               ges_u(i,j,k))
+           u_x(i,j,k) = u_x(i,j,k) - u_t(i,j,k)*ges_u(i,j,k)
+           v  (i,j,k) = v  (i,j,k) - u_t(i,j,k)*(ges_u_lat(i,j,k) - two*curvx(i,j)* &
+               ges_v(i,j,k) - coriolis(i,j))
+           u_y(i,j,k) = u_y(i,j,k) - u_t(i,j,k)*ges_v(i,j,k)
+
+        end do  !end do i
+      end do    !end do j
+    end do      !end do k
+
+
+!   adjoint of calculation of vertical velocity
+
+    if ( (.not.regional) .AND. (idvc5==3)) then
+
+!     Basic state horizontal temperature tendency
+
+!     Get horizontal part of temperature tendency for vertical velocity term
+
+      do k=1,nsig
+        do j=jtstart(kk),jtstop(kk)
+           do i=1,lat2
+              tmp=-rd*ges_tv(i,j,k)*r_prsum9(i,j,k)
+              t_thor9(i,j,k)=-ges_u(i,j,k)*ges_tv_lon(i,j,k) - &
+                   ges_v(i,j,k)*ges_tv_lat(i,j,k)
+              t_thor9(i,j,k)=t_thor9(i,j,k) -tmp*rcp * ( ges_u(i,j,k)*pr_xsum9(i,j,k) + &
+                 ges_v(i,j,k)*pr_ysum9(i,j,k) + &
+                 prsth9(i,j,k) + prsth9(i,j,k+1) )
+           end do
+        end do
+      end do
+      call getvvel_ad(t,t_t,t_thor9,prsth,prdif,what,jtstart(kk),jtstop(kk))
+    else
+#ifdef USE_ALL_ORIGINAL
+      if (wrf_nmm_regional.or.nems_nmmb_regional) then
+        do k=2,nsig
+           do j=jtstart(kk),jtstop(kk)
+              do i=1,lat2
+                 prsth(i,j,1) = prsth(i,j,1) - eta2_ll (k)*what(i,j,k)
+                 prsth(i,j,k) = prsth(i,j,k) + what(i,j,k)
+              end do
+           end do
+        end do 
+      else
+#endif /* USE_ALL_ORIGINAL */
+        do k=2,nsig
+           do j=jtstart(kk),jtstop(kk)
+              do i=1,lat2
+                 prsth(i,j,1) = prsth(i,j,1) - bk5     (k)*what(i,j,k)
+                 prsth(i,j,k) = prsth(i,j,k) + what(i,j,k)
+              end do
+           end do
+        end do 
+#ifdef USE_ALL_ORIGINAL
+      end if
+#endif /* USE_ALL_ORIGINAL */
+    end if
+
+!   Horizontal Part of temperature tendency, now that adjoint of
+!   vertical velocity is done
+
+    do k=1,nsig
+      do j=jtstart(kk),jtstop(kk)
+        do i=1,lat2
+           tmp=rd*ges_tv(i,j,k)*r_prsum9(i,j,k)
+ 
+           tmp2 = t_t(i,j,k)*rcp*( ges_u(i,j,k)* &
+              pr_xsum9(i,j,k) + &
+              ges_v(i,j,k)*pr_ysum9(i,j,k) + &
+              prsth9(i,j,k)+prsth9(i,j,k+1) )
+           prsum(i,j,k) = prsum(i,j,k) - tmp2*tmp*r_prsum9(i,j,k)
+
+           var=t_t(i,j,k)*tmp*rcp
+           pr_xsum(i,j,k) = pr_xsum(i,j,k) + var*ges_u(i,j,k)
+           pr_ysum(i,j,k) = pr_ysum(i,j,k) + var*ges_v(i,j,k)
+           u      (i,j,k) = u      (i,j,k) + var*pr_xsum9(i,j,k)
+           v      (i,j,k) = v      (i,j,k) + var*pr_ysum9(i,j,k)
+           prsth  (i,j,k) = prsth  (i,j,k) + var
+           prsth(i,j,k+1) = prsth(i,j,k+1) + var
+
+           t(i,j,k) = t(i,j,k) + rd*tmp2*r_prsum9(i,j,k)
+ 
+           u  (i,j,k) = u  (i,j,k) - t_t(i,j,k)*ges_tv_lon(i,j,k)
+           t_x(i,j,k) = t_x(i,j,k) - t_t(i,j,k)*ges_u (i,j,k)
+           v  (i,j,k) = v  (i,j,k) - t_t(i,j,k)*ges_tv_lat(i,j,k)
+           t_y(i,j,k) = t_y(i,j,k) - t_t(i,j,k)*ges_v (i,j,k)
+        end do
+      end do
+    end do
+
+!   adjoint of horizontal portion of pressure tendency
+
+    do k=1,nsig
+      do j=jtstart(kk),jtstop(kk)
+        do i=1,lat2
+           u      (i,j,k) = u      (i,j,k) - prsth(i,j,k)*pr_xdif9(i,j,k)
+           pr_xdif(i,j,k) = pr_xdif(i,j,k) - prsth(i,j,k)*ges_u(i,j,k)
+           v      (i,j,k) = v      (i,j,k) - prsth(i,j,k)*pr_ydif9(i,j,k)
+           pr_ydif(i,j,k) = pr_ydif(i,j,k) - prsth(i,j,k)*ges_v(i,j,k)
+           u_x    (i,j,k) = u_x    (i,j,k) - prsth(i,j,k)*(prdif9(i,j,k))
+           v_y    (i,j,k) = v_y    (i,j,k) - prsth(i,j,k)*(prdif9(i,j,k))
+           prdif  (i,j,k) = prdif  (i,j,k) - prsth(i,j,k)*(ges_u_lon(i,j,k) + &
+              ges_v_lat(i,j,k))
+           prsth(i,j,k+1) = prsth(i,j,k+1) + prsth(i,j,k)
+        end do
+      end do
+    end do
+
+    do k=1,nsig
+      do j=jtstart(kk),jtstop(kk)
+        do i=1,lat2
+           pri  (i,j,k  )=pri  (i,j,k  ) + (prsum  (i,j,k)+prdif  (i,j,k))
+           pri  (i,j,k+1)=pri  (i,j,k+1) + (prsum  (i,j,k)-prdif  (i,j,k))
+           pri_x(i,j,k  )=pri_x(i,j,k  ) + (pr_xsum(i,j,k)+pr_xdif(i,j,k))
+           pri_x(i,j,k+1)=pri_x(i,j,k+1) + (pr_xsum(i,j,k)-pr_xdif(i,j,k))
+           pri_y(i,j,k  )=pri_y(i,j,k  ) + (pr_ysum(i,j,k)+pr_ydif(i,j,k))
+           pri_y(i,j,k+1)=pri_y(i,j,k+1) + (pr_ysum(i,j,k)-pr_ydif(i,j,k))
+        end do
+      end do
+    end do
+
+  end do
+
+!  end of threading loop
+
+  if(uvflag)then
+     call tget_derivatives2uv(st,vp,t,pri,u,v,u_x,v_x,t_x,pri_x, &
+                                         u_y,v_y,t_y,pri_y)
+  else
+     call tget_derivatives2(st,vp,t,pri,u,v,u_x,v_x,t_x,pri_x, &
+                                      u_y,v_y,t_y,pri_y)
+  end if
+
+
+  call getprs_ad(p,t,pri)
+
+  return
+end subroutine calctends_no_ad

--- a/src/gsibec/gsi/calctends_no_tl.F90
+++ b/src/gsibec/gsi/calctends_no_tl.F90
@@ -1,0 +1,410 @@
+subroutine calctends_no_tl(st,vp,t,p,mype,u_t,v_t,t_t,p_t,uvflag)
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    calctends_tl       tlm of calctends
+!   prgmmr: kleist           org: np20                date: 2005-09-29
+!
+! abstract: TLM of routine that compute tendencies for pressure, Tv, u, v 
+!
+! program history log:
+!   2005-09-29  kleist
+!   2005-10-17  kleist - changes to improve computational efficiency
+!   2005-11-21  kleist - add tracer tendencies, use new module
+!   2006-04-12  treadon - replace sigi with bk5
+!   2006-04-21  kleist - add divergence tendency parts
+!   2006-07-31  kleist - changes to use ps instead of ln(ps)
+!   2006-09-21  kleist - add rescaling to divergence tendency formulation
+!   2006-10-04  rancic - correct bug in tracer advection terms
+!   2007-04-16  kleist - move constraint specific items elsewhere
+!   2007-05-08  kleist - add bits for fully generalized vertical coordinate
+!   2007-06-21  rancic - add pbl 
+!   2007-07-26  cucurull - add 3d pressure pri in argument list ;
+!                          move getprs_tl outside calctends_tl;
+!                          call getprs_horiz_tl;
+!                          remove ps from argument list
+!   2007-08-08  derber - optimize
+!   2008-06-05  safford - rm unused uses
+!   2009-04-21  derber - remove call to getuv and modify get_derivatives to include uv
+!   2009-08-20  parrish - replace curvfct with curvx, curvy.  this allows tendency computation to
+!                          work for any general orthogonal coordinate.
+!   2010-11-03  derber - moved threading calculations to gridmod and modified
+!   2012-02-08  kleist - add uvflag to argument list
+!   2013-10-19  todling - derivatives and guess fields now in bundles
+!
+! usage:
+!   input argument list:
+!     u        - zonal wind on subdomain
+!     v        - meridional wind on subdomain
+!     t        - virtual temperature on subdomain
+!     mype     - task id
+!     uvflag   - logical, set to true for st,vp wind components, instead of stream/potential function
+!
+!   output argument list:
+!     u_t      - time tendency of u
+!     v_t      - time tendency of v
+!     t_t      - time tendency of t
+!     p_t      - time tendency of 2d surface pressure
+!
+!   notes:
+!     TLM check performed & verified on 2005-09-29 by d. kleist
+!
+! attributes:
+!   language: f90
+!   machine:  ibm RS/6000 SP
+!
+!$$$
+  use m_kinds,only: r_kind,i_kind
+  use gridmod, only: lat2,lon2,nsig,istart,nlat,idvc5,bk5,&
+      nthreads,jtstart,jtstop,regional
+#ifdef USE_ALL_ORIGINAL
+  use gridmod, only: wrf_nmm_regional,nems_nmmb_regional,eta2_ll
+#endif /* USE_ALL_ORIGINAL */
+  use constants, only: zero,half,two,rd,rcp
+  use tendsmod, only: what9,prsth9,r_prsum9,prdif9,r_prdif9,pr_xsum9,pr_xdif9,&
+      pr_ysum9,pr_ydif9,curvx,curvy,coriolis
+  use guess_grids, only: ntguessig,ges_teta,ges_prsi
+  use gsi_metguess_mod, only: gsi_metguess_bundle
+  use gsi_bundlemod, only: gsi_bundlegetpointer
+  use derivsmod, only: gsi_xderivative_bundle
+  use derivsmod, only: gsi_yderivative_bundle
+  implicit none
+
+! Declare passed variables
+  real(r_kind),dimension(lat2,lon2,nsig),intent(in   ) :: st,vp,t
+  real(r_kind),dimension(lat2,lon2)     ,intent(in   ) :: p
+  integer(i_kind)                       ,intent(in   ) :: mype
+  real(r_kind),dimension(lat2,lon2,nsig),intent(  out) :: u_t,v_t,t_t
+  real(r_kind),dimension(lat2,lon2)     ,intent(  out) :: p_t
+  logical                               ,intent(   in) :: uvflag
+
+! Declare local variables
+  character(len=*),parameter::myname='calctends_no_tl'
+  real(r_kind),dimension(lat2,lon2,nsig+1):: pri
+  real(r_kind),dimension(lat2,lon2,nsig):: u,v
+  real(r_kind),dimension(lat2,lon2,nsig+1):: pri_x,pri_y
+  real(r_kind),dimension(lat2,lon2,nsig+1):: prsth,what
+  real(r_kind),dimension(lat2,lon2,nsig):: prsum,prdif,pr_xsum,pr_xdif,&
+       pr_ysum,pr_ydif
+  real(r_kind),dimension(lat2,lon2):: sumkm1,sumvkm1,sum2km1,sum2vkm1
+  real(r_kind),dimension(lat2,lon2,nsig):: t_thor9
+  real(r_kind),dimension(lat2,lon2,nsig):: u_x,u_y,v_x,v_y,t_x,t_y
+
+  real(r_kind) tmp,tmp2,tmp3,sumk,sumvk,sum2k,sum2vk,uduvdv
+  integer(i_kind) i,j,k,ix,it,kk,ier,istatus
+
+  real(r_kind),pointer,dimension(:,:,:) :: ges_u=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_v=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_tv=>NULL()
+
+  real(r_kind),pointer,dimension(:,:,:) :: ges_u_lon=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_v_lon=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_tv_lon=>NULL()
+
+  real(r_kind),pointer,dimension(:,:,:) :: ges_u_lat=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_v_lat=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_tv_lat=>NULL()
+
+! linearized about guess solution, so set it flag accordingly
+  it=ntguessig
+
+  ier=0
+  call gsi_bundlegetpointer(gsi_metguess_bundle(it),'u' ,ges_u, istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_metguess_bundle(it),'v' ,ges_v, istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_metguess_bundle(it),'tv',ges_tv,istatus);ier=istatus+ier
+  if(ier/=0) then
+     write(6,*) myname, ': pointers not found in met-guess, ier=', ier
+     call stop2(999)
+  endif
+
+  ier=0
+  call gsi_bundlegetpointer(gsi_xderivative_bundle(it),'u' ,ges_u_lon, istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_xderivative_bundle(it),'v' ,ges_v_lon, istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_xderivative_bundle(it),'tv',ges_tv_lon,istatus);ier=istatus+ier
+  if(ier/=0) then
+     write(6,*) myname, ': pointers not found in lon-derivatives, ier=', ier
+     call stop2(999)
+  endif
+
+  ier=0
+  call gsi_bundlegetpointer(gsi_yderivative_bundle(it),'u' ,ges_u_lat, istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_yderivative_bundle(it),'v' ,ges_v_lat, istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_yderivative_bundle(it),'tv',ges_tv_lat,istatus);ier=istatus+ier
+  if(ier/=0) then
+     write(6,*) myname, ': pointers not found in lat-derivatives, ier=', ier
+     call stop2(999)
+  endif
+
+! preliminaries:
+
+! get 3d pressure
+  call getprs_tl(p,t,pri)
+
+  if(uvflag)then
+    call get_derivatives2uv(st,vp,t,pri,u,v,u_x,v_x,t_x,pri_x, &
+                                        u_y,v_y,t_y,pri_y)
+  else
+    call get_derivatives2(st,vp,t,pri,u,v,u_x,v_x,t_x,pri_x, &
+                                        u_y,v_y,t_y,pri_y)
+  end if
+
+
+!$omp parallel do private(i,j,k,kk,tmp,tmp2,uduvdv, &
+!$omp                  tmp3,sumk,sumvk,sum2k,sum2vk,ix)
+  do kk=1,nthreads
+
+    do k=1,nsig
+      do j=jtstart(kk),jtstop(kk)
+        do i=1,lat2
+           prsum  (i,j,k)=pri  (i,j,k)+pri  (i,j,k+1)
+           prdif  (i,j,k)=pri  (i,j,k)-pri  (i,j,k+1)
+           pr_xsum(i,j,k)=pri_x(i,j,k)+pri_x(i,j,k+1)
+           pr_xdif(i,j,k)=pri_x(i,j,k)-pri_x(i,j,k+1)
+           pr_ysum(i,j,k)=pri_y(i,j,k)+pri_y(i,j,k+1)
+           pr_ydif(i,j,k)=pri_y(i,j,k)-pri_y(i,j,k+1)
+        end do
+      end do
+    end do
+
+!   Compute horizontal part of tendency for 3d pressure
+
+    do j=jtstart(kk),jtstop(kk)
+      do i=1,lat2
+        prsth(i,j,nsig+1)=zero
+      end do
+    end do
+    do k=nsig,1,-1
+      do j=jtstart(kk),jtstop(kk)
+        do i=1,lat2
+           prsth(i,j,k)=prsth(i,j,k+1) -  ( u(i,j,k)*pr_xdif9(i,j,k) + &
+              ges_u(i,j,k)*pr_xdif(i,j,k) + v(i,j,k)*pr_ydif9(i,j,k) + &
+              ges_v(i,j,k)*pr_ydif(i,j,k) + &
+              (u_x      (i,j,k) + v_y      (i,j,k))*(prdif9(i,j,k)) + &
+              (ges_u_lon(i,j,k) + ges_v_lat(i,j,k))*(prdif (i,j,k)) )
+        end do
+      end do
+    end do
+
+!   Get horizontal part of temperature tendency for vertical velocity term
+
+    do k=1,nsig
+      do j=jtstart(kk),jtstop(kk)
+        do i=1,lat2
+           tmp=rd*ges_tv(i,j,k)*r_prsum9(i,j,k)
+           t_t(i,j,k)=-u(i,j,k)*ges_tv_lon(i,j,k) - ges_u(i,j,k)*t_x(i,j,k) - &
+              v(i,j,k)*ges_tv_lat(i,j,k) - ges_v(i,j,k)*t_y(i,j,k) +          &
+              tmp*rcp*( ges_u(i,j,k)*pr_xsum(i,j,k) + &
+              u(i,j,k)*pr_xsum9(i,j,k) + &
+              ges_v(i,j,k)*pr_ysum(i,j,k) + &
+              v(i,j,k)*pr_ysum9(i,j,k) + &
+              prsth(i,j,k) + prsth(i,j,k+1)) + &
+              rcp*( ges_u(i,j,k)*pr_xsum9(i,j,k) + &
+              ges_v(i,j,k)*pr_ysum9(i,j,k) + &
+              prsth9(i,j,k)+prsth9(i,j,k+1) ) * &
+              ( rd*t(i,j,k)*r_prsum9(i,j,k) - tmp*prsum(i,j,k)*r_prsum9(i,j,k) )
+ 
+        end do
+      end do
+    end do
+
+!   calculate vertical velocity term:  z(dp/dz) (zero at top/bottom interfaces)
+!   if running global, and there is a c(k) coefficient, we call the vvel subroutine
+
+    if ( (.not.regional) .AND. (idvc5==3)) then
+
+!     Get horizontal part of temperature tendency for vertical velocity term
+
+      do k=1,nsig
+        do j=jtstart(kk),jtstop(kk)
+           do i=1,lat2
+              tmp=rd*ges_tv(i,j,k)*r_prsum9(i,j,k)
+  
+              t_thor9(i,j,k)=-ges_u(i,j,k)*ges_tv_lon(i,j,k) - &
+                   ges_v(i,j,k)*ges_tv_lat(i,j,k)
+              t_thor9(i,j,k)=t_thor9(i,j,k) -tmp*rcp * ( ges_u(i,j,k)*pr_xsum9(i,j,k) + &
+                   ges_v(i,j,k)*pr_ysum9(i,j,k) + &
+                   prsth9(i,j,k) + prsth9(i,j,k+1) )
+           end do
+        end do
+      end do
+      call getvvel_tl(t,t_t,t_thor9,prsth,prdif,what,jtstart(kk),jtstop(kk))
+    else
+#ifdef USE_ALL_ORIGINAL
+      if(wrf_nmm_regional.or.nems_nmmb_regional) then
+        do k=2,nsig
+           do j=jtstart(kk),jtstop(kk)
+              do i=1,lat2
+                 what(i,j,k)=prsth(i,j,k)-eta2_ll(k)*prsth(i,j,1)
+              end do
+           end do
+        end do
+      else
+#endif /* USE_ALL_ORIGINAL */
+        do k=2,nsig
+           do j=jtstart(kk),jtstop(kk)
+              do i=1,lat2
+                 what(i,j,k)=prsth(i,j,k)-bk5(k)*prsth(i,j,1)
+              end do
+           end do
+        end do
+#ifdef USE_ALL_ORIGINAL
+      end if
+#endif /* USE_ALL_ORIGINAL */
+    end if
+
+!   top/bottom boundary condition:
+
+    do j=jtstart(kk),jtstop(kk)
+      do i=1,lat2
+        what(i,j,1)=zero
+        what(i,j,nsig+1)=zero
+      enddo
+    enddo
+
+
+!   load actual dp/dt
+
+    do j=jtstart(kk),jtstop(kk)
+      do i=1,lat2
+        p_t(i,j)=prsth(i,j,1)
+      end do
+    end do
+
+!   before big k loop, zero out the km1 summation arrays
+
+    do j=jtstart(kk),jtstop(kk)
+      do i=1,lat2
+        sumkm1  (i,j)=zero
+        sum2km1 (i,j)=zero
+        sumvkm1 (i,j)=zero
+        sum2vkm1(i,j)=zero
+      end do
+    end do
+
+!   Compute terms for tendencies of wind components & Temperature
+
+    do k=1,nsig
+      do j=jtstart(kk),jtstop(kk)
+        do i=1,lat2
+           uduvdv=two*(ges_u(i,j,k)*u(i,j,k) + ges_v(i,j,k)*v(i,j,k))
+           u_t(i,j,k)=-u(i,j,k)*ges_u_lon(i,j,k) - ges_u(i,j,k)*u_x(i,j,k) - &
+              v(i,j,k)*ges_u_lat(i,j,k) - ges_v(i,j,k)*u_y(i,j,k) + &
+              coriolis(i,j)*v(i,j,k) + curvx(i,j)*uduvdv
+           v_t(i,j,k)=-u(i,j,k)*ges_v_lon(i,j,k) - ges_u(i,j,k)*v_x(i,j,k) - &
+              v(i,j,k)*ges_v_lat(i,j,k) - ges_v(i,j,k)*v_y(i,j,k) - &
+              coriolis(i,j)*u(i,j,k) + curvy(i,j)*uduvdv
+ 
+           tmp=rd*ges_tv(i,j,k)*r_prsum9(i,j,k)
+           tmp2=rd*t(i,j,k)*r_prsum9(i,j,k)
+
+           u_t(i,j,k) = u_t(i,j,k)-tmp*( pr_xsum(i,j,k) - &
+              (prsum(i,j,k)*pr_xsum9(i,j,k)*r_prsum9(i,j,k)) ) - &
+              tmp2*pr_xsum9(i,j,k)
+
+           v_t(i,j,k) = v_t(i,j,k)-tmp*( pr_ysum(i,j,k) - &
+              (prsum(i,j,k)*pr_ysum9(i,j,k)*r_prsum9(i,j,k)) ) - &
+              tmp2*pr_ysum9(i,j,k)
+
+!          vertical flux terms
+           if (k > 1) then
+              tmp=half*what(i,j,k)*r_prdif9(i,j,k)
+              tmp2=half*what9(i,j,k)*r_prdif9(i,j,k)
+
+              u_t(i,j,k) = u_t(i,j,k) - tmp*(ges_u (i,j,k-1)-ges_u (i,j,k)) - &
+                 tmp2*( (u(i,j,k-1)-u(i,j,k)) - (ges_u (i,j,k-1)-ges_u (i,j,k))* &
+                 prdif(i,j,k)*r_prdif9(i,j,k))          
+              v_t(i,j,k) = v_t(i,j,k) - tmp*(ges_v (i,j,k-1)-ges_v (i,j,k)) - &
+                 tmp2*( (v(i,j,k-1)-v(i,j,k)) - (ges_v (i,j,k-1)-ges_v (i,j,k))* &
+                 prdif(i,j,k)*r_prdif9(i,j,k))
+              t_t(i,j,k) = t_t(i,j,k) - tmp*(ges_tv(i,j,k-1)-ges_tv(i,j,k)) - &
+                 tmp2*( (t(i,j,k-1)-t(i,j,k)) - (ges_tv(i,j,k-1)-ges_tv(i,j,k))* &
+                 prdif(i,j,k)*r_prdif9(i,j,k))
+           end if
+           if (k < nsig) then
+              tmp=half*what(i,j,k+1)*r_prdif9(i,j,k)
+              tmp2=half*what9(i,j,k+1)*r_prdif9(i,j,k)
+              u_t(i,j,k) = u_t(i,j,k) - tmp*(ges_u (i,j,k)-ges_u (i,j,k+1)) - &
+                 tmp2*( (u(i,j,k)-u(i,j,k+1)) - (ges_u (i,j,k)-ges_u (i,j,k+1))* &
+                 prdif(i,j,k)*r_prdif9(i,j,k))
+              v_t(i,j,k) = v_t(i,j,k) - tmp*(ges_v (i,j,k)-ges_v (i,j,k+1)) - &
+                 tmp2*( (v(i,j,k)-v(i,j,k+1)) - (ges_v (i,j,k)-ges_v (i,j,k+1))* &
+                 prdif(i,j,k)*r_prdif9(i,j,k))
+              t_t(i,j,k) = t_t(i,j,k) - tmp*(ges_tv(i,j,k)-ges_tv(i,j,k+1)) - &
+                 tmp2*( (t(i,j,k)-t(i,j,k+1)) - (ges_tv(i,j,k)-ges_tv(i,j,k+1))* &
+                 prdif(i,j,k)*r_prdif9(i,j,k))
+           end if
+        end do   !end do i
+      end do     !end do j
+
+!     first sum to level k-1     
+
+      do j=jtstart(kk),jtstop(kk)
+        do i=1,lat2
+           tmp=rd*t(i,j,k)*r_prsum9(i,j,k)
+           tmp2=rd*ges_tv(i,j,k)*r_prsum9(i,j,k)
+           tmp3=prdif9(i,j,k)*r_prsum9(i,j,k)
+
+           sumk = sumkm1(i,j) + ( tmp - tmp2*prsum(i,j,k)*r_prsum9(i,j,k) ) * &
+              ( pr_xdif9(i,j,k) - ( pr_xsum9(i,j,k)*tmp3 ) )
+           sumk = sumk + tmp2*( pr_xdif(i,j,k) - &
+              (tmp3 *pr_xsum(i,j,k) + pr_xsum9(i,j,k)*( ( &
+              prdif(i,j,k) - tmp3* prsum(i,j,k) )*r_prsum9(i,j,k) ) ) )
+
+           sumvk = sumvkm1(i,j) + ( tmp - tmp2*prsum(i,j,k)*r_prsum9(i,j,k) ) * &
+              ( pr_ydif9(i,j,k) - ( pr_ysum9(i,j,k)*tmp3 ) )
+           sumvk = sumvk + tmp2*( pr_ydif(i,j,k) - &
+              (tmp3*pr_ysum(i,j,k) + pr_ysum9(i,j,k)*( ( &
+              prdif(i,j,k) - tmp3* prsum(i,j,k) )*r_prsum9(i,j,k) ) ) )
+
+           sum2k = sum2km1(i,j) + t_x(i,j,k)*tmp3 + &
+              ges_tv_lon(i,j,k)*( (prdif(i,j,k) - &
+              tmp3*prsum(i,j,k))*r_prsum9(i,j,k))
+ 
+           sum2vk = sum2vkm1(i,j) + t_y(i,j,k)*tmp3 + &
+              ges_tv_lat(i,j,k)*( (prdif(i,j,k) - &
+              tmp3*prsum(i,j,k))*r_prsum9(i,j,k))
+ 
+           u_t(i,j,k) = u_t(i,j,k) - sumkm1 (i,j) - rd*sum2km1 (i,j) - &
+              sumk  - rd*sum2k
+           v_t(i,j,k) = v_t(i,j,k) - sumvkm1(i,j) - rd*sum2vkm1(i,j) - &
+              sumvk - rd*sum2vk
+
+!          load up the km1 arrays for next k loop
+           sumkm1  (i,j)=sumk
+           sumvkm1 (i,j)=sumvk
+           sum2km1 (i,j)=sum2k
+           sum2vkm1(i,j)=sum2vk
+
+        end do !end do i
+      end do   !end do j
+    end do  !end do k
+
+    call turbl_tl(ges_prsi(1,1,1,it),ges_tv,ges_teta(1,1,1,it),&
+               u,v,pri,t,u_t,v_t,t_t,jtstart(kk),jtstop(kk))
+
+#ifdef USE_ALL_ORIGINAL
+    if(.not.wrf_nmm_regional.and..not.nems_nmmb_regional)then
+#endif /* USE_ALL_ORIGINAL */
+      do k=1,nsig
+
+!       Zero out time derivatives at poles
+
+        do j=jtstart(kk),jtstop(kk)
+           do i=1,lat2
+              ix=istart(mype+1)+i-2
+              if (ix == 1 .or. ix == nlat) then
+                 u_t(i,j,k)=zero
+                 v_t(i,j,k)=zero
+              end if
+           end do
+        end do
+
+      end do  !end do k 
+#ifdef USE_ALL_ORIGINAL
+    end if
+#endif /* USE_ALL_ORIGINAL */
+
+  end do
+!  end threading loop
+
+  return
+end subroutine calctends_no_tl

--- a/src/gsibec/gsi/calctends_tl.F90
+++ b/src/gsibec/gsi/calctends_tl.F90
@@ -1,0 +1,561 @@
+subroutine calctends_tl(fields,fields_dt,mype)
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    calctends_tl       tlm of calctends
+!   prgmmr: kleist           org: np20                date: 2005-09-29
+!
+! abstract: TLM of routine that compute tendencies for pressure, Tv, u, v 
+!
+! program history log:
+!   2005-09-29  kleist
+!   2005-10-17  kleist - changes to improve computational efficiency
+!   2005-11-21  kleist - add tracer tendencies, use new module
+!   2006-04-12  treadon - replace sigi with bk5
+!   2006-04-21  kleist - add divergence tendency parts
+!   2006-07-31  kleist - changes to use ps instead of ln(ps)
+!   2006-09-21  kleist - add rescaling to divergence tendency formulation
+!   2006-10-04  rancic - correct bug in tracer advection terms
+!   2007-04-16  kleist - move constraint specific items elsewhere
+!   2007-05-08  kleist - add bits for fully generalized vertical coordinate
+!   2007-06-21  rancic - add pbl 
+!   2007-07-26  cucurull - add 3d pressure pri in argument list ;
+!                          move getprs_tl outside calctends_tl;
+!                          call getprs_horiz_tl;
+!                          remove ps from argument list
+!   2007-08-08  derber - optimize
+!   2008-06-05  safford - rm unused uses
+!   2009-08-20  parrish - replace curvfct with curvx, curvy.  this allows tendency computation to
+!                          work for any general orthogonal coordinate.
+!   2010-11-03  derber - moved threading calculations to gridmod and modified
+!   2011-05-01  todling - cwmr no longer in guess-grids; use metguess bundle now
+!   2011-12-02  zhu     - add safe-guard for the case when there is no entry in the metguess table
+!   2012-03-11  tong    - added condition to calcuate cw_t
+!   2013-10-19  todling - revamp interface (pass all in bundles); derivatives and
+!                         guess fields also in bundles
+!   2013-10-28  todling - rename p3d to prse
+!   2014-06-05  eliu    - move location to get cw index(icw) from sv table; add condition
+!                         to get pointer for cw 
+!
+! usage:
+!   input argument list:
+!     fields    - bundle holding relevant fields
+!     mype      - task id
+!
+!   output argument list:
+!     fields_dt - bundle holding related time tendencies
+!
+!   notes:
+!     TLM check performed & verified on 2005-09-29 by d. kleist
+!
+! attributes:
+!   language: f90
+!   machine:  ibm RS/6000 SP
+!
+!$$$
+  use m_kinds,only: r_kind,i_kind
+  use gridmod, only: lat2,lon2,nsig,istart,nlat,idvc5,bk5,&
+      nthreads,jtstart,jtstop,regional
+#ifdef USE_ALL_ORIGINAL
+  use gridmod, only: wrf_nmm_regional,nems_nmmb_regional,eta2_ll
+#endif /* USE_ALL_ORIGINAL */
+  use constants, only: zero,half,two,rd,rcp
+  use derivsmod, only: cwgues
+  use tendsmod, only: what9,prsth9,r_prsum9,prdif9,r_prdif9,pr_xsum9,pr_xdif9,&
+      pr_ysum9,pr_ydif9,curvx,curvy,coriolis
+  use guess_grids, only: ntguessig,ges_teta,ges_prsi
+  use gsi_metguess_mod, only: gsi_metguess_get,gsi_metguess_bundle
+  use gsi_bundlemod, only: gsi_bundlegetpointer
+  use gsi_bundlemod, only: gsi_bundle
+  use gsi_bundlemod, only: gsi_bundledup
+  use gsi_bundlemod, only: gsi_bundleinquire
+  use gsi_bundlemod, only: gsi_bundledestroy
+  use mpeu_util, only: die, getindex
+  use derivsmod, only: gsi_xderivative_bundle
+  use derivsmod, only: gsi_yderivative_bundle
+  implicit none
+
+! Declare passed variables
+  type(gsi_bundle) :: fields
+  type(gsi_bundle) :: fields_dt
+  integer(i_kind),intent(in) :: mype
+
+! Declare local variables
+  character(len=*),parameter::myname='calctends_tl'
+  real(r_kind),dimension(:,:,:),pointer :: u_t,v_t,t_t,q_t,oz_t,cw_t
+  real(r_kind),dimension(:,:,:),pointer :: p_t
+  real(r_kind),dimension(:,:,:),pointer :: pri
+  real(r_kind),dimension(:,:,:),pointer :: u,v,t,q,oz,cw
+  real(r_kind),dimension(:,:,:),pointer :: u_x,u_y,v_x,v_y,t_x,t_y
+  real(r_kind),dimension(:,:,:),pointer :: q_x,q_y,oz_x,oz_y,cw_x,cw_y
+  real(r_kind),dimension(:,:)  ,pointer :: ps_x,ps_y
+  real(r_kind),dimension(:,:,:),pointer :: pri_x,pri_y
+  real(r_kind),dimension(lat2,lon2,nsig+1):: prsth,what
+  real(r_kind),dimension(lat2,lon2,nsig):: prsum,prdif,pr_xsum,pr_xdif,&
+       pr_ysum,pr_ydif
+  real(r_kind),dimension(lat2,lon2):: sumkm1,sumvkm1,sum2km1,sum2vkm1
+  real(r_kind),dimension(lat2,lon2,nsig):: t_thor9
+
+  real(r_kind) tmp,tmp2,tmp3,sumk,sumvk,sum2k,sum2vk,uduvdv
+  integer(i_kind) i,j,k,ix,it,kk,istatus,n_actual_clouds,ier,icw
+  logical ihave_xtra_derivatives
+  character(len=10),allocatable,dimension(:)::fvars2d,fvars3d
+
+  type(gsi_bundle) :: xderivative
+  type(gsi_bundle) :: yderivative
+
+  real(r_kind),pointer,dimension(:,:,:) :: ges_u=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_v=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_tv=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_q =>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_oz=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_cwmr=>NULL()
+
+  real(r_kind),pointer,dimension(:,:,:) :: ges_u_lon=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_v_lon=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_tv_lon=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_q_lon =>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_oz_lon=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_cw_lon=>NULL()
+
+  real(r_kind),pointer,dimension(:,:,:) :: ges_u_lat=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_v_lat=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_tv_lat=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_q_lat =>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_oz_lat=>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: ges_cw_lat=>NULL()
+
+! linearized about guess solution, so set it flag accordingly
+  it=ntguessig
+
+  if(fields%n2d>0) allocate(fvars2d(fields%n2d))
+  if(fields%n3d>0) allocate(fvars3d(fields%n3d))
+  call gsi_bundleinquire (fields,'shortnames::2d',fvars2d,istatus)
+  call gsi_bundleinquire (fields,'shortnames::3d',fvars3d,istatus)
+  icw=getindex(fvars3d,'cw')
+
+  ier=0
+  call gsi_bundlegetpointer(fields,'u',   u,   istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(fields,'v',   v,   istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(fields,'tv',  t,   istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(fields,'q',   q,   istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(fields,'oz' , oz,  istatus);ier=istatus+ier
+  if (icw>0) &  
+  call gsi_bundlegetpointer(fields,'cw' , cw,  istatus);ier=istatus+ier 
+  call gsi_bundlegetpointer(fields,'prse',pri, istatus);ier=istatus+ier
+  if(ier/=0) then
+     write(6,*) myname,': pointers not found on input, ier=', ier
+     call stop2(999)
+  endif
+
+  ier=0
+  call gsi_bundlegetpointer(fields_dt,'u',   u_t, istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(fields_dt,'v',   v_t, istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(fields_dt,'tv',  t_t, istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(fields_dt,'q',   q_t, istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(fields_dt,'oz' , oz_t,istatus);ier=istatus+ier
+  if (icw>0) &
+  call gsi_bundlegetpointer(fields_dt,'cw' , cw_t,istatus);ier=istatus+ier       
+  call gsi_bundlegetpointer(fields_dt,'prse',p_t ,istatus);ier=istatus+ier
+  if(ier/=0) then
+     write(6,*) myname,': pointers not found on tendency, ier=', ier
+     call stop2(999)
+  endif
+
+  ier=0
+  call gsi_bundlegetpointer(gsi_metguess_bundle(it),'u' ,ges_u, istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_metguess_bundle(it),'v' ,ges_v, istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_metguess_bundle(it),'tv',ges_tv,istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_metguess_bundle(it),'q', ges_q ,istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_metguess_bundle(it),'oz',ges_oz,istatus);ier=istatus+ier
+  if(ier/=0) then
+     write(6,*) myname, ': pointers not found in met-guess, ier=', ier
+     call stop2(999)
+  endif
+
+  ier=0
+  call gsi_bundlegetpointer(gsi_xderivative_bundle(it),'u' ,ges_u_lon, istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_xderivative_bundle(it),'v' ,ges_v_lon, istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_xderivative_bundle(it),'tv',ges_tv_lon,istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_xderivative_bundle(it),'q', ges_q_lon ,istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_xderivative_bundle(it),'oz',ges_oz_lon,istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_xderivative_bundle(it),'cw',ges_cw_lon,istatus);ier=istatus+ier
+  if(ier/=0) then
+     write(6,*) myname, ': pointers not found in lon-derivatives, ier=', ier
+     call stop2(999)
+  endif
+
+  ier=0
+  call gsi_bundlegetpointer(gsi_yderivative_bundle(it),'u' ,ges_u_lat, istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_yderivative_bundle(it),'v' ,ges_v_lat, istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_yderivative_bundle(it),'tv',ges_tv_lat,istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_yderivative_bundle(it),'q', ges_q_lat ,istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_yderivative_bundle(it),'oz',ges_oz_lat,istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(gsi_yderivative_bundle(it),'cw',ges_cw_lat,istatus);ier=istatus+ier
+  if(ier/=0) then
+     write(6,*) myname, ': pointers not found in lat-derivatives, ier=', ier
+     call stop2(999)
+  endif
+
+
+! Get pointer to could water mixing ratio
+  call gsi_metguess_get('clouds::3d',n_actual_clouds,ier)
+  if (n_actual_clouds>0) then
+     call gsi_bundlegetpointer (gsi_metguess_bundle(it),'cw',ges_cwmr,istatus)
+     if (istatus/=0) then 
+        if (regional) then 
+           ges_cwmr => cwgues     ! temporily, revise after moist physics is ready
+        else
+           call die(myname,'cannot get pointer to cwmr, istatus =',istatus)
+        end if
+     end if
+  else
+     ges_cwmr => cwgues
+  end if
+
+! preliminaries:
+  ihave_xtra_derivatives=.false. 
+  ier=0
+  call gsi_bundledup ( fields, xderivative, 'lon-derivatives', istatus )
+  ier=ier+istatus
+  call gsi_bundledup ( fields, yderivative, 'lat-derivatives', istatus )
+  ier=ier+istatus
+  if(ier==0) then
+    ihave_xtra_derivatives=.true. 
+  else
+    call die(myname,': trouble creating temporary space for derivatives',ier)
+  endif
+
+  call get_derivatives( fields, xderivative, yderivative )
+
+  call gsi_bundlegetpointer(xderivative,'ps'  , ps_x,istatus)
+  call gsi_bundlegetpointer(xderivative,'u'   ,  u_x,istatus)
+  call gsi_bundlegetpointer(xderivative,'v'   ,  v_x,istatus)
+  call gsi_bundlegetpointer(xderivative,'tv'  ,  t_x,istatus)
+  call gsi_bundlegetpointer(xderivative,'q'   ,  q_x,istatus)
+  call gsi_bundlegetpointer(xderivative,'oz'  , oz_x,istatus)
+  call gsi_bundlegetpointer(xderivative,'cw'  , cw_x,istatus)
+  call gsi_bundlegetpointer(xderivative,'prse',pri_x,istatus)
+
+  call gsi_bundlegetpointer(yderivative,'ps'  , ps_y,istatus)
+  call gsi_bundlegetpointer(yderivative,'u'   ,  u_y,istatus)
+  call gsi_bundlegetpointer(yderivative,'v'   ,  v_y,istatus)
+  call gsi_bundlegetpointer(yderivative,'tv'  ,  t_y,istatus)
+  call gsi_bundlegetpointer(yderivative,'q'   ,  q_y,istatus)
+  call gsi_bundlegetpointer(yderivative,'oz'  , oz_y,istatus)
+  call gsi_bundlegetpointer(yderivative,'cw'  , cw_y,istatus)
+  call gsi_bundlegetpointer(yderivative,'prse',pri_y,istatus)
+
+  call getprs_horiz_tl(ps_x,ps_y,pri,pri_x,pri_y)
+
+!$omp parallel do private(i,j,k,kk,tmp,tmp2,uduvdv, &
+!$omp                  tmp3,sumk,sumvk,sum2k,sum2vk,ix)
+  do kk=1,nthreads
+
+    do k=1,nsig
+      do j=jtstart(kk),jtstop(kk) 
+        do i=1,lat2
+           prsum  (i,j,k)=pri  (i,j,k)+pri  (i,j,k+1)
+           prdif  (i,j,k)=pri  (i,j,k)-pri  (i,j,k+1)
+           pr_xsum(i,j,k)=pri_x(i,j,k)+pri_x(i,j,k+1)
+           pr_xdif(i,j,k)=pri_x(i,j,k)-pri_x(i,j,k+1)
+           pr_ysum(i,j,k)=pri_y(i,j,k)+pri_y(i,j,k+1)
+           pr_ydif(i,j,k)=pri_y(i,j,k)-pri_y(i,j,k+1)
+        end do
+      end do
+    end do
+
+!   Compute horizontal part of tendency for 3d pressure
+
+    do j=jtstart(kk),jtstop(kk) 
+      do i=1,lat2
+        prsth(i,j,nsig+1)=zero
+      end do
+    end do
+    do k=nsig,1,-1
+      do j=jtstart(kk),jtstop(kk) 
+        do i=1,lat2
+           prsth(i,j,k)=prsth(i,j,k+1) - ( u(i,j,k)*pr_xdif9(i,j,k) + &
+              ges_u(i,j,k)*pr_xdif(i,j,k) + v(i,j,k)*pr_ydif9(i,j,k) + &
+              ges_v(i,j,k)*pr_ydif(i,j,k) + &
+              (u_x(i,j,k) + v_y(i,j,k))*(prdif9(i,j,k)) + &
+              (ges_u_lon(i,j,k) + ges_v_lat(i,j,k))*(prdif(i,j,k)) )
+        end do
+      end do
+    end do
+
+!   Get horizontal part of temperature tendency for vertical velocity term
+
+    do k=1,nsig
+      do j=jtstart(kk),jtstop(kk) 
+        do i=1,lat2
+           tmp=rd*ges_tv(i,j,k)*r_prsum9(i,j,k)
+           t_t(i,j,k)=-u(i,j,k)*ges_tv_lon(i,j,k) - ges_u(i,j,k)*t_x(i,j,k) - &
+              v(i,j,k)*ges_tv_lat(i,j,k) - ges_v(i,j,k)*t_y(i,j,k) +          &
+              tmp*rcp*( ges_u(i,j,k)*pr_xsum(i,j,k) + &
+              u(i,j,k)*pr_xsum9(i,j,k) + &
+              ges_v(i,j,k)*pr_ysum(i,j,k) + &
+              v(i,j,k)*pr_ysum9(i,j,k) + &
+              prsth(i,j,k) + prsth(i,j,k+1)) + &
+              rcp*( ges_u(i,j,k)*pr_xsum9(i,j,k) + &
+              ges_v(i,j,k)*pr_ysum9(i,j,k) + &
+              prsth9(i,j,k)+prsth9(i,j,k+1) ) * &
+              ( rd*t(i,j,k)*r_prsum9(i,j,k) - tmp*prsum(i,j,k)*r_prsum9(i,j,k) )
+ 
+        end do
+      end do
+    end do
+
+!   calculate vertical velocity term:  z(dp/dz) (zero at top/bottom interfaces)
+!   if running global, and there is a c(k) coefficient, we call the vvel subroutine
+
+    if ( (.not.regional) .AND. (idvc5==3)) then
+
+!     Get horizontal part of temperature tendency for vertical velocity term
+
+      do k=1,nsig
+        do j=jtstart(kk),jtstop(kk) 
+           do i=1,lat2
+              tmp=rd*ges_tv(i,j,k)*r_prsum9(i,j,k)
+  
+              t_thor9(i,j,k)=-ges_u(i,j,k)*ges_tv_lon(i,j,k) - &
+                   ges_v(i,j,k)*ges_tv_lat(i,j,k)
+              t_thor9(i,j,k)=t_thor9(i,j,k) -tmp*rcp * ( ges_u(i,j,k)*pr_xsum9(i,j,k) + &
+                 ges_v(i,j,k)*pr_ysum9(i,j,k) + &
+                 prsth9(i,j,k) + prsth9(i,j,k+1) )
+           end do
+        end do
+      end do
+      call getvvel_tl(t,t_t,t_thor9,prsth,prdif,what,jtstart(kk),jtstop(kk))
+    else
+#ifdef USE_ALL_ORIGINAL
+      if(wrf_nmm_regional.or.nems_nmmb_regional) then
+        do k=2,nsig
+           do j=jtstart(kk),jtstop(kk) 
+              do i=1,lat2
+                 what(i,j,k)=prsth(i,j,k)-eta2_ll(k)*prsth(i,j,1)
+              end do
+           end do
+        end do
+      else
+#endif /* USE_ALL_ORIGINAL */
+        do k=2,nsig
+           do j=jtstart(kk),jtstop(kk) 
+              do i=1,lat2
+                 what(i,j,k)=prsth(i,j,k)-bk5    (k)*prsth(i,j,1)
+              end do
+           end do
+        end do
+#ifdef USE_ALL_ORIGINAL
+      end if
+#endif /* USE_ALL_ORIGINAL */
+    end if
+
+!   top/bottom boundary condition:
+
+    do j=jtstart(kk),jtstop(kk) 
+      do i=1,lat2
+        what(i,j,1)=zero
+        what(i,j,nsig+1)=zero
+      enddo
+    enddo
+
+
+!   load actual dp/dt
+
+    do k=1,nsig+1
+      do j=jtstart(kk),jtstop(kk) 
+        do i=1,lat2
+           p_t(i,j,k)=prsth(i,j,k)-what(i,j,k)
+        end do
+      end do
+    end do
+
+!   before big k loop, zero out the km1 summation arrays
+
+    do j=jtstart(kk),jtstop(kk) 
+      do i=1,lat2
+        sumkm1  (i,j)=zero
+        sum2km1 (i,j)=zero
+        sumvkm1 (i,j)=zero
+        sum2vkm1(i,j)=zero
+      end do
+    end do
+
+!   Compute terms for tendencies of wind components & Temperature
+
+    do k=1,nsig
+      do j=jtstart(kk),jtstop(kk) 
+        do i=1,lat2
+           uduvdv=two*(ges_u(i,j,k)*u(i,j,k) + ges_v(i,j,k)*v(i,j,k))
+           u_t(i,j,k)=-u(i,j,k)*ges_u_lon(i,j,k) - ges_u(i,j,k)*u_x(i,j,k) - &
+              v(i,j,k)*ges_u_lat(i,j,k) - ges_v(i,j,k)*u_y(i,j,k) + &
+              coriolis(i,j)*v(i,j,k) + curvx(i,j)*uduvdv
+           v_t(i,j,k)=-u(i,j,k)*ges_v_lon(i,j,k) - ges_u(i,j,k)*v_x(i,j,k) - &
+              v(i,j,k)*ges_v_lat(i,j,k) - ges_v(i,j,k)*v_y(i,j,k) - &
+              coriolis(i,j)*u(i,j,k) + curvy(i,j)*uduvdv
+
+           tmp=rd*ges_tv(i,j,k)*r_prsum9(i,j,k)
+           tmp2=rd*t(i,j,k)*r_prsum9(i,j,k)
+
+           u_t(i,j,k) = u_t(i,j,k)-tmp*( pr_xsum(i,j,k) - &
+              (prsum(i,j,k)*pr_xsum9(i,j,k)*r_prsum9(i,j,k)) ) - &
+              tmp2*pr_xsum9(i,j,k)
+ 
+           v_t(i,j,k) = v_t(i,j,k)-tmp*( pr_ysum(i,j,k) - &
+              (prsum(i,j,k)*pr_ysum9(i,j,k)*r_prsum9(i,j,k)) ) - &
+              tmp2*pr_ysum9(i,j,k)
+
+!     vertical flux terms
+
+           if (k > 1) then
+              tmp=half*what(i,j,k)*r_prdif9(i,j,k)
+              tmp2=half*what9(i,j,k)*r_prdif9(i,j,k)
+
+              u_t(i,j,k) = u_t(i,j,k) - tmp*(ges_u (i,j,k-1)-ges_u (i,j,k)) - &
+                 tmp2*( (u(i,j,k-1)-u(i,j,k)) - (ges_u (i,j,k-1)-ges_u (i,j,k))* &
+                 prdif(i,j,k)*r_prdif9(i,j,k))          
+              v_t(i,j,k) = v_t(i,j,k) - tmp*(ges_v (i,j,k-1)-ges_v (i,j,k)) - &
+                 tmp2*( (v(i,j,k-1)-v(i,j,k)) - (ges_v (i,j,k-1)-ges_v (i,j,k))* &
+                 prdif(i,j,k)*r_prdif9(i,j,k))
+              t_t(i,j,k) = t_t(i,j,k) - tmp*(ges_tv(i,j,k-1)-ges_tv(i,j,k)) - &
+                 tmp2*( (t(i,j,k-1)-t(i,j,k)) - (ges_tv(i,j,k-1)-ges_tv(i,j,k))* &
+                 prdif(i,j,k)*r_prdif9(i,j,k))
+           end if
+           if (k < nsig) then
+              tmp=half*what(i,j,k+1)*r_prdif9(i,j,k)
+              tmp2=half*what9(i,j,k+1)*r_prdif9(i,j,k)
+              u_t(i,j,k) = u_t(i,j,k) - tmp*(ges_u (i,j,k)-ges_u (i,j,k+1)) - &
+                 tmp2*( (u(i,j,k)-u(i,j,k+1)) - (ges_u (i,j,k)-ges_u (i,j,k+1))* &
+                 prdif(i,j,k)*r_prdif9(i,j,k))
+              v_t(i,j,k) = v_t(i,j,k) - tmp*(ges_v (i,j,k)-ges_v (i,j,k+1)) - &
+                 tmp2*( (v(i,j,k)-v(i,j,k+1)) - (ges_v (i,j,k)-ges_v (i,j,k+1))* &
+                 prdif(i,j,k)*r_prdif9(i,j,k))
+              t_t(i,j,k) = t_t(i,j,k) - tmp*(ges_tv(i,j,k)-ges_tv(i,j,k+1)) - &
+                 tmp2*( (t(i,j,k)-t(i,j,k+1)) - (ges_tv(i,j,k)-ges_tv(i,j,k+1))* &
+                 prdif(i,j,k)*r_prdif9(i,j,k))
+           end if
+         end do   !end do i
+      end do     !end do j
+
+!     first sum to level k-1     
+
+      do j=jtstart(kk),jtstop(kk) 
+        do i=1,lat2
+           tmp=rd*t(i,j,k)*r_prsum9(i,j,k)
+           tmp2=rd*ges_tv(i,j,k)*r_prsum9(i,j,k)
+           tmp3=prdif9(i,j,k)*r_prsum9(i,j,k)
+
+           sumk = sumkm1(i,j) + ( tmp - tmp2*prsum(i,j,k)*r_prsum9(i,j,k) ) * &
+              ( pr_xdif9(i,j,k) - ( pr_xsum9(i,j,k)*tmp3 ) )
+           sumk = sumk + tmp2*( pr_xdif(i,j,k) - &
+              (tmp3 *pr_xsum(i,j,k) + pr_xsum9(i,j,k)*( ( &
+              prdif(i,j,k) - tmp3* prsum(i,j,k) )*r_prsum9(i,j,k) ) ) )
+
+           sumvk = sumvkm1(i,j) + ( tmp - tmp2*prsum(i,j,k)*r_prsum9(i,j,k) ) * &
+              ( pr_ydif9(i,j,k) - ( pr_ysum9(i,j,k)*tmp3 ) )
+           sumvk = sumvk + tmp2*( pr_ydif(i,j,k) - &
+              (tmp3*pr_ysum(i,j,k) + pr_ysum9(i,j,k)*( ( &
+              prdif(i,j,k) - tmp3* prsum(i,j,k) )*r_prsum9(i,j,k) ) ) )
+
+           sum2k  = sum2km1 (i,j) + t_x(i,j,k)*tmp3 + &
+              ges_tv_lon(i,j,k)*( (prdif(i,j,k) - &
+              tmp3*prsum(i,j,k))*r_prsum9(i,j,k))
+
+           sum2vk = sum2vkm1(i,j) + t_y(i,j,k)*tmp3 + &
+              ges_tv_lat(i,j,k)*( (prdif(i,j,k) - &
+              tmp3*prsum(i,j,k))*r_prsum9(i,j,k))
+
+           u_t(i,j,k) = u_t(i,j,k) - sumkm1 (i,j) - rd*sum2km1 (i,j) - &
+              sumk  - rd*sum2k
+           v_t(i,j,k) = v_t(i,j,k) - sumvkm1(i,j) - rd*sum2vkm1(i,j) - &
+              sumvk - rd*sum2vk
+ 
+! load up the km1 arrays for next k loop
+
+           sumkm1  (i,j)=sumk
+           sumvkm1 (i,j)=sumvk
+           sum2km1 (i,j)=sum2k
+           sum2vkm1(i,j)=sum2vk
+
+        end do !end do i
+      end do   !end do j
+    end do  !end do k
+
+    call turbl_tl(ges_prsi(1,1,1,it),ges_tv,ges_teta(1,1,1,it),&
+               u,v,pri,t,u_t,v_t,t_t,jtstart(kk),jtstop(kk))
+
+#ifdef USE_ALL_ORIGINAL
+    if(.not.wrf_nmm_regional.and..not.nems_nmmb_regional)then
+#endif /* USE_ALL_ORIGINAL */
+      do k=1,nsig
+
+!       Zero out time derivatives at poles
+        do j=jtstart(kk),jtstop(kk) 
+           do i=1,lat2
+              ix=istart(mype+1)+i-2
+              if (ix == 1 .or. ix == nlat) then
+                 u_t(i,j,k)=zero
+                 v_t(i,j,k)=zero
+              end if
+           end do
+        end do
+
+      end do  !end do k 
+#ifdef USE_ALL_ORIGINAL
+    end if
+#endif /* USE_ALL_ORIGINAL */
+    do k=1,nsig
+      do j=jtstart(kk),jtstop(kk) 
+        do i=1,lat2
+!          tracer advection terms
+           q_t (i,j,k) = -u(i,j,k)*ges_q_lon    (i,j,k) - ges_u(i,j,k)*q_x (i,j,k) - &
+              v(i,j,k)*ges_q_lat    (i,j,k) - ges_v(i,j,k)*q_y (i,j,k)
+           oz_t(i,j,k) = -u(i,j,k)*ges_oz_lon   (i,j,k) - ges_u(i,j,k)*oz_x(i,j,k) - &
+              v(i,j,k)*ges_oz_lat   (i,j,k) - ges_v(i,j,k)*oz_y(i,j,k)
+           if (icw>0) then
+              cw_t(i,j,k) = -u(i,j,k)*ges_cw_lon(i,j,k) - ges_u(i,j,k)*cw_x(i,j,k) - &
+                 v(i,j,k)*ges_cw_lat(i,j,k) - ges_v(i,j,k)*cw_y(i,j,k)
+           end if
+           if(k > 1)then
+              tmp=half*what(i,j,k)*r_prdif9(i,j,k)
+              tmp2=half*what9(i,j,k)*r_prdif9(i,j,k)
+              q_t (i,j,k) = q_t (i,j,k) - tmp*(ges_q   (i,j,k-1)-ges_q   (i,j,k)) - &
+                 tmp2*( (q (i,j,k-1)-q (i,j,k)) - (ges_q   (i,j,k-1)-ges_q   (i,j,k))* &
+                 prdif(i,j,k)*r_prdif9(i,j,k))
+              oz_t(i,j,k) = oz_t(i,j,k) - tmp*(ges_oz  (i,j,k-1)-ges_oz  (i,j,k)) - &
+                 tmp2*( (oz(i,j,k-1)-oz(i,j,k)) - (ges_oz  (i,j,k-1)-ges_oz  (i,j,k))* &
+                 prdif(i,j,k)*r_prdif9(i,j,k))
+              if (icw>0) then 
+                 cw_t(i,j,k) = cw_t(i,j,k) - tmp*(ges_cwmr(i,j,k-1)-ges_cwmr(i,j,k)) - &
+                    tmp2*( (cw(i,j,k-1)-cw(i,j,k)) - (ges_cwmr(i,j,k-1)-ges_cwmr(i,j,k))* &
+                    prdif(i,j,k)*r_prdif9(i,j,k))
+              end if
+           end if
+           if(k < nsig)then
+              tmp=half*what(i,j,k+1)*r_prdif9(i,j,k)
+              tmp2=half*what9(i,j,k+1)*r_prdif9(i,j,k)
+              q_t (i,j,k) = q_t (i,j,k) - tmp*(ges_q   (i,j,k)-ges_q   (i,j,k+1)) - &
+                 tmp2*( (q (i,j,k)-q (i,j,k+1)) - (ges_q   (i,j,k)-ges_q   (i,j,k+1))* &
+                 prdif(i,j,k)*r_prdif9(i,j,k))
+              oz_t(i,j,k) = oz_t(i,j,k) - tmp*(ges_oz  (i,j,k)-ges_oz  (i,j,k+1)) - &
+                 tmp2*( (oz(i,j,k)-oz(i,j,k+1)) - (ges_oz  (i,j,k)-ges_oz  (i,j,k+1))* &
+                 prdif(i,j,k)*r_prdif9(i,j,k))
+              if (icw>0) then
+                 cw_t(i,j,k) = cw_t(i,j,k) - tmp*(ges_cwmr(i,j,k)-ges_cwmr(i,j,k+1)) - &
+                    tmp2*( (cw(i,j,k)-cw(i,j,k+1)) - (ges_cwmr(i,j,k)-ges_cwmr(i,j,k+1))* &
+                    prdif(i,j,k)*r_prdif9(i,j,k))
+              end if
+           end if
+        end do
+      end do
+    end do
+
+  end do
+  if (ihave_xtra_derivatives) then
+     deallocate(fvars2d,fvars3d)
+     call gsi_bundledestroy(yderivative,ier)
+     call gsi_bundledestroy(xderivative,ier)
+  endif
+! end of threading loop
+  return
+end subroutine calctends_tl

--- a/src/gsibec/gsi/compute_derived.F90
+++ b/src/gsibec/gsi/compute_derived.F90
@@ -125,7 +125,6 @@ subroutine compute_derived(mype,init_pass)
   use gridmod, only: lat2,lon2,nsig,nsig1o  
 #ifdef TLNMC
   use mod_strong, only: l_tlnmc,baldiag_full
-  use obsmod, only: write_diag
 #endif
   use gsi_4dvar, only: l4dvar
 
@@ -315,7 +314,7 @@ subroutine compute_derived(mype,init_pass)
                           gsi_tendency_bundle)
 
 #ifdef TLNMC
-           if(l_tlnmc .and. write_diag(jiter) .and. baldiag_full) then
+           if(l_tlnmc .and. baldiag_full) then
               fullfield=.true.
 
               call init_vars_('tendency')

--- a/src/gsibec/gsi/ensctl2state.F90
+++ b/src/gsibec/gsi/ensctl2state.F90
@@ -41,9 +41,11 @@ use gsi_bundlemod, only: self_add
 use gsi_bundlemod, only: assignment(=)
 use mpeu_util, only: getindex
 use gsi_metguess_mod, only: gsi_metguess_get
-#ifdef USE_ALL_ORIGINAL
+#ifdef TLNMC
 use mod_strong, only: tlnmc_option
 use balmod, only: strong_bk
+#endif /* TLNMC */
+#ifdef USE_ALL_ORIGINAL
 use cwhydromod, only: cw2hydro_tl
 use cwhydromod, only: cw2hydro_tl_hwrf
 use timermod, only: timer_ini,timer_fnl
@@ -160,10 +162,10 @@ end do
 
 do jj=1,ntlevs_ens 
 
-#ifdef USE_ALL_ORIGINAL
+#ifdef TLNMC
    do_tlnmc = lstrong_bk_vars .and. ( (tlnmc_option==3) .or. &
          (jj==ibin_anl .and. tlnmc_option==2) )
-#endif /* USE_ALL_ORIGINAL */
+#endif /* TLNMC */
 
 !  Initialize work bundle to first component 
 !  For 4densvar, this is the "3D/Time-invariant contribution from static B"
@@ -272,7 +274,7 @@ do jj=1,ntlevs_ens
    call self_add(eval(jj),mval)
 
 ! Call strong constraint if necessary
-#ifdef USE_ALL_ORIGINAL
+#ifdef TLNMC
    if(do_tlnmc) then
 
       call strong_bk(sv_u,sv_v,sv_ps,sv_tv,.true.)
@@ -282,7 +284,7 @@ do jj=1,ntlevs_ens
       if(do_getprs_tl) call getprs_tl(sv_ps,sv_tv,sv_prse)
   
    end if
-#endif /* USE_ALL_ORIGINAL */
+#endif /* TLNMC */
 
 !  Calculate sensible temperature 
    if(do_tv_to_tsen) call tv_to_tsen(sv_tv,sv_q,sv_tsen)

--- a/src/gsibec/gsi/ensctl2state_ad.F90
+++ b/src/gsibec/gsi/ensctl2state_ad.F90
@@ -40,9 +40,11 @@ use gsi_bundlemod, only : self_add
 use constants, only: zero,max_varname_length
 use mpeu_util, only: getindex
 use gsi_metguess_mod, only: gsi_metguess_get
-#ifdef USE_ALL_ORIGINAL
+#ifdef TLNMC
 use balmod, only: strong_bk_ad
 use mod_strong, only: tlnmc_option
+#endif /* TLNMC */
+#ifdef USE_ALL_ORIGINAL
 use cwhydromod, only: cw2hydro_ad
 use cwhydromod, only: cw2hydro_ad_hwrf
 use timermod, only: timer_ini,timer_fnl
@@ -155,10 +157,10 @@ endif
 do jj=1,ntlevs_ens
 
 ! If calling TLNMC, already have u,v (so set last argument to true)
-#ifdef USE_ALL_ORIGINAL
+#ifdef TLNMC
    do_tlnmc = lstrong_bk_vars .and. ( (tlnmc_option==3) .or. &
             (jj==ibin_anl .and. tlnmc_option==2))  
-#endif /* USE_ALL_ORIGINAL */
+#endif /* TLNMC */
 
    wbundle_c%values=zero
 
@@ -176,7 +178,7 @@ do jj=1,ntlevs_ens
 !  Adjoint of consistency for sensible temperature, calculate sensible temperature
    if(do_tv_to_tsen_ad) call tv_to_tsen_ad(rv_tv,rv_q,rv_tsen)
 
-#ifdef USE_ALL_ORIGINAL
+#ifdef TLNMC
    if(do_tlnmc) then
 
       ! Adjoint to convert ps to 3-d pressure
@@ -187,7 +189,7 @@ do jj=1,ntlevs_ens
       call strong_bk_ad(rv_u,rv_v,rv_ps,rv_tv,.true.)
 
    end if
-#endif /* USE_ALL_ORIGINAL */
+#endif /* TLNMC */
 
    call self_add(mval,eval(jj))
 

--- a/src/gsibec/gsi/get_semimp_mats.f90
+++ b/src/gsibec/gsi/get_semimp_mats.f90
@@ -1,0 +1,449 @@
+subroutine get_semimp_mats(tbar,pbar,bhat,chat,amat,bmat,hmat,smat)
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    get_semimp_mats       compute matrices for semi implicit
+!   prgmmr: kleist           org: np20                date: 2007-05-08
+!
+! abstract: routine to load matrices used in semi-implicit scheme and 
+!           vertical mode decomposition
+!
+! program history log:
+!   2007-05-08  kleist
+!   2008-06-04  safford - rm unused uses
+!
+! usage:
+!   input argument list:
+!     tbar     - profile reference temperature
+!     pbar     - profile reference pressure
+!     bhat     - vertical coordinate b-coefficient (sigma)
+!     chat     - vertical coordinate c-coefficient (isentropic)
+!
+!   output argument list:
+!     amat     - a matrix for semi-implicit
+!     bmat     - b matrix for semi-implicit
+!     hmat     - h matrix for semi-implicit
+!     smat     - s matrix for semi implicit
+!
+!   notes:
+!     taken from global forecast model routine get_am_bm_hyb_gc.f 
+!
+! attributes:
+!   language: f90
+!   machine:  ibm RS/6000 SP
+!
+!$$$
+  use m_kinds,only: r_kind,i_kind
+  use constants,only: zero,half,one,two,four,rd,rd_over_cp
+  use gridmod,only: nsig
+  implicit none
+
+! Declare passed variables
+  real(r_kind),dimension(nsig)     ,intent(in   ) :: tbar
+  real(r_kind),dimension(nsig+1   ),intent(in   ) :: pbar,bhat,chat
+  real(r_kind),dimension(nsig,nsig),intent(  out) :: amat,bmat
+  real(r_kind),dimension(nsig)     ,intent(  out) :: hmat,smat
+
+! Declare local variables
+  real(r_kind),dimension(nsig-1,nsig-1):: zm
+  real(r_kind),dimension(nsig-1,nsig):: tm,wtm
+  real(r_kind),dimension(nsig,nsig-1):: pm
+  integer(i_kind),dimension(nsig-1):: lll,mmm
+  real(r_kind),dimension(nsig):: dpkref,rpkref,rp2ref,dbkref,bbkref,rdlref,&
+       hmat0,hmatk,alpha,beta,gamma,delta,dup,dum
+  real(r_kind),dimension(nsig+1):: c0kref
+  real(r_kind) kappa,rkappa,dprp,tcprp2,tcpcprp2,det,wmkm1,wmkp1
+  integer(i_kind) i,j,k,n
+
+! Constants
+  kappa=rd_over_cp
+  rkappa=one/kappa
+
+  do k=1,nsig
+     dpkref(k)=pbar(k)-pbar(k+1)
+     rdlref(k)=half/dpkref(k)
+     rpkref(k)=one/(pbar(k)+pbar(k+1))
+     rp2ref(k)=rpkref(k)*rpkref(k)
+     dbkref(k)=bhat(k)-bhat(k+1)
+     bbkref(k)=bhat(k)+bhat(k+1)
+  end do
+
+  c0kref=zero
+  do k=2,nsig
+     c0kref(k)=chat(k)*rkappa/(tbar(k-1)+tbar(k))
+  end do
+
+! SMAT :
+  do k=1,nsig
+     smat(k)=dpkref(k)
+  end do
+
+! HMAT :
+  do k=1,nsig
+     hmat0(k)=tbar(k)*rpkref(k)*bbkref(k)
+  end do
+  do k=1,nsig
+     hmatk(k)=rpkref(k)*tbar(k)* &
+          (dbkref(k)-rpkref(k)*dpkref(k)*bbkref(k))
+  end do
+  hmat(1)=zero
+  do k=1,nsig-1
+     hmat(k)  = hmat(k) + hmatk(k)
+     hmat(k+1)= hmat(k) + hmatk(k)
+  end do
+  hmat(nsig) = hmat(nsig) + hmatk(nsig)
+
+  do k=1,nsig
+     hmat(k) = rd*(hmat0(k)+hmat(k))
+  end do
+
+! AMAT :
+  amat=zero
+
+! AMAT 1+
+  do i=1,nsig
+     amat(i,i)=tbar(i)*rpkref(i)*(c0kref(i)+c0kref(i+1))
+  end do
+  do i=2,nsig
+     amat(i,i-1)=tbar(i)*rpkref(i)*c0kref(i)
+  end do
+  do i=1,nsig-1
+     amat(i,i+1)=tbar(i)*rpkref(i)*c0kref(i+1)
+  end do
+
+! AMAT 2+
+  do i=2,nsig-1
+     tcprp2=tbar(i)*c0kref(i)*pbar(i+1)*rp2ref(i)
+     amat(i,i-1)=amat(i,i-1) + two*tcprp2
+     do k=i+1,nsig
+        amat(k,i-1)=amat(k,i-1) + four*tcprp2
+     end do
+  end do
+
+! AMAT 3+
+  do i=1,nsig-1
+     tcpcprp2=tbar(i)*rp2ref(i)* &
+         (c0kref(i)*pbar(i+1)-c0kref(i+1)*pbar(i))
+     amat(i,i)=amat(i,i) + two*tcpcprp2
+     do k=i+1,nsig
+        amat(k,i)=amat(k,i) + four*tcpcprp2
+     end do
+  end do
+
+! AMAT 4+
+  do i=1,nsig-1
+     tcprp2=tbar(i)*c0kref(i+1)*pbar(i)*rp2ref(i)
+     amat(i,i+1)=amat(i,i+1) - two*tcprp2
+     do k=i+1,nsig
+        amat(k,i+1)=amat(k,i+1) - four*tcprp2
+     end do
+  end do
+
+! AMAT 5+
+  do i=1,nsig
+     dprp=dpkref(i)*rpkref(i)
+     amat(i,i)=amat(i,i) + dprp
+     do k=i+1,nsig
+        amat(k,i)=amat(k,i) + two*dprp
+     end do
+  end do
+
+! Apply raa to the sum
+  do j=1,nsig
+     do i=1,nsig
+        amat(i,j)=rd*amat(i,j)
+     end do
+  end do
+
+! BMAT:
+  bmat = zero
+  do i=1,nsig
+     bmat(i,i)=kappa*tbar(i)*rpkref(i)*dpkref(i)
+  end do
+  do j=2,nsig
+     do i=1,j-1
+        bmat(i,j)=two*kappa*tbar(i)*rpkref(i)*dpkref(j)
+     end do
+  end do
+
+! need zm, tm and pm for bmat+
+! alpha, beta, gamma
+  alpha(nsig)=zero
+  beta(1)=zero
+  do k=2,nsig
+     alpha(k-1)=(pbar(k)+pbar(k+1))/(pbar(k-1)+pbar(k))
+     alpha(k-1)=alpha(k-1)**kappa
+  end do
+  do k=1,nsig
+     gamma(k)=one - kappa*dpkref(k)*rpkref(k)*two
+     delta(k)=one + kappa*DPKREF(k)*RPKREF(k)*two
+  end do
+  do k=1,nsig-1
+     beta(k+1)=(pbar(k)+pbar(k+1))/(pbar(k+1)+pbar(k+2))
+     beta(k+1)=beta(k+1)**kappa
+  end do
+
+! ZM :
+  dup(nsig)=zero
+  dum(1)=zero
+  do k=1,nsig-1
+     dup(k)=delta(k)*tbar(k)-beta(k+1)*tbar(k+1)
+     dum(k+1)=alpha(k)*tbar(k)-gamma(k+1)*tbar(k+1)
+  end do
+!
+  zm=zero            ! (levs-1,levs-1)
+  k=2
+  wmkm1=c0kref(k)*rdlref(k-1)
+  wmkp1=c0kref(k)*rdlref(k)
+  zm(k-1,k-1)=wmkm1*dup(k-1)+wmkp1*dum(k)-one
+  zm(k-1,k)=wmkp1*dup(k)
+
+  do k=3,nsig-1
+     wmkm1=c0kref(k)*rdlref(k-1)
+     wmkp1=c0kref(k)*rdlref(     k)
+     zm(k-1,k-2)=wmkm1*dum(k-1)
+     zm(k-1,k-1)=wmkm1*dup(k-1)+wmkp1*dum(k)-one
+     zm(k-1,k         )=wmkp1*dup(k)
+  end do
+  k=nsig
+  wmkm1=c0kref(k)*rdlref(k-1)
+  wmkp1=c0kref(k)*rdlref(     k)
+  zm(k-1,k-2)=wmkm1*dum(k-1)
+  zm(k-1,k-1   )=wmkm1*dup(k-1)+wmkp1*dum(k)-one
+
+  call iminv(zm,nsig-1,det,lll,mmm)
+
+! TM :
+  tm=zero
+  do k=2,nsig
+     tm(k-1,k-1)=-c0kref(k)*kappa*tbar(k-1)*dpkref(k-1)*rpkref(k-1)
+     tm(k-1,k     )= c0kref(k)*kappa*tbar(k     )*dpkref(k     )*rpkref(k     )
+  end do
+  do k=2,nsig
+     do n=1,nsig
+        tm(k-1,n)=tm(k-1,n)-bhat(k)*dpkref(n)
+     end do
+  end do
+  do k=2,nsig
+     do n=k,nsig
+        tm(k-1,n)=tm(k-1,n)+(one-two*c0kref(k)*kappa*  &
+                 (tbar(k-1)*rpkref(k-1) + tbar(k)*rpkref(k)))*dpkref(n)
+     enddo
+  enddo
+
+! ZM*TM :
+  wtm=zero
+  do i=1,nsig
+     do n=1,nsig-1
+        do j=1,nsig-1
+           wtm(j,i)=wtm(j,i)+zm(j,n)*tm(n,i)
+        end do
+     end do
+  end do
+
+! PM :
+  pm=zero
+  k=1
+  pm(k,k)=(delta(k)*tbar(k)-beta(k+1)*tbar(k+1))*rdlref(k)
+  do k=2,nsig-1
+     pm(k,k-1)=(alpha(k-1)*tbar(k-1)-gamma(k)*tbar(k))*rdlref(k)
+     pm(k,k     )=(delta(k     )*tbar(k     )-beta(k+1)*tbar(k+1))*rdlref(k)
+  end do
+  k=nsig
+  pm(k,k-1)=(alpha(k-1)*tbar(k-1)-gamma(k)*tbar(k))*rdlref(k)
+
+! BMAT+ = PM*WTM:
+  do i=1,nsig
+     do k=1,nsig
+        do j=1,nsig-1
+
+!          ***NOTE:  NOT SURE ABOUT THIS PART??
+!          bmat(k,i)=bmat(k,i)+pm(k,j)*wtm(j,i)
+
+        end do
+     end do
+  end do
+
+  return
+end subroutine get_semimp_mats
+
+
+      subroutine iminv (a,n,d,l,m)                                              
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    iminv    invert a matrix
+!
+!   prgrmmr:
+!
+! abstract:      the standard gauss-jordan method is used. the determinant           
+!                is also calculated. a determinant of zero indicates that            
+!                the matrix is singular.                                             
+!                                                                               
+! remarks        matrix a must be a general matrix                                   
+!
+! program history log:
+!   2008-06-04  safford -- add subprogram doc block
+!
+!   input argument list:
+!     a - input matrix, destroyed in computation and replaced by resultant inverse
+!     n - order of matrix a                                               
+!     d - resultant determinant                                           
+!     l - work vector of length n                                         
+!     m - work vector of length n                                         
+!
+!   output argument list:
+!     a - input matrix, destroyed in computation and replaced by resultant inverse
+!
+! attributes:
+!   language:  f90
+!   machine:   ibm RS/6000 SP
+!
+!$$$ end documentation block
+
+        use m_kinds,only: r_kind,i_kind
+        use constants,only: zero,one
+        implicit none
+
+        integer(i_kind)             ,intent(in   ) :: n
+        integer(i_kind),dimension(n),intent(inout) :: l,m
+        real(r_kind)                ,intent(inout) :: d
+        real(r_kind),dimension(n*n) ,intent(inout) :: a
+
+        integer(i_kind):: nk,k,j,iz,i,ij
+        integer(i_kind):: kj,ik,jr,jq,jk,ki,kk,jp,ji
+
+        real(r_kind):: biga,hold
+!                                                                               
+!        if a double precision version of this routine is desired, the          
+!        ! in column 1 should be removed from the double precision              
+!        statement which follows.                                               
+!                                                                               
+!     double precision a, d, biga, hold                                         
+!                                                                               
+!        the ! must also be removed from double precision statements            
+!        appearing in other routines used in conjunction with this              
+!        routine.                                                               
+!                                                                               
+!        the double precision version of this sr........ must also              
+!        contain double precision fortran functions.  abs in statemen           
+!        10 must be changed to dabs  .                                          
+!                                                                               
+!        ...............................................................        
+!                                                                               
+!        search for largest element                                             
+!                                                                               
+         d=one
+         nk=-n
+         do 80 k=1,n
+            nk=nk+n
+            l(k)=k
+            m(k)=k
+            kk=nk+k
+            biga=a(kk)
+            do 20 j=k,n
+               iz=n*(j-1)
+               do 20 i=k,n
+                  ij=iz+i
+!  10             if (dabs(biga)-dabs(a(ij))) 15,20,20
+   10             if(abs(biga)-abs(a(ij))) 15,20,20
+   15             biga=a(ij)
+                  l(k)=i
+                  m(k)=j
+   20       continue
+!
+!        interchange rows
+!
+            j=l(k)
+            if(j-k) 35,35,25
+   25       ki=k-n
+            do 30 i=1,n
+               ki=ki+n
+               hold=-a(ki)
+               ji=ki-k+j
+               a(ki)=a(ji)
+   30          a(ji) =hold
+!
+!        interchange columns
+!
+   35          i=m(k)
+               if(i-k) 45,45,38
+   38          jp=n*(i-1)
+               do 40 j=1,n
+                  jk=nk+j
+                  ji=jp+j
+                  hold=-a(jk)
+                  a(jk)=a(ji)
+   40             a(ji) =hold
+!
+!        divide column by minus pivot (value of pivot element is
+!        contained in biga)
+!
+   45             if(biga) 48,46,48
+   46             d=zero 
+                  return
+   48             do 55 i=1,n
+                     if(i-k) 50,55,50
+   50                ik=nk+i
+                     a(ik)=a(ik)/(-biga)
+   55             continue
+!
+!        reduce matrix
+!
+                  do 65 i=1,n
+                     ik=nk+i
+                     ij=i-n
+                     do 65 j=1,n
+                        ij=ij+n
+                        if(i-k) 60,65,60
+   60                   if(j-k) 62,65,62
+   62                   kj=ij-i+k
+                        a(ij)=a(ik)*a(kj)+a(ij)
+   65             continue
+!
+!        divide row by pivot
+!
+                  kj=k-n
+                  do 75 j=1,n
+                     kj=kj+n
+                     if(j-k) 70,75,70
+   70                a(kj)=a(kj)/biga
+   75             continue
+!
+!        product of pivots
+!
+                  d=d*biga
+!
+!        replace pivot by reciprocal
+!
+                  a(kk)=one/biga
+   80    continue
+!
+!        final row and column interchange
+!
+         k=n
+         do 
+  100       k=(k-1)
+            if(k) 150,150,105
+  105       i=l(k)
+            if(i-k) 120,120,108
+  108       jq=n*(k-1)
+            jr=n*(i-1)
+            do 110 j=1,n
+               jk=jq+j
+               hold=a(jk)
+               ji=jr+j
+               a(jk)=-a(ji)
+               a(ji) =hold
+  110       continue
+  120       j=m(k)
+            if(j-k) 100,100,125
+  125       ki=k-n
+            do 130 i=1,n
+               ki=ki+n
+               hold=a(ki)
+               ji=ki-k+j
+               a(ki)=-a(ji)
+               a(ji) =hold
+  130       continue
+         end do
+  150    return
+      end subroutine iminv

--- a/src/gsibec/gsi/gsimod.F90
+++ b/src/gsibec/gsi/gsimod.F90
@@ -82,9 +82,11 @@
 
   use gsi_io, only: init_io, verbose
 
-  use mod_vtrans, only: nvmodes_keep,init_vtrans
+  use mod_vtrans, only: nvmodes_keep,init_vtrans,destroy_vtrans
   use mod_strong, only: reg_tlnmc_type,l_tlnmc,nstrong,tlnmc_option,&
-       period_max,period_width,init_strongvars,baldiag_full,baldiag_inc
+       period_max,period_width,baldiag_full,baldiag_inc, &
+       init_strongvars ! RT: this needs attention
+  use turblmod, only: create_turblvars
 
   implicit none
 
@@ -684,13 +686,14 @@
      if(mype==0)then
        write(6,*)' pseudo-q2 = ', pseudo_q2, ' qoption = ', qoption
        write(6,*)' pseudo-q2 must be used together w/ qoption=2 only, aborting.'
-       call die(myname_,'consistency(q2)',999)  
      endif
+     call die(myname_,'consistency(q2)',999)  
   endif
 
   if (qoption==2.or.l_tlnmc) then
      tendsflag =.true.
      switch_on_derivatives = .true.
+     if (mype==0) write(6,*)'GSIMOD:  tendencies and derivatives are on'
   endif
 
 ! Initialize variables, create/initialize arrays
@@ -702,6 +705,9 @@
   call init_general_commvars_dims (cvars2d,cvars3d,cvarsmd,nrf_var, &
                                    dvars2d,dvars3d)
   call init_general_commvars
+  if (tendsflag) then
+     call create_turblvars()
+  endif
 
   if(mype==0)then
     write(6,*) myname_, ': Complete'
@@ -805,6 +811,7 @@
   integer :: ier
 ! Deallocate arrays
 
+  call destroy_vtrans
   call destroy_ges_tendencies
   call destroy_ges_derivatives
 ! call final_reg_glob_ll ! if ever regional

--- a/src/gsibec/gsi/gsimod.F90
+++ b/src/gsibec/gsi/gsimod.F90
@@ -82,6 +82,10 @@
 
   use gsi_io, only: init_io, verbose
 
+  use mod_vtrans, only: nvmodes_keep,init_vtrans
+  use mod_strong, only: reg_tlnmc_type,l_tlnmc,nstrong,tlnmc_option,&
+       period_max,period_width,init_strongvars,baldiag_full,baldiag_inc
+
   implicit none
 
   private
@@ -408,6 +412,31 @@
 	bkgv_flowdep,bkgv_rewgtfct,bkgv_write,fpsproj,adjustozvar,fut2ps,cwcoveqqcov,adjustozhscl,&
         simcv,bkgv_write_cv,bkgv_write_sv
 
+! STRONGOPTS (strong dynamic constraint)
+!     reg_tlnmc_type -  =1 for 1st version of regional strong constraint
+!                       =2 for 2nd version of regional strong constraint
+!     nstrong  - if > 0, then number of iterations of implicit normal mode initialization
+!                   to apply for each inner loop iteration
+!     period_max     - cutoff period for gravity waves included in implicit normal mode
+!                    initialization (units = hours)
+!     period_width   - defines width of transition zone from included to excluded gravity waves
+!     period_max - cutoff period for gravity waves included in implicit normal mode
+!                   initialization (units = hours)
+!     period_width - defines width of transition zone from included to excluded gravity waves
+!     nvmodes_keep - number of vertical modes to use in implicit normal mode initialization
+!     baldiag_full
+!     baldiag_inc
+!     tlnmc_option : integer flag for strong constraint (various capabilities for hybrid)
+!                   =0: no TLNMC
+!                   =1: TLNMC for 3DVAR mode
+!                   =2: TLNMC on total increment for single time level only (for 3D EnVar)
+!                       or if 4D EnVar mode, TLNMC applied to increment in center of window
+!                   =3: TLNMC on total increment over all time levels (if in 4D EnVar mode)
+!                   =4: TLNMC on static contribution to increment ONLY for any EnVar mode
+
+  namelist/strongopts/tlnmc_option, &
+                      nstrong,period_max,period_width,nvmodes_keep, &
+                      baldiag_full,baldiag_inc
 
 ! HYBRID_ENSEMBLE (parameters for use with hybrid ensemble option)
 !     l_hyb_ens     - if true, then turn on hybrid ensemble option
@@ -540,6 +569,8 @@
   call init_grid
   call init_compact_diffs
   call init_smooth_polcas
+  call init_strongvars
+  call init_vtrans
   call init_hybrid_ensemble_parameters
   call set_fgrid2agrid
   call init_4dvar
@@ -560,6 +591,13 @@
   open(11,file=thisrc)
   read(11,bkgerr,iostat=ios)
   if(ios/=0) call die(myname_,'read(bkgerr)',ios)
+  close(11)
+
+  open(11,file=thisrc)
+  read(11,strongopts,iostat=ios)
+  if(ios/=0) then
+    call die(myname_,'read(strongopts)',ios)
+  endif
   close(11)
 
   open(11,file=thisrc)
@@ -610,6 +648,37 @@
      write(6,hybrid_ensemble)
   endif
 
+! Consistency check for TLNMC options
+  if(reg_tlnmc_type>0) then
+     call die(myname_,'regional optional not available',999)  
+  endif
+  if (tlnmc_option>=2 .and. tlnmc_option<=4) then
+     if (.not.l_hyb_ens) then
+     if(mype==0) write(6,*)' GSIMOD: inconsistent set of options for Hybrid/EnVar & TLNMC = ',l_hyb_ens,tlnmc_option
+     if(mype==0) write(6,*)' GSIMOD: resetting tlnmc_option to 1 for 3DVAR mode'
+     tlnmc_option=1
+     end if
+  else if (tlnmc_option<0 .or. tlnmc_option>4) then
+     if(mype==0) write(6,*)' GSIMOD: This option does not yet exist for tlnmc_option: ',tlnmc_option
+     if(mype==0) write(6,*)' GSIMOD: Reset to default 0'
+     tlnmc_option=0
+  end if
+  if (tlnmc_option>0 .and. tlnmc_option<5) then
+     l_tlnmc=.true.
+     if(mype==0) write(6,*)' GSIMOD: valid TLNMC option chosen, setting l_tlnmc logical to true'
+  end if
+
+! If strong constraint is turned off, force other strong constraint variables to zero
+  if ((.not.l_tlnmc) .and. nstrong/=0 ) then
+     nstrong=0
+     if (mype==0) write(6,*)'GSIMOD:  reset nstrong=',nstrong,&
+          ' because TLNMC option is set to off= ',tlnmc_option
+  endif
+  if (.not.l_tlnmc) then
+     baldiag_full=.false.
+     baldiag_inc =.false.
+  end if
+
 ! check consistency in q option
   if(pseudo_q2 .and. qoption==1)then
      if(mype==0)then
@@ -619,8 +688,7 @@
      endif
   endif
 
-! if (qoption==2.or.l_tlnmc) then
-  if (qoption==2) then
+  if (qoption==2.or.l_tlnmc) then
      tendsflag =.true.
      switch_on_derivatives = .true.
   endif

--- a/src/gsibec/gsi/guess_grids.f90
+++ b/src/gsibec/gsi/guess_grids.f90
@@ -14,8 +14,9 @@ use gsi_metguess_mod, only: gsi_metguess_bundle
 use gsi_metguess_mod, only: gsi_metguess_get
 use gsi_metguess_mod, only: gsi_metguess_create_grids
 use gsi_metguess_mod, only: gsi_metguess_destroy_grids
-use tendsmod, only: create_ges_tendencies
-use derivsmod, only: create_ges_derivatives
+use mod_vtrans, only: nvmodes_keep,create_vtrans
+use mod_strong, only: l_tlnmc
+use strong_fast_global_mod, only: init_strongvars
 implicit none
 private
 !
@@ -229,6 +230,15 @@ subroutine bkgcov_init_(need)
   logical, save :: init_pass = .true.
   call other_set_(need=need)  ! a little out of place, but ...
   call compute_derived(mype,init_pass) ! this belongs in a state set
+  if (l_tlnmc .and. nvmodes_keep>0) then
+     call create_vtrans(mype)
+!    if(regional) then
+!       if(reg_tlnmc_type==1) call zrnmi_initialize(mype)
+!       if(reg_tlnmc_type==2) call fmg_initialize_e(mype)
+!    else
+        call init_strongvars(mype)
+!    end if
+  end if
   init_pass = .false.
   gesgrid_initialized_ = .true.
 end subroutine bkgcov_init_

--- a/src/gsibec/gsi/guess_grids.f90
+++ b/src/gsibec/gsi/guess_grids.f90
@@ -231,7 +231,7 @@ subroutine bkgcov_init_(need)
   call other_set_(need=need)  ! a little out of place, but ...
   call compute_derived(mype,init_pass) ! this belongs in a state set
   if (l_tlnmc .and. nvmodes_keep>0) then
-     call create_vtrans(mype)
+     call create_vtrans(mype,ntguessig)
 !    if(regional) then
 !       if(reg_tlnmc_type==1) call zrnmi_initialize(mype)
 !       if(reg_tlnmc_type==2) call fmg_initialize_e(mype)

--- a/src/gsibec/gsi/mod_strong.f90
+++ b/src/gsibec/gsi/mod_strong.f90
@@ -1,0 +1,1270 @@
+module mod_strong
+!$$$   module documentation block
+!                .      .    .                                       .
+! module:  mod_strong
+! prgmmr:  parrish            org: np23               date: 2007-02-15
+!
+! abstract: high level module for carrying all parameters used for various
+!           flavors of strong constraint.
+!           Implement implicit normal mod initialization routines for
+!           use with analysis increment and analysis increment tendencies.
+!           reference: Temperton, C., 1989:  "Implicit Normal Mode Initialization
+!                           for Spectral Models", .  MWR, 117, 436-451.
+!
+! program history log:
+!   2007-02-15 parrish
+!   2012-02-08 kleist - add option tlnmc_option to control how TLNMC is applied
+!   2013-07-02 parrish - change tlnmc_type to reg_tlnmc_type.  tlnmc_type no
+!                          longer used for global application of tlnmc.
+!   2014-12-03  derber  - remove unused variables
+!
+! Subroutines Included:
+!   sub init_strongvars  - set default namelist variable values
+!   sub gproj            - project input u,v,mass variable to gravity modes for
+!   update
+!   sub gproj_diag       - project input u,v,mass variable to gravity modes plus
+!   diagnostics
+!   sub gproj_diag_update- project input u,v,mass variable to gravity modes plus
+!   diagnostic and update
+!   sub gproj0           -
+!   sub gproj_ad         -
+!   sub dinmi            - obtain balance increment from input tendencies
+!   sub dinmi_ad         - adjoint of dinmi
+!   sub dinmi0           - lower level--balance increment from input tendencies
+!   sub balm_1           - compute balance diagnostic variable
+!   sub getbcf           - compute matrices B,C,F as defined in above reference
+!   sub scale_vars       - scale variables as defined in reference
+!   sub scale_vars_ad    - adjoint of scale variables
+!   sub unscale_vars     - unscale variables
+!   sub unscale_vars_ad  - adjoint of unscale variables
+!   sub f_mult           - multiply by F matrix
+!   sub c_mult           - multiply by C matrix
+!   sub i_mult           - multiply by sqrt(-1)
+!   sub solve_f2c2       - solve (F*F+C*C)*x = y
+!
+! Variable Definitions:
+!   def l_tlnmc          - Logical for TLNMC (set to true if namelist option tlnmc_option
+!                          is 1, 2, or 3
+!   def reg_tlnmc_type   - =1 for regional 1st version of strong constraint
+!                          =2 for regional 2nd version of strong constraint
+!   def nstrong          - number of iterations of strong constraint initialization
+!   def scheme           - which scheme (B, C or D) is being used (see reference above)
+!   def period_max       - max period (hours) of gravity modes to be balanced
+!   def period_width     - width of smooth transition (hours, centered on period_max)
+!                          from balanced to unbalanced gravity modes
+!   def baldiag_full     - flag to toggle balance diagnostics for the full fields
+!   def baldiag_inc      - flag to toggle balance diagnostics for the analysis increment
+!   def tlnmc_option - Integer option for Incremental Normal Mode Constraint (inmc) / TLNMC
+!                            when in hybrid ensemble mode:
+!                          =0: no constraint at all
+!                          =1: TLNMC on static contribution to increment (or if non-hybrid)
+!                          =2: TLNMC on total increment (single time level only, or 3D mode)
+!                          =3: TLNMC on total increment over all nobs_bins (if 4D mode)
+! attributes:
+!   language: f90
+!   machine:  ibm RS/6000 SP
+!
+!$$$ end documentation block
+
+use m_kinds,only: r_kind,i_kind
+use constants, only: zero,half,one,two,four,r3600,omega,pi,rearth,one_tenth
+implicit none
+
+! set default to private
+  private
+! set subroutines to public
+  public :: init_strongvars
+  public :: gproj
+  public :: gproj_diag
+  public :: gproj_diag_update
+  public :: gproj0
+  public :: gproj_ad
+  public :: dinmi
+  public :: dinmi_ad
+  public :: dinmi0
+  public :: balm_1
+  public :: getbcf
+  public :: scale_vars
+  public :: scale_vars_ad
+  public :: unscale_vars
+  public :: unscale_vars_ad
+  public :: f_mult
+  public :: c_mult
+  public :: i_mult
+  public :: solve_f2c2
+
+! set passed variables to public
+  public :: nstrong,baldiag_full,l_tlnmc,baldiag_inc,period_width,period_max,scheme
+  public :: reg_tlnmc_type
+  public :: tlnmc_option
+
+  integer(i_kind) nstrong
+  integer(i_kind) reg_tlnmc_type,tlnmc_option
+  real(r_kind) period_max,period_width
+  logical l_tlnmc,baldiag_full,baldiag_inc
+  character(1) scheme
+
+contains
+
+
+  subroutine init_strongvars
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    init_strongvars
+!
+!   prgrmmr:
+!
+! abstract:
+!
+! program history log:
+!   2008-05-05  safford -- add subprogram doc block
+!   2013-07-02 parrish - change tlnmc_type to reg_tlnmc_type.  Set default for reg_tlnmc_type = 1.
+!
+!   input argument list:
+!
+!   output argument list:
+!
+! attributes:
+!   language:  f90
+!   machine:   ibm RS/6000 SP
+!
+!$$$ end documentation block
+
+    implicit none
+
+    l_tlnmc=.false.
+    reg_tlnmc_type=0
+    tlnmc_option=0
+    nstrong=0
+    period_max=1000000._r_kind
+    period_width=one_tenth
+    scheme='B'
+    baldiag_full=.false.
+    baldiag_inc =.false.
+
+  end subroutine init_strongvars
+          
+
+  subroutine gproj_diag_update(vort,div,phi,vort_g,div_g,phi_g,rmstend,rmstend_g,rmstend_f,rmstend_fg, &
+         m,mmax,gspeed)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    gproj
+!
+!   prgrmmr:
+!
+! abstract:    
+!         for gravity wave projection:    vort, div, phi --> vort_g, div_g, phi_g
+!
+!         scale:      vort,div,phi --> vort_hat,div_hat,phi_hat
+!
+!         solve:     (F*F+C*C)*x = F*vort_hat + C*phi_hat
+!         then:
+!               phi_hat_g = C*x
+!              vort_hat_g = F*x
+!               div_hat_g = div_hat
+!
+!         unscale:    vort_hat_g, div_hat_g, phi_hat_g --> vort_g, div_g, phi_g
+!
+! program history log:
+!   2008-05-05  safford -- add subprogram doc block, rm unused uses
+!
+!   input argument list:
+!     vort,div,phi
+!     rmstend,rmstend_g
+!     filtered
+!
+!   output argument list:
+!     vort_g,div_g,phi_g
+!     rmstend,rmstend_g
+!
+! attributes:
+!   language:  f90
+!   machine:   ibm RS/6000 SP
+!
+!$$$ end documentation block
+
+    implicit none
+
+    real(r_kind),intent(in   ),dimension(2,m:mmax):: vort,div,phi
+    real(r_kind),intent(  out),dimension(2,m:mmax):: vort_g,div_g,phi_g
+    real(r_kind),intent(in   ) :: gspeed
+    real(r_kind),intent(inout) :: rmstend,rmstend_g,rmstend_f,rmstend_fg
+    integer(i_kind),intent(in) :: m,mmax
+
+    real(r_kind),dimension(2,m:mmax):: vort_hat,div_hat,phi_hat,vort_hat_g,phi_hat_g
+    real(r_kind),dimension(m:mmax):: b,c,f,c2,c3
+
+    call getbcf(b,c,f,c2,c3,m,mmax,gspeed)
+    call scale_vars(vort,div,phi,vort_hat,div_hat,phi_hat,.false.,c2,c3,m,mmax,gspeed)
+    call balm_1(vort_hat,div_hat,phi_hat,rmstend,m,mmax)
+
+    call gproj0(vort_hat,phi_hat,vort_hat_g,phi_hat_g,c,f,m,mmax)
+    call balm_1(vort_hat_g,div_hat,phi_hat_g,rmstend_g,m,mmax)
+
+    call scale_vars(vort,div,phi,vort_hat,div_hat,phi_hat,.true.,c2,c3,m,mmax,gspeed)
+    call balm_1(vort_hat,div_hat,phi_hat,rmstend_f,m,mmax)
+
+    call gproj0(vort_hat,phi_hat,vort_hat_g,phi_hat_g,c,f,m,mmax)
+    call balm_1(vort_hat_g,div_hat,phi_hat_g,rmstend_fg,m,mmax)
+
+    call unscale_vars(vort_hat_g,div_hat,phi_hat_g,vort_g,div_g,phi_g,c2,c3,m,mmax)
+
+  end subroutine gproj_diag_update
+  subroutine gproj_diag(vort,div,phi,rmstend,rmstend_g,rmstend_f,rmstend_fg,&
+         m,mmax,gspeed)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    gproj
+!
+!   prgrmmr:
+!
+! abstract:    
+!         for gravity wave projection:    vort, div, phi --> vort_g, div_g, phi_g
+!
+!         scale:      vort,div,phi --> vort_hat,div_hat,phi_hat
+!
+!         solve:     (F*F+C*C)*x = F*vort_hat + C*phi_hat
+!         then:
+!               phi_hat_g = C*x
+!              vort_hat_g = F*x
+!               div_hat_g = div_hat
+!
+!         unscale:    vort_hat_g, div_hat_g, phi_hat_g --> vort_g, div_g, phi_g
+!
+! program history log:
+!   2008-05-05  safford -- add subprogram doc block, rm unused uses
+!
+!   input argument list:
+!     vort,div,phi
+!     rmstend,rmstend_g
+!     filtered
+!
+!   output argument list:
+!     vort_g,div_g,phi_g
+!     rmstend,rmstend_g
+!
+! attributes:
+!   language:  f90
+!   machine:   ibm RS/6000 SP
+!
+!$$$ end documentation block
+
+    implicit none
+
+    real(r_kind),intent(in   ),dimension(2,m:mmax):: vort,div,phi
+    real(r_kind),intent(in   ) :: gspeed
+    real(r_kind),intent(inout) :: rmstend,rmstend_g,rmstend_f,rmstend_fg
+    integer(i_kind),intent(in) :: m,mmax
+
+    real(r_kind),dimension(2,m:mmax):: vort_hat,div_hat,phi_hat,vort_hat_g,phi_hat_g
+    real(r_kind),dimension(m:mmax):: b,c,f,c2,c3
+
+    call getbcf(b,c,f,c2,c3,m,mmax,gspeed)
+    call scale_vars(vort,div,phi,vort_hat,div_hat,phi_hat,.false.,c2,c3,m,mmax,gspeed)
+    call balm_1(vort_hat,div_hat,phi_hat,rmstend,m,mmax)
+
+    call gproj0(vort_hat,phi_hat,vort_hat_g,phi_hat_g,c,f,m,mmax)
+    call balm_1(vort_hat_g,div_hat,phi_hat_g,rmstend_g,m,mmax)
+
+    call scale_vars(vort,div,phi,vort_hat,div_hat,phi_hat,.true.,c2,c3,m,mmax,gspeed)
+    call balm_1(vort_hat,div_hat,phi_hat,rmstend_f,m,mmax)
+
+    call gproj0(vort_hat,phi_hat,vort_hat_g,phi_hat_g,c,f,m,mmax)
+    call balm_1(vort_hat_g,div_hat,phi_hat_g,rmstend_fg,m,mmax)
+
+  end subroutine gproj_diag
+  subroutine gproj(vort,div,phi,vort_g,div_g,phi_g,m,mmax,gspeed)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    gproj
+!
+!   prgrmmr:
+!
+! abstract:    
+!         for gravity wave projection:    vort, div, phi --> vort_g, div_g, phi_g
+!
+!         scale:      vort,div,phi --> vort_hat,div_hat,phi_hat
+!
+!         solve:     (F*F+C*C)*x = F*vort_hat + C*phi_hat
+!         then:
+!               phi_hat_g = C*x
+!              vort_hat_g = F*x
+!               div_hat_g = div_hat
+!
+!         unscale:    vort_hat_g, div_hat_g, phi_hat_g --> vort_g, div_g, phi_g
+!
+! program history log:
+!   2008-05-05  safford -- add subprogram doc block, rm unused uses
+!
+!   input argument list:
+!     vort,div,phi
+!     rmstend,rmstend_g
+!     filtered
+!
+!   output argument list:
+!     vort_g,div_g,phi_g
+!     rmstend,rmstend_g
+!
+! attributes:
+!   language:  f90
+!   machine:   ibm RS/6000 SP
+!
+!$$$ end documentation block
+
+    implicit none
+
+    real(r_kind),intent(in   ),dimension(2,m:mmax):: vort,div,phi
+    real(r_kind),intent(  out),dimension(2,m:mmax):: vort_g,div_g,phi_g
+    real(r_kind),intent(in   ) :: gspeed
+    integer(i_kind),intent(in) :: m,mmax
+
+    real(r_kind),dimension(2,m:mmax):: vort_hat,div_hat,phi_hat,vort_hat_g,phi_hat_g
+    real(r_kind),dimension(m:mmax):: b,c,f,c2,c3
+
+    call getbcf(b,c,f,c2,c3,m,mmax,gspeed)
+    call scale_vars(vort,div,phi,vort_hat,div_hat,phi_hat,.true.,c2,c3,m,mmax,gspeed)
+
+    call gproj0(vort_hat,phi_hat,vort_hat_g,phi_hat_g,c,f,m,mmax)
+
+    call unscale_vars(vort_hat_g,div_hat,phi_hat_g,vort_g,div_g,phi_g,c2,c3,m,mmax)
+
+  end subroutine gproj
+
+
+  subroutine gproj0(vort_hat,phi_hat,vort_hat_g,phi_hat_g,c,f,m,mmax)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    gproj0
+!
+!   prgrmmr:
+!
+! abstract:
+!  for gravity wave projection: vort,div,phi --> vort_g,div_g,phi_g
+!  -----------------------------------------------------------------------------
+!
+!    solve:  (F*F+C*C)*x = F*vort_hat + C*phi_hat
+!
+!    then:
+!          phi_hat_g  = C*x
+!         vort_hat_g  = F*x
+!          div_hat_g  = div_hat
+!         
+! program history log:
+!   2008-05-05  safford -- add subprogram doc block, rm unused uses
+!               
+!   input argument list:
+!     vort_hat,div_hat,phi_hat
+!
+!   output argument list:
+!     vort_hat_g,div_hat_g,phi_hat_g
+!   
+! attributes:
+!   language:  f90
+!   machine:   ibm RS/6000 SP
+!   
+!$$$ end documentation block
+
+    implicit none
+
+    real(r_kind),dimension(2,m:mmax),intent(in   ) :: vort_hat,phi_hat
+    real(r_kind),dimension(  m:mmax),intent(in   ) :: c,f
+    real(r_kind),dimension(2,m:mmax),intent(  out) :: vort_hat_g,phi_hat_g
+    integer(i_kind),intent(in) :: m,mmax
+
+    real(r_kind),dimension(2,m:mmax):: x,y
+
+
+    call f_mult(y,vort_hat,f,m,mmax)
+    call c_mult(x,phi_hat,c,m,mmax)
+    y=y+x
+    call solve_f2c2(x,y,f,c,m,mmax)
+    call c_mult(phi_hat_g,x,c,m,mmax)
+    call f_mult(vort_hat_g,x,f,m,mmax)
+
+  end subroutine gproj0
+
+
+  subroutine gproj_ad(vort,div,phi,vort_g,div_g,phi_g,m,mmax,gspeed)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    gproj_ad
+!
+!   prgrmmr:
+!
+! abstract:
+!    for gravity wave projection: vort,div,phi --> vort_g,div_g,phi_g
+!
+!    scale:      vort,div,phi --> vort_hat,div_hat,phi_hat
+!
+!    solve:  (F*F+C*C)*x = F*vort_hat + C*phi_hat
+!
+!    then:
+!               phi_hat_g = C*x
+!              vort_hat_g = F*x
+!               div_hat_g = div_hat
+!
+!      unscale:    vort_hat_g, div_hat_g, phi_hat_g --> vort_g, div_g, phi_g
+!         
+! program history log:
+!   2008-05-05  safford -- add subprogram doc block, rm unused uses
+!               
+!   input argument list:
+!     vort,div,phi
+!     vort_g,div_g,phi_g
+!
+!   output argument list:
+!     vort,div,phi
+!   
+! attributes:
+!   language:  f90
+!   machine:   ibm RS/6000 SP
+!   
+!$$$ end documentation block
+
+    implicit none
+
+    real(r_kind),intent(inout),dimension(2,m:mmax) :: vort,div,phi
+    real(r_kind),intent(in   ),dimension(2,m:mmax) :: vort_g,div_g,phi_g
+    real(r_kind),intent(in   )                     :: gspeed
+    integer(i_kind),intent(in) :: m,mmax
+
+    real(r_kind),dimension(2,m:mmax)::vort_hat,div_hat,phi_hat,vort_hat_g,phi_hat_g
+    real(r_kind),dimension(m:mmax):: b,c,f,c2,c3
+
+    call getbcf(b,c,f,c2,c3,m,mmax,gspeed)
+    call unscale_vars_ad(vort_hat_g,div_hat,phi_hat_g,vort_g,div_g,phi_g,c2,c3,m,mmax)
+    call gproj0(vort_hat_g,phi_hat_g,vort_hat,phi_hat,c,f,m,mmax)
+    call scale_vars_ad(vort,div,phi,vort_hat,div_hat,phi_hat,c2,c3,m,mmax,gspeed)
+
+  end subroutine gproj_ad
+
+
+  subroutine dinmi(vort_t,div_t,phi_t,del_vort,del_div,del_phi,m,mmax,gspeed)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    dinmi
+!
+!   prgrmmr:
+!
+! abstract:
+!      for implicit nmi correction: vort_t,div_t,phi_t --> del_vort,del_div,del_phi
+!
+!      scale:      vort_t,div_t,phi_t --> vort_t_hat,div_t_hat,phi_t_hat
+!
+!      solve:  (F*F+C*C)*del_div_hat = sqrt(-1)*(F*vort_t_hat + C*phi_t_hat)
+!
+!      solve:  (F*F+C*C)*x = sqrt(-1)*div_t_hat - B*del_div_hat
+!
+!      then:
+!            del_phi_hat  = C*x
+!            del_vort_hat = F*x
+!
+!      unscale: del_vort_hat,del_div_hat,del_phi_hat --> del_vort,del_div,del_phi
+!         
+! program history log:
+!   2008-05-05  safford -- add subprogram doc block, rm unused uses
+!               
+!   input argument list:
+!     vort_t,div_t,phi_t
+!
+!   output argument list:
+!     del_vort,del_div,del_phi
+!   
+! attributes:
+!   language:  f90
+!   machine:   ibm RS/6000 SP
+!   
+!$$$ end documentation block
+
+    implicit none
+
+    real(r_kind),intent(in   ),dimension(2,m:mmax):: vort_t,div_t,phi_t
+    real(r_kind),intent(  out),dimension(2,m:mmax):: del_vort,del_div,del_phi
+    real(r_kind),intent(in   ):: gspeed
+    integer(i_kind),intent(in) :: m,mmax
+
+    real(r_kind),dimension(2,m:mmax):: vort_t_hat,div_t_hat,phi_t_hat
+    real(r_kind),dimension(2,m:mmax):: del_vort_hat,del_div_hat,del_phi_hat
+    real(r_kind),dimension(m:mmax):: b,c,f,c2,c3
+
+    call getbcf(b,c,f,c2,c3,m,mmax,gspeed)
+    call scale_vars(vort_t,div_t,phi_t,vort_t_hat,div_t_hat,phi_t_hat,.true.,c2,c3,m,mmax,gspeed)
+    call dinmi0(vort_t_hat,div_t_hat,phi_t_hat,del_vort_hat,del_div_hat,del_phi_hat,b,c,f,m,mmax)
+
+    call unscale_vars(del_vort_hat,del_div_hat,del_phi_hat,del_vort,del_div,del_phi,c2,c3,m,mmax)
+
+  end subroutine dinmi
+
+
+  subroutine dinmi_ad(vort_t,div_t,phi_t,del_vort,del_div,del_phi,m,mmax,gspeed)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    dinmi_ad
+!
+!   prgrmmr:
+!
+! abstract:
+!       for implicit nmi correction: vort_t,div_t,phi_t --> del_vort,del_div,del_phi
+!
+!       scale:      vort_t,div_t,phi_t --> vort_t_hat,div_t_hat,phi_t_hat
+!
+!       solve:  (F*F+C*C)*del_div_hat = sqrt(-1)*(F*vort_t_hat + C*phi_t_hat)
+!
+!       solve:  (F*F+C*C)*x = sqrt(-1)*div_t_hat - B*del_div_hat
+!
+!       then:
+!          del_phi_hat  = C*x
+!          del_vort_hat = F*x
+!
+!       unscale: del_vort_hat,del_div_hat,del_phi_hat --> del_vort,del_div,del_phi
+!         
+! program history log:
+!   2008-05-05  safford -- add subprogram doc block, rm unused uses
+!               
+!   input argument list:
+!    del_vort,del_div,del_phi
+!    vort_t,div_t,phi_t
+!
+!   output argument list:
+!    vort_t,div_t,phi_t
+!   
+! attributes:
+!   language:  f90
+!   machine:   ibm RS/6000 SP
+!   
+!$$$ end documentation block
+    implicit none
+
+    real(r_kind),intent(inout),dimension(2,m:mmax):: vort_t,div_t,phi_t
+    real(r_kind),intent(in   ),dimension(2,m:mmax):: del_vort,del_div,del_phi
+    real(r_kind),intent(in   ):: gspeed
+    integer(i_kind),intent(in) :: m,mmax
+
+    real(r_kind),dimension(2,m:mmax):: vort_t_hat,div_t_hat,phi_t_hat
+    real(r_kind),dimension(2,m:mmax):: del_vort_hat,del_div_hat,del_phi_hat
+    real(r_kind),dimension(m:mmax):: b,c,f,c2,c3
+    integer(i_kind) n
+
+    call getbcf(b,c,f,c2,c3,m,mmax,gspeed)
+    call unscale_vars_ad(del_vort_hat,del_div_hat,del_phi_hat,del_vort,del_div,del_phi,c2,c3,m,mmax)
+    call dinmi0(del_vort_hat,del_div_hat,del_phi_hat,vort_t_hat,div_t_hat,phi_t_hat,b,c,f,m,mmax)
+    do n=m,mmax
+       vort_t_hat(1,n)=-vort_t_hat(1,n)
+       vort_t_hat(2,n)=-vort_t_hat(2,n)
+       div_t_hat(1,n)=-div_t_hat(1,n)
+       div_t_hat(2,n)=-div_t_hat(2,n)
+       phi_t_hat(1,n)=-phi_t_hat(1,n)
+       phi_t_hat(2,n)=-phi_t_hat(2,n)
+    end do
+    call scale_vars_ad(vort_t,div_t,phi_t,vort_t_hat,div_t_hat,phi_t_hat,c2,c3,m,mmax,gspeed)
+
+  end subroutine dinmi_ad
+
+
+  subroutine dinmi0(vort_t_hat,div_t_hat,phi_t_hat,del_vort_hat,del_div_hat,del_phi_hat,b,c,f,&
+         m,mmax)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    dinmi0
+!
+!   prgrmmr:
+!
+! abstract:
+!      for implicit nmi correction: vort_t,div_t,phi_t --> del_vort,del_div,del_phi
+!
+!      solve:  (F*F+C*C)*del_div_hat = sqrt(-1)*(F*vort_t_hat + C*phi_t_hat)
+!
+!      solve:  (F*F+C*C)*x = sqrt(-1)*div_t_hat - B*del_div_hat
+!
+!      then:
+!          del_phi_hat  = C*x
+!          del_vort_hat = F*x
+!         
+! program history log:
+!   2008-05-05  safford -- add subprogram doc block, rm unused uses
+!               
+!   input argument list:
+!    vort_t_hat,div_t_hat,phi_t_hat
+!
+!   output argument list:
+!    del_vort_hat,del_div_hat,del_phi_hat
+!   
+! attributes:
+!   language:  f90
+!   machine:   ibm RS/6000 SP
+!   
+!$$$ end documentation block
+
+    implicit none
+
+    real(r_kind),dimension(2,m:mmax),intent(in   ) :: vort_t_hat,div_t_hat,phi_t_hat
+    real(r_kind),dimension(  m:mmax),intent(in   ) :: b,c,f
+    real(r_kind),dimension(2,m:mmax),intent(  out) :: del_vort_hat,del_div_hat,del_phi_hat
+    integer(i_kind),intent(in)::m,mmax
+
+    real(r_kind),dimension(2,m:mmax):: x,y
+
+
+    call f_mult(y,vort_t_hat,f,m,mmax)
+    call c_mult(x,phi_t_hat,c,m,mmax)
+    x=y+x
+    call i_mult(y,x,m,mmax)
+    call solve_f2c2(del_div_hat,y,f,c,m,mmax)
+    call c_mult(x,del_div_hat,b,m,mmax)       !  actually multiplying by b
+    call i_mult(y,div_t_hat,m,mmax)
+    y=y-x
+    call solve_f2c2(x,y,f,c,m,mmax)
+    call c_mult(del_phi_hat,x,c,m,mmax)
+    call f_mult(del_vort_hat,x,f,m,mmax)
+
+  end subroutine dinmi0
+
+
+  subroutine balm_1(vort_t_hat,div_t_hat,phi_t_hat,balnm1,m,mmax)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    gproj
+!
+!   prgrmmr:
+!
+! abstract:      obtain balance diagnostic for each wave number n,m using 
+!                method 1 (eq 4.23 of Temperton,1989)
+!
+!                balnm1 = abs(vort_t_hat)(n,m)**2 + abs(div_t_hat)(n,m)**2 + 
+!                         abs(phi_t_hat)(n,m)**2
+!         
+! program history log:
+!   2008-05-05  safford -- add subprogram doc block, rm unused uses
+!   2011-07-01  todling -- balm1 must not be zeroed out
+!               
+!   input argument list:
+!    vort_t_hat,div_t_hat,phi_t_hat
+!
+!   output argument list:
+!    balnm1
+!   
+! attributes:
+!   language:  f90
+!   machine:   ibm RS/6000 SP
+!   
+!$$$ end documentation block
+
+    implicit none
+
+    real(r_kind),intent(in   ),dimension(2,m:mmax) :: vort_t_hat,div_t_hat,phi_t_hat
+    real(r_kind),intent(inout) :: balnm1
+    integer(i_kind),intent(in)::m,mmax
+
+    integer(i_kind) n
+
+    do n=m,mmax
+       balnm1=balnm1+vort_t_hat(1,n)**2+vort_t_hat(2,n)**2 &
+                     +div_t_hat(1,n)**2+ div_t_hat(2,n)**2 &
+                     +phi_t_hat(1,n)**2+ phi_t_hat(2,n)**2
+    end do
+
+  end subroutine balm_1
+
+
+  subroutine getbcf(b,c,f,c2,c3,m,mmax,gspeed)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    getbcf
+!
+!   prgrmmr:
+!
+! abstract:      compute operators needed to do gravity wave projection
+!                and implicit normal mode initialization in spectral space
+!         
+! program history log:
+!   2008-05-05  safford -- add subprogram doc block, rm unused uses
+!               
+!   input argument list:
+!
+!   output argument list:
+!     b,c,f,c2,c3
+!   
+! attributes:
+!   language:  f90
+!   machine:   ibm RS/6000 SP
+!   
+!$$$ end documentation block
+
+    implicit none
+
+    real(r_kind),intent(  out),dimension(m:mmax) :: b,c,f,c2,c3
+    real(r_kind),intent(in   ) ::gspeed
+    integer(i_kind),intent(in)::m,mmax
+
+    integer(i_kind) n,nstart
+    real(r_kind) eps,rn,rm,rn1
+
+!   scheme B:   b = 2*omega*m/(n*(n+1))
+!               f = 2*omega*sqrt(n*n-1)*eps/n
+!               c = gspeed*sqrt(n*(n+1))/erad
+
+!   scheme C:   b = 0
+!               f = 2*omega*sqrt(n*n-1)*eps/n
+!               c = gspeed*sqrt(n*(n+1))/erad
+
+!   scheme D:   b = 0
+!               f = 2*omega*eps
+!               c = gspeed*sqrt(n*(n+1))/erad
+
+!     in the above, eps = sqrt((n*n-m*m)/(4*n*n-1))
+
+    nstart=max(m,1)
+    rm=m
+    do n=nstart,mmax
+       rn=n
+       eps=sqrt((rn*rn-rm*rm )/(four*rn*rn-one))
+       rn1=sqrt(rn*(rn+one))
+       if(scheme=='B') then
+          b(n)=two*omega*rm/(rn*(rn+one))
+          f(n)=two*omega*sqrt(rn*rn-one)*eps/rn
+          c(n)=gspeed*rn1/rearth
+          c2(n)=rearth/rn1
+          c3(n)=one/gspeed
+       else if(scheme=='C') then
+          b(n)=zero
+          f(n)=two*omega*sqrt(rn*rn-one)*eps/rn
+          c(n)=gspeed*rn1/rearth
+          c2(n)=rearth/rn1
+          c3(n)=one/gspeed
+       else if(scheme=='D') then
+          b(n)=zero
+          f(n)=two*omega*eps
+          c(n)=gspeed*rn1/rearth
+          c2(n)=rearth
+          c3(n)=rn1/gspeed
+       else
+          write(6,*)' scheme = ',scheme,' incorrect, must be = B, C, or D'
+       end if
+    end do
+
+  end subroutine getbcf
+
+
+  subroutine scale_vars(vort,div,phi,vort_hat,div_hat,phi_hat,filtered,c2,c3,&
+             m,mmax,gspeed)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    scale_vars
+!
+!   prgrmmr:
+!
+! abstract:
+!        input scaling:
+!
+!           for schemes B, C:
+!               vort_hat(n) = erad*vort(n)/sqrt(n*(n+1))
+!               div_hat(n)  = sqrt(-1)*erad*div(n)/sqrt(n*(n+1))
+!               phi_hat(n)  = phi(n)/gspeed
+!
+!           for scheme D:
+!               vort_hat(n) = erad*vort(n)
+!               div_hat(n)  = sqrt(-1)*erad*div(n)
+!               phi_hat(n)  = phi(n)*sqrt(n*(n+1))/gspeed
+!         
+! program history log:
+!   2008-05-05  safford -- add subprogram doc block, rm unused uses
+!               
+!   input argument list:
+!     vort,div,phi
+!
+!   output argument list:
+!     vort_hat,div_hat,phi_hat
+!   
+! attributes:
+!   language:  f90
+!   machine:   ibm RS/6000 SP
+!   
+!$$$ end documentation block
+
+    implicit none
+
+    real(r_kind),intent(in   ),dimension(2,m:mmax):: vort,div,phi
+    real(r_kind),intent(in   ),dimension(m:mmax):: c2,c3
+    real(r_kind),intent(in   )                  :: gspeed
+    real(r_kind),intent(  out),dimension(2,m:mmax):: vort_hat,div_hat,phi_hat
+    integer(i_kind),intent(in)::m,mmax
+    logical,intent(in)::filtered
+
+    real(r_kind) pmask,c1,pmax
+    integer(i_kind) n,nstart
+
+!   following is to account for 0,0 term being zero
+
+    vort_hat(1,m)=zero
+    vort_hat(2,m)=zero
+    div_hat(1,m)=zero
+    div_hat(2,m)=zero
+    phi_hat(1,m)=zero
+    phi_hat(2,m)=zero
+    nstart=max(m,1)
+
+    c1=two*pi*rearth/(gspeed*r3600*period_width)
+    pmax=period_max/period_width
+    do n=nstart,mmax
+       pmask=one
+       if(filtered)pmask=half*(one-tanh(c1/real(n,r_kind)-pmax))
+       vort_hat(1,n)=pmask*c2(n)*vort(1,n)
+       vort_hat(2,n)=pmask*c2(n)*vort(2,n)
+       div_hat(2,n) =pmask*c2(n)*div (1,n)
+       div_hat(1,n) =-pmask*c2(n)*div(2,n)
+       phi_hat(1,n) =pmask*c3(n)*phi(1,n)
+       phi_hat(2,n) =pmask*c3(n)*phi(2,n)
+    end do
+
+  end subroutine scale_vars
+
+
+  subroutine scale_vars_ad(vort,div,phi,vort_hat,div_hat,phi_hat,c2,c3,&
+               m,mmax,gspeed)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    scale_vars_ad
+!
+!   prgrmmr:
+!
+! abstract:
+!        input scaling:
+!               for schemes B, C:
+!                 vort_hat(n) = erad*vort(n)/sqrt(n*(n+1))
+!                 div_hat(n)  = sqrt(-1)*erad*div(n)/sqrt(n*(n+1))
+!                 phi_hat(n)  = phi(n)/gspeed
+!
+!              for scheme D:
+!                 vort_hat(n) = erad*vort(n)
+!                 div_hat(n)  = sqrt(-1)*erad*div(n)
+!                 phi_hat(n)  = phi(n)*sqrt(n*(n+1))/gspeed
+!         
+! program history log:
+!   2008-05-05  safford -- add subprogram doc block, rm unused uses
+!               
+!   input argument list:
+!     vort,div,phi
+!     vort_hat,div_hat,phi_hat
+!
+!   output argument list:
+!     vort,div,phi
+!   
+! attributes:
+!   language:  f90
+!   machine:   ibm RS/6000 SP
+!   
+!$$$ end documentation block
+
+    implicit none
+
+    real(r_kind),intent(inout),dimension(2,m:mmax):: vort,div,phi
+    real(r_kind),intent(in   ),dimension(m:mmax):: c2,c3
+    real(r_kind),intent(in   )                  :: gspeed
+    real(r_kind),intent(in   ),dimension(2,m:mmax):: vort_hat,div_hat,phi_hat
+    integer(i_kind),intent(in)::m,mmax
+
+    integer(i_kind) n,nstart
+    real(r_kind) pmask,pmax,c1
+
+    nstart=max(m,1)
+    c1=two*pi*rearth/(gspeed*r3600*period_width)
+    pmax=period_max/period_width
+    do n=nstart,mmax
+       pmask=half*(one-tanh(c1/real(n,r_kind)-pmax))
+       vort(1,n)=vort(1,n)+pmask*c2(n)*vort_hat(1,n)
+       vort(2,n)=vort(2,n)+pmask*c2(n)*vort_hat(2,n)
+       div(1,n) =div(1,n) +pmask*c2(n)*div_hat (2,n)
+       div(2,n) =div(2,n) -pmask*c2(n)*div_hat (1,n)
+       phi(1,n) =phi(1,n) +pmask*c3(n)*phi_hat (1,n)
+       phi(2,n) =phi(2,n) +pmask*c3(n)*phi_hat (2,n)
+    end do
+
+  end subroutine scale_vars_ad
+
+
+  subroutine unscale_vars(vort_hat,div_hat,phi_hat,vort,div,phi,c2,c3,m,mmax)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    unscale_vars
+!
+!   prgrmmr:
+!
+! abstract:
+!      output scaling:
+!            for schemes B, C:
+!                vort(n,m) = sqrt(n*(n+1))*vort_hat(n,m)/erad
+!                div(n,m)  = -sqrt(-1)*sqrt(n*(n+1))*div_hat(n,m)/erad
+!                phi(n,m)  = gspeed*phi_hat(n,m)
+!            for scheme C:
+!                vort(n,m) = vort_hat(n,m)/erad
+!                div(n,m)  = -sqrt(-1)*div_hat(n,m)/erad
+!                phi(n,m)  = gspeed*phi_hat(n,m)/sqrt(n*(n+1))
+!         
+! program history log:
+!   2008-05-05  safford -- add subprogram doc block, rm unused uses
+!               
+!   input argument list:
+!    vort_hat,div_hat,phi_hat
+!
+!   output argument list:
+!    vort,div,phi
+!   
+! attributes:
+!   language:  f90
+!   machine:   ibm RS/6000 SP
+!   
+!$$$ end documentation block
+
+    implicit none
+
+    real(r_kind),intent(in   ),dimension(2,m:mmax):: vort_hat,div_hat,phi_hat
+    real(r_kind),intent(in   ),dimension(m:mmax):: c2,c3
+    real(r_kind),intent(  out),dimension(2,m:mmax):: vort,div,phi
+    integer(i_kind),intent(in)::m,mmax
+
+    integer(i_kind) n,nstart
+
+!   following is to account for 0,0 term being zero
+
+    vort(1,m)=zero
+    vort(2,m)=zero
+    div(1,m)=zero
+    div(2,m)=zero
+    phi(1,m)=zero
+    phi(2,m)=zero
+    nstart=max(m,1)
+    do n=nstart,mmax
+       vort(1,n)=vort_hat(1,n)/c2(n)
+       vort(2,n)=vort_hat(2,n)/c2(n)
+       div (1,n)=div_hat (2,n)/c2(n)
+       div (2,n)=-div_hat(1,n)/c2(n)
+       phi (1,n)=phi_hat (1,n)/c3(n)
+       phi (2,n)=phi_hat (2,n)/c3(n)
+    end do
+
+  end subroutine unscale_vars
+
+
+  subroutine unscale_vars_ad(vort_hat,div_hat,phi_hat,vort,div,phi,c2,c3,m,mmax)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    unscale_vars_ad
+!
+!   prgrmmr:
+!
+! abstract:
+!      output scaling:
+!          for schemes B, C:
+!              vort(n,m) = sqrt(n*(n+1))*vort_hat(n,m)/erad
+!              div(n,m)  = -sqrt(-1)*sqrt(n*(n+1))*div_hat(n,m)/erad
+!              phi(n,m)  = gspeed*phi_hat(n,m)
+!          for scheme C:
+!              vort(n,m) = vort_hat(n,m)/erad
+!              div(n,m)  = -sqrt(-1)*div_hat(n,m)/erad
+!              phi(n,m)  = gspeed*phi_hat(n,m)/sqrt(n*(n+1))
+!         
+! program history log:
+!   2008-05-05  safford -- add subprogram doc block, rm unused uses
+!               
+!   input argument list:
+!    vort,div,phi
+!    vort_hat,div_hat,phi_hat
+!
+!   output argument list:
+!    vort_hat,div_hat,phi_hat
+!
+! attributes:
+!   language:  f90
+!   machine:   ibm RS/6000 SP
+!   
+!$$$ end documentation block
+
+    implicit none
+
+    real(r_kind),intent(inout),dimension(2,m:mmax):: vort_hat,div_hat,phi_hat
+    real(r_kind),intent(in   ),dimension(2,m:mmax):: vort,div,phi
+    real(r_kind),intent(in   ),dimension(m:mmax):: c2,c3
+    integer(i_kind),intent(in)::m,mmax
+
+    integer(i_kind) n,nstart
+
+!   following is to account for 0,0 term being zero
+
+    vort_hat(1,m)=zero
+    vort_hat(2,m)=zero
+    div_hat(1,m)=zero
+    div_hat(2,m)=zero
+    phi_hat(1,m)=zero
+    phi_hat(2,m)=zero
+    nstart=max(m,1)
+    do n=nstart,mmax
+       vort_hat(1,n)=vort(1,n)/c2(n)
+       vort_hat(2,n)=vort(2,n)/c2(n)
+       div_hat (1,n)=-div (2,n)/c2(n)
+       div_hat (2,n)=div (1,n)/c2(n)
+       phi_hat (1,n)=phi (1,n)/c3(n)
+       phi_hat (2,n)=phi (2,n)/c3(n)
+    end do
+
+  end subroutine unscale_vars_ad
+
+
+  subroutine f_mult(x,y,f,m,mmax)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    f_mult
+!
+!   prgrmmr:
+!
+! abstract:      x = F*y
+!         
+! program history log:
+!   2008-05-05  safford -- add subprogram doc block, rm unused uses
+!               
+!   input argument list:
+!     y,f
+!
+!   output argument list:
+!     x
+!   
+! attributes:
+!   language:  f90
+!   machine:   ibm RS/6000 SP
+!   
+!$$$ end documentation block
+
+    implicit none
+
+    real(r_kind),intent(in   ),dimension(m:mmax):: f
+    real(r_kind),intent(in   ),dimension(2,m:mmax):: y
+    real(r_kind),intent(  out),dimension(2,m:mmax):: x
+    integer(i_kind),intent(in)::m,mmax
+
+    integer(i_kind) n,nstart
+
+    if(m==mmax) then
+       x=zero
+       return
+    end if
+
+!   following is to account for 0,0 term being zero
+
+    x(1,m)=zero
+    x(2,m)=zero
+    nstart=max(m,1)
+
+    x(1,mmax)=zero
+    x(2,mmax)=zero
+    if(nstart<mmax) then
+
+       do n=nstart,mmax-1
+          x(1,n)=f(n+1)*y(1,n+1)
+          x(2,n)=f(n+1)*y(2,n+1)
+       end do
+       do n=nstart+1,mmax
+          x(1,n)=x(1,n)+f(n)*y(1,n-1)
+          x(2,n)=x(2,n)+f(n)*y(2,n-1)
+       end do
+    end if
+
+  end subroutine f_mult
+
+
+  subroutine c_mult(x,y,c,m,mmax)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    c_mult
+!
+!   prgrmmr:
+!
+! abstract:      x = C*y
+!         
+! program history log:
+!   2008-05-05  safford -- add subprogram doc block, rm unused uses
+!               
+!   input argument list:
+!     y,c
+!
+!   output argument list:
+!     x
+!   
+! attributes:
+!   language:  f90
+!   machine:   ibm RS/6000 SP
+!   
+!$$$ end documentation block
+
+    implicit none
+
+    real(r_kind),intent(in   ),dimension(m:mmax):: c
+    real(r_kind),intent(in   ),dimension(2,m:mmax):: y
+    real(r_kind),intent(  out),dimension(2,m:mmax):: x
+    integer(i_kind),intent(in)::m,mmax
+
+    integer(i_kind) n,nstart
+
+
+!   following is to account for 0,0 term being zero
+
+    x(1,m)=zero
+    x(2,m)=zero
+    nstart=max(m,1)
+
+    do n=nstart,mmax
+       x(1,n)=c(n)*y(1,n)
+       x(2,n)=c(n)*y(2,n)
+    end do
+
+  end subroutine c_mult
+
+
+  subroutine i_mult(x,y,m,mmax)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    i_mult
+!
+!   prgrmmr:
+!
+! abstract:      x = sqrt(-1)*y
+!         
+! program history log:
+!   2008-05-05  safford -- add subprogram doc block, rm unused uses
+!               
+!   input argument list:
+!     y
+!
+!   output argument list:
+!     x
+!   
+! attributes:
+!   language:  f90
+!   machine:   ibm RS/6000 SP
+!   
+!$$$ end documentation block
+
+    implicit none
+
+    real(r_kind),intent(in   ),dimension(2,m:mmax):: y
+    real(r_kind),intent(  out),dimension(2,m:mmax):: x
+    integer(i_kind),intent(in)::m,mmax
+
+    integer(i_kind) n,nstart
+
+
+!   following is to account for 0,0 term being zero
+
+    x(1,m)=zero
+    x(2,m)=zero
+    nstart=max(m,1)
+
+    do n=nstart,mmax
+       x(1,n)=-y(2,n)
+       x(2,n)=y(1,n)
+    end do
+
+  end subroutine i_mult
+
+
+  subroutine solve_f2c2(x,y,f,c,m,mmax)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    solve_f2c2
+!
+!   prgrmmr:
+!
+! abstract:      solve (F*F+C*C)*x = y
+!         
+! program history log:
+!   2008-05-05  safford -- add subprogram doc block, rm unused uses
+!               
+!   input argument list:
+!     y,f,c
+!
+!   output argument list:
+!     x
+!   
+! attributes:
+!   language:  f90
+!   machine:   ibm RS/6000 SP
+!   
+!$$$ end documentation block
+
+    implicit none
+
+    real(r_kind),intent(in   ),dimension(m:mmax):: f,c
+    real(r_kind),intent(in   ),dimension(2,m:mmax):: y
+    real(r_kind),intent(  out),dimension(2,m:mmax):: x
+    integer(i_kind),intent(in)::m,mmax
+
+    integer(i_kind) n,nstart
+    real(r_kind),dimension(m:mmax):: a,b
+    real(r_kind),dimension(2,m:mmax):: z
+
+
+!   following is to account for 0,0 term being zero
+
+    x(1,m)=zero
+    x(2,m)=zero
+    nstart=max(m,1)
+
+!     copy forcing y to internal array
+
+    do n=nstart,mmax
+       z(1,n)=y(1,n)
+       z(2,n)=y(2,n)
+    end do
+
+!     if nstart==mmax, then trivial solution
+
+    if(nstart==mmax) then
+       a(  nstart)=c(  nstart)*c(nstart)
+       x(1,nstart)=z(1,nstart)/a(nstart)
+       x(2,nstart)=z(2,nstart)/a(nstart)
+    else
+
+!       compute main diagonal of F*F + C*C
+
+       a(nstart)=f(nstart+1)*f(nstart+1)+c(nstart)*c(nstart)
+       if(nstart+1 < mmax) then
+          do n=nstart+1,mmax-1
+             a(n)=f(n)*f(n)+f(n+1)*f(n+1)+c(n)*c(n)
+          end do
+       end if
+       a(mmax)=f(mmax)*f(mmax)+c(mmax)*c(mmax)
+
+!       compute only non-zero off-diagonal of F*F + C*C
+
+       if(nstart+2<=mmax) then
+          do n=nstart+2,mmax
+             b(n)=f(n-1)*f(n)
+             a(n)=a(n)-b(n)*b(n)/a(n-2)
+          end do
+
+!        forward elimination:
+
+          do n=nstart,mmax-2
+             z(1,n+2)=z(1,n+2)-b(n+2)*z(1,n)/a(n)
+             z(2,n+2)=z(2,n+2)-b(n+2)*z(2,n)/a(n)
+          end do
+
+       end if
+
+!        backward substitution:
+
+       x(1,mmax  )=z(1,mmax  )/a(mmax  )
+       x(2,mmax  )=z(2,mmax  )/a(mmax  )
+       x(1,mmax-1)=z(1,mmax-1)/a(mmax-1)
+       x(2,mmax-1)=z(2,mmax-1)/a(mmax-1)
+       if(nstart+2 <= mmax) then
+          do n=mmax-2,nstart,-1
+             x(1,n)=(z(1,n) - b(n+2)*x(1,n+2))/a(n)
+             x(2,n)=(z(2,n) - b(n+2)*x(2,n+2))/a(n)
+          end do
+       end if
+
+    end if
+
+  end subroutine solve_f2c2
+          
+end module mod_strong

--- a/src/gsibec/gsi/mod_vtrans.F90
+++ b/src/gsibec/gsi/mod_vtrans.F90
@@ -327,10 +327,14 @@ contains
 
 !    allocate variables used in vertical mode transformations:
 
-    allocate(depths(nvmodes_keep),speeds(nvmodes_keep))
-    allocate(vmodes(nsig,nvmodes_keep),dualmodes(nsig,nvmodes_keep))
-    allocate(phihat2t(nsig,nvmodes_keep),phihat2p(nvmodes_keep))
-    allocate(p2phihat(nvmodes_keep),t2phihat(nsig,nvmodes_keep))
+    if(.not.allocated(depths)) allocate(depths(nvmodes_keep))
+    if(.not.allocated(speeds)) allocate(speeds(nvmodes_keep))
+    if(.not.allocated(vmodes)) allocate(vmodes(nsig,nvmodes_keep))
+    if(.not.allocated(dualmodes)) allocate(dualmodes(nsig,nvmodes_keep))
+    if(.not.allocated(phihat2t)) allocate(phihat2t(nsig,nvmodes_keep))
+    if(.not.allocated(phihat2p)) allocate(phihat2p(nvmodes_keep))
+    if(.not.allocated(p2phihat)) allocate(p2phihat(nvmodes_keep))
+    if(.not.allocated(t2phihat)) allocate(t2phihat(nsig,nvmodes_keep))
 
 if(mype==workpe) then    ! BEGIN MYPE=workpe SECTION !!!!!!!!!!!!!
 
@@ -373,8 +377,10 @@ if(mype==workpe) then    ! BEGIN MYPE=workpe SECTION !!!!!!!!!!!!!
 
 !     next get eigenvalues and eigenvectors.
 
-   allocate(swww(nvmodes_keep),swwwd(nvmodes_keep))
-   allocate(szzz(nsig,nvmodes_keep),szzzd(nsig,nvmodes_keep))
+   if(.not.allocated(swww)) allocate(swww(nvmodes_keep))
+   if(.not.allocated(swwwd)) allocate(swwwd(nvmodes_keep))
+   if(.not.allocated(szzz)) allocate(szzz(nsig,nvmodes_keep))
+   if(.not.allocated(szzzd)) allocate(szzzd(nsig,nvmodes_keep))
    call special_eigvv(qmat,hmat,smat,nsig,swww,szzz,swwwd,szzzd,nvmodes_keep)
 
    do k=1,nvmodes_keep

--- a/src/gsibec/gsi/mod_vtrans.F90
+++ b/src/gsibec/gsi/mod_vtrans.F90
@@ -116,7 +116,7 @@ contains
 
   end subroutine init_vtrans
 
-  subroutine create_vtrans(mype)
+  subroutine create_vtrans(mype,ntguessig)
 !$$$  subprogram documentation block
 !                .      .    .                                       .
 ! subprogram:    create_vtrans   get vertical functions for dynamic constraint
@@ -207,7 +207,6 @@ contains
     use constants,only: zero,one,one_tenth,ten
     use gridmod,only: lat2,lon2,nsig,nlat,nlon
     use m_mpimod,only: mpi_rtype,gsi_mpi_comm_world,ierror,mpi_integer
-    use guess_grids, only: ntguessig
     use general_sub2grid_mod, only: general_sub2grid
     use general_commvars_mod, only: g1
     use gsi_metguess_mod, only: gsi_metguess_bundle
@@ -218,6 +217,7 @@ contains
 
 !   Declare passed variables
     integer(i_kind),intent(in   ) :: mype
+    integer(i_kind),intent(in   ) :: ntguessig
 
 !   Declare local variables
     character(len=*),parameter::myname_=myname//'*create_vtrans'

--- a/src/gsibec/gsi/mod_vtrans.F90
+++ b/src/gsibec/gsi/mod_vtrans.F90
@@ -1,0 +1,1419 @@
+module mod_vtrans
+!$$$   module documentation block
+!                .      .    .                                       .
+! module:    mod_vtrans      contains all routines for vertical modes
+!
+!   prgmmr: parrish          org: np23                date: 2006-06-26
+!
+! abstract:  contains routines and variables for vertical mode 
+!            generation and use in vertical transforms
+!
+! program history log:
+!   2006-06-26
+!   2007-05-08   kleist - finish vertical coordinate generalization
+!   2011-07-04  todling  - fixes to run either single or double precision
+!   2012-11-19  parrish - compute vertical mode information on pe 0 only, and
+!                          then broadcast results to other processors.
+!                          This fixes a problem with reproducibility encountered on tide.
+!   2012-12-18  parrish - problem with reproducibility reappeared.  Even with all vertical mode
+!                           computations done on pe 0, the library routine dgeev supplied on the WCOSS
+!                           machine uses threading internally in ways that prevent reproducibility,
+!                           even when computation is nominally restricted to one processor.  To fix this,
+!                           available local subroutines within gsi src directory have been used in place of
+!                           dgeev.  Subroutine eigen, located in raflib.f90, computes eigenvalues and
+!                           eigenvectors of symmetric matrices.  The matrix qmat is not symmetric, but a
+!                           rescaling produces an almost symmetric matrix.  The symmetric average of the
+!                           rescaled qmat has eigenvalues and eigenvectors that differ from those of qmat
+!                           by only a few percent.  Using these as starting values, inverse iteration can
+!                           retrieve the desired eigenvalues and eigenvectors of qmat.  To reproduce the
+!                           eigenvalues and eigenvectors of qmat obtained from dgeev to 15 digits, the
+!                           inverse iteration refinement of the starting eigenvalues and eigenvectors is
+!                           done in quad precision.  This requires a quad precision matrix inversion
+!                           routine.  A copy of subroutine iminv in get_semimp_mats.f90 has been copied
+!                           on the end of this module and given the name iminv_quad.  This is also used
+!                           to get the inverse of qmat, instead of the previous method which was to
+!                           construct the inverse of qmat from its eigenvalues and eigenvectors.  This
+!                           required all of the eigenvalues and eigenvectors, which dgeev provided.
+!                           However, by using iminv_quad, now only the first nvmodes_keep eigenvectors and
+!                           eigenvalues need be computed.  The complete computation if the eigenvectors
+!                           and eigenvalues without using dgeev uses less than 2 seconds for 8
+!                           eigenvalue/vectors and all related computations.
+!   2018-02-15  wu       - add code for fv3_regional option
+!
+! subroutines included:
+!   sub init_vtrans              - initialize vertical mode related variables
+!   sub create_vtrans            - allocate and load vert mode variables
+!   sub destroy_vtrans           - deallocate vert mode variables
+!   sub getabc                   -
+!   sub vtrans_inv               - physical space u,v,T,p --> vert transformed u,v,phi
+!   sub vtrans_inv_ad            - adjoint of vtrans_inv
+!   sub vtrans                   - vert transformed u,v,phi --> physical space u,v,T,p
+!   sub vtrans_ad                - adjoint of vtrans
+!
+! Variable Definitions:
+!   def nvmodes_keep             - number of vertical modes to keep ( <= nsig )
+!   def speeds                   - phase speeds of vertical modes
+!   def vmodes                   - vertical modes
+!   def dualmodes                - dual vertical modes
+!   def phihat2t                 - matrix operator to convert phihat to T
+!
+! attributes:
+!   language: f90
+!   machine:  ibm RS/6000 SP
+!
+!$$$ end documentation block
+
+  use m_kinds,only: r_kind,i_kind
+  implicit none
+
+! set default to private
+  private
+! set subroutines to public
+  public :: init_vtrans
+  public :: create_vtrans
+  public :: destroy_vtrans
+  public :: getabc
+  public :: vtrans_inv
+  public :: vtrans_inv_ad
+  public :: vtrans
+  public :: vtrans_ad
+! set passed variables to public
+  public :: nvmodes_keep,depths,speeds
+
+  integer(i_kind) nvmodes_keep
+  real(r_kind),dimension(:),allocatable:: depths,speeds
+  real(r_kind),dimension(:,:),allocatable:: vmodes,phihat2t,dualmodes
+  real(r_kind),dimension(:,:),allocatable:: t2phihat
+  real(r_kind),dimension(:),allocatable:: p2phihat,phihat2p
+
+  character(len=*),parameter::myname='mod_vtrans'
+
+contains
+
+  subroutine init_vtrans
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    init_vtrans     set default values for vtrans variables
+!   prgmmr: parrish         org: np23                date: 2006-06-26
+!
+! abstract: set default values for vtrans variables
+!
+! program history log:
+!   2006-06-26  parrish
+!
+!   input argument list:
+!
+!   output argument list:
+!
+! attributes:
+!   language: f90
+!   machine:  ibm RS/6000 SP
+!
+!$$$ end documentation block
+    implicit none
+
+    nvmodes_keep=0
+
+  end subroutine init_vtrans
+
+  subroutine create_vtrans(mype)
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    create_vtrans   get vertical functions for dynamic constraint
+!   prgmmr: parrish        org: np23         date:  2006-06-26
+!
+! abstract:  using linearization of dynamics about rest state, derive
+!             coupling matrix and obtain eigenvectors/values
+!             (linearization follows Juang, 2005, NCEP Office Note 445)
+!            The conversion from mass variable to T,p follows the 
+!            Machenhauer-Phillips approach, pointed out by R. Errico
+!            in a conversation on 7-11-2006.
+!
+!           Briefly, the linear equations used to define the vertical
+!            modes are
+!
+!             dD/dt = -laplacian ( H*p + A*T )                          (1)
+!
+!             dT/dt = -B*D                                              (2)
+!
+!             dp/dt = -S*D                                              (3)
+!
+!                 where D is divergence, p is surface pressure, T is virtual temperature,
+!
+!                    and the matrices H, A, B, S are as defined in ON 445.
+!
+!           Taking the time derivative of (1) and substituting from (2) and (3)
+!           yields an equation for just divergence,
+!
+!              d2D/dt2 = -Q * laplacian(D)
+!
+!                 Q = H*S + A*B
+!
+!           The vertical modes are the right eigenvectors of Q and the
+!           scale geopotential values for each vertical mode are the eigenvalues of Q.
+!
+!                 Q = U*E*V(transpose)
+!
+!           To transform from physical space to vertical modes, first form
+!           the mass variable
+!
+!                 M = H*p + A*T
+!
+!           Then the transform variables are
+!
+!            (Mhat,uhat,vhat) = V(transpose)*(M,u,v)
+!
+!           To return from mode space to physical space, we have
+!
+!             (M,u,v) = U*(Mhat,uhat,vhat)
+!
+!           Finally, to get T,p from M using the Machenhauer-Phillips approach,
+!
+!              T = B*Q**(-1)*M
+!
+!              p = S*Q**(-1)*M
+!
+!           The above is only strictly valid for T and p small perturbations in gravity modes
+!           only, but that is the application for which this code is intended.
+!
+!
+! program history log:
+!   2006-06-26  parrish
+!   2007-02-26  yang    - replace IBM subroutine of dgeev by GSI dgeev
+!   2010-04-01  treadon - move strip to gridmod
+!   2012-11-19  parrish - compute vertical mode information on pe 0 only, and
+!                          then broadcast results to other processors.
+!                          This fixes a problem with reproducibility encountered on tide.
+!   2012-12-18  parrish - substantial rewrite of this code to allow use of all local code.
+!                          r_quad precision has been used in eigenvalue/eigenvector computation 
+!                          to get agreement with eigenvalues/eigenvectors from library routine dgeev,
+!                          which has been replaced in this version.  It appears that reproducibility
+!                          has been restored.  (See more extensive comment at top of this module.)
+!   2013-10-19  todling - metguess now holds background 
+!
+!
+! usage:
+!   input argument list:
+!       mype     - current processor number
+!
+!   output argument list:
+!
+! attributes:
+!   language: f90
+!   machine:  ibm RS/6000 SP
+!
+!$$$ end documentation block
+    use m_kinds, only: r_quad
+    use constants,only: zero,one,one_tenth,ten
+    use gridmod,only: lat2,lon2,nsig,nlat,nlon
+    use m_mpimod,only: mpi_rtype,gsi_mpi_comm_world,ierror,mpi_integer
+    use guess_grids, only: ntguessig
+    use general_sub2grid_mod, only: general_sub2grid
+    use general_commvars_mod, only: g1
+    use gsi_metguess_mod, only: gsi_metguess_bundle
+    use gsi_bundlemod, only: gsi_bundlegetpointer
+    use mpeu_util, only: die
+    use gsi_io, only: verbose
+    implicit none
+
+!   Declare passed variables
+    integer(i_kind),intent(in   ) :: mype
+
+!   Declare local variables
+    character(len=*),parameter::myname_=myname//'*create_vtrans'
+    integer(i_kind) i,j,k,n
+    real(r_kind) count,psbar
+    real(r_kind) sum
+    real(r_kind),dimension(1,lat2,lon2,1):: worksub
+    real(r_kind),allocatable,dimension(:,:,:,:):: hwork
+    real(r_kind),dimension(nsig+1)::pbar
+    real(r_kind),dimension(nsig)::tbar
+    real(r_kind),dimension(nsig+1)::ahat,bhat,chat
+    real(r_kind),dimension(nsig)::hmat,smat,sqmatinv
+    real(r_kind),dimension(nsig,nsig)::amat,bmat,qmat,qmatinv,bqmatinv
+    real(r_kind),allocatable,dimension(:):: swww,swwwd
+    real(r_kind),allocatable,dimension(:,:):: szzz,szzzd
+    integer(i_kind),allocatable:: numlevs(:)
+    real(r_kind),dimension(:,:  ),pointer:: ges_ps_nt=>NULL()
+    real(r_kind),dimension(:,:,:),pointer:: ges_tv_nt=>NULL()
+    integer(i_kind) workpe,ier,istatus
+    integer(i_kind) lpivot(nsig),mpivot(nsig)
+    real(r_quad) qmatinv_quad(nsig,nsig),detqmat_quad
+    logical print_verbose
+
+!   get work pe:
+
+    print_verbose=.false.
+    allocate(numlevs(0:g1%npe-1))
+    numlevs(0:g1%npe-1)=g1%kend(0:g1%npe-1)-g1%kbegin(0:g1%npe-1)+1
+    if(g1%mype==0) then
+        workpe=-1
+        do i=0,g1%npe-1
+   !       write(6,*)' i,numlevs(i)=',i,numlevs(i)
+           if(numlevs(i)==1) workpe=i
+        end do
+   !    write(6,*)' workpe=',workpe
+    end if
+    call mpi_bcast(workpe,1,mpi_integer,0,gsi_mpi_comm_world,ierror)
+   !write(6,*)' mype,workpe=',mype,workpe
+    if(verbose .and. g1%mype==workpe) print_verbose=.true.
+
+!    obtain vertical coordinate constants ahat,bhat,chat
+    if(g1%mype==workpe) call getabc(ahat,bhat,chat)
+
+!   get global mean T and ps
+
+    allocate(hwork(g1%inner_vars,g1%nlat,g1%nlon,g1%kbegin_loc:g1%kend_alloc))
+
+!   count:
+!  Not clear if area weighting would be better.
+    count=one/float(nlat*nlon)
+
+    ier=0
+    call gsi_bundlegetpointer (gsi_metguess_bundle(ntguessig),'ps',ges_ps_nt, istatus)
+    ier=ier+istatus
+    call gsi_bundlegetpointer (gsi_metguess_bundle(ntguessig),'tv',ges_tv_nt, istatus)
+    ier=ier+istatus
+    if(ier/=0) call die(myname_,'missing require variables, ier=', ier)
+
+!   psbar:
+
+    do j=1,lon2
+       do i=1,lat2
+          worksub(1,i,j,1)=ges_ps_nt(i,j)
+       end do
+    end do
+    call general_sub2grid(g1,worksub,hwork)
+    if(g1%mype==workpe) then
+       psbar=zero
+       do j=1,nlon
+          do i=1,nlat
+             psbar=psbar+hwork(1,i,j,1)
+          end do
+       end do
+       psbar=ten*count*psbar
+       do k=1,nsig+1
+          pbar(k)=ahat(k)+bhat(k)*psbar     !  + chat(k)*(T/T0)**(1/kappa)   --- add later
+       end do
+    end if
+
+!   tbar:
+
+    do k=1,nsig
+       do j=1,lon2
+          do i=1,lat2
+             worksub(1,i,j,1)=ges_tv_nt(i,j,k)
+          end do
+       end do
+       call general_sub2grid(g1,worksub,hwork)
+       if(g1%mype==workpe) then
+          tbar(k)=zero
+          do j=1,nlon
+             do i=1,nlat
+                tbar(k)=tbar(k)+hwork(1,i,j,1)
+             end do
+          end do
+          tbar(k)=count*tbar(k)
+       end if
+    end do
+  
+    if(print_verbose) then
+       do k=1,nsig
+          write(6,'(" k,pbar,tbar = ",i5,2f18.9)')k,pbar(k),tbar(k)
+       end do
+       k=nsig+1
+       write(6,'(" k,pbar      = ",i5,f18.9)')k,pbar(k)
+    end if
+
+!    allocate variables used in vertical mode transformations:
+
+    allocate(depths(nvmodes_keep),speeds(nvmodes_keep))
+    allocate(vmodes(nsig,nvmodes_keep),dualmodes(nsig,nvmodes_keep))
+    allocate(phihat2t(nsig,nvmodes_keep),phihat2p(nvmodes_keep))
+    allocate(p2phihat(nvmodes_keep),t2phihat(nsig,nvmodes_keep))
+
+if(mype==workpe) then    ! BEGIN MYPE=workpe SECTION !!!!!!!!!!!!!
+
+    hmat=zero ; smat=zero ; amat=zero ; bmat=zero
+
+! Get matrices for variable transforms/vertical modes
+    call get_semimp_mats(tbar,pbar,bhat,chat,amat,bmat,hmat,smat)
+
+!   qmat = hmat*smat + amat*bmat
+
+    do j=1,nsig
+       do i=1,nsig
+          qmat(i,j)=hmat(i)*smat(j)
+          do k=1,nsig
+             qmat(i,j)=qmat(i,j)+amat(i,k)*bmat(k,j)
+          end do
+       end do
+    end do
+
+!  get inverse of Q using iminv_quad
+
+    qmatinv_quad=qmat
+    call iminv_quad(qmatinv_quad,nsig,detqmat_quad,lpivot,mpivot)
+    qmatinv=qmatinv_quad
+
+!   check inverse
+
+ !errormax=zero
+ !do j=1,nsig
+ !   do i=1,nsig
+ !      sum=zero
+ !      if(i==j) sum=-one
+ !      do k=1,nsig
+ !         sum=sum+qmat(i,k)*qmatinv(k,j)
+ !      end do
+ !      errormax=max(abs(sum),errormax)
+ !   end do
+ !end do
+ !write(6,*)' error in qmatinv =',errormax
+
+!     next get eigenvalues and eigenvectors.
+
+   allocate(swww(nvmodes_keep),swwwd(nvmodes_keep))
+   allocate(szzz(nsig,nvmodes_keep),szzzd(nsig,nvmodes_keep))
+   call special_eigvv(qmat,hmat,smat,nsig,swww,szzz,swwwd,szzzd,nvmodes_keep)
+
+   do k=1,nvmodes_keep
+      depths(k)=swww(k)
+      speeds(k)=sqrt(depths(k))
+      do j=1,nsig
+         vmodes(j,k)=szzz(j,k)
+         dualmodes(j,k)=szzzd(j,k)
+      end do
+   end do
+
+!   next compute p2phihat and t2phihat
+
+  t2phihat=zero
+  p2phihat=zero
+  do n=1,nvmodes_keep
+     do k=1,nsig
+        do j=1,nsig
+           t2phihat(k,n)=t2phihat(k,n)+szzzd(j,n)*amat(j,k)
+        end do
+        p2phihat(n)=p2phihat(n)+szzzd(k,n)*hmat(k)
+     end do
+  end do
+  p2phihat=ten*p2phihat ! in this code, p is in units of mb, but in gsi, p is in cb -- change later
+
+!   finally compute phihat2p, phihat2t
+
+  do j=1,nsig
+     do i=1,nsig
+        bqmatinv(i,j)=zero
+        do k=1,nsig
+           bqmatinv(i,j)=bqmatinv(i,j)+bmat(i,k)*qmatinv(k,j)
+        end do
+     end do
+  end do
+  do j=1,nsig
+     sqmatinv(j)=zero
+     do i=1,nsig
+        sqmatinv(j)=sqmatinv(j)+smat(i)*qmatinv(i,j)
+     end do
+  end do
+
+  do j=1,nvmodes_keep
+     sum=zero
+     do k=1,nsig
+        sum=sum+sqmatinv(k)*szzz(k,j)
+     end do
+     phihat2p(j)=sum
+     do i=1,nsig
+        sum=zero
+        do k=1,nsig
+           sum=sum+bqmatinv(i,k)*szzz(k,j)
+        end do
+        phihat2t(i,j)=sum
+     end do
+  end do
+  phihat2p=one_tenth*phihat2p ! local units are mb, but gsi units are cb--fix later
+end if  ! END MYPE=workpe SECTION !!!!!!!!!!!!!
+
+!  BROADCAST RESULTS FROM ABOVE SECTION TO ALL PES
+
+    call mpi_bcast(depths,nvmodes_keep,mpi_rtype,workpe,gsi_mpi_comm_world,ierror)
+    call mpi_bcast(speeds,nvmodes_keep,mpi_rtype,workpe,gsi_mpi_comm_world,ierror)
+    call mpi_bcast(vmodes,nsig*nvmodes_keep,mpi_rtype,workpe,gsi_mpi_comm_world,ierror)
+    call mpi_bcast(phihat2t,nsig*nvmodes_keep,mpi_rtype,workpe,gsi_mpi_comm_world,ierror)
+    call mpi_bcast(dualmodes,nsig*nvmodes_keep,mpi_rtype,workpe,gsi_mpi_comm_world,ierror)
+    call mpi_bcast(t2phihat,nsig*nvmodes_keep,mpi_rtype,workpe,gsi_mpi_comm_world,ierror)
+    call mpi_bcast(p2phihat,nvmodes_keep,mpi_rtype,workpe,gsi_mpi_comm_world,ierror)
+    call mpi_bcast(phihat2p,nvmodes_keep,mpi_rtype,workpe,gsi_mpi_comm_world,ierror)
+
+  end subroutine create_vtrans
+
+  subroutine destroy_vtrans
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    destroy_vtrans   remove space used by vtrans routines
+!   prgmmr: parrish        org: np23         date:  2006-06-26
+!
+! abstract:  remove space used in vertical mode transformations
+!
+! program history log:
+!   2006-06-26  parrish
+!
+!
+! usage:
+!   input argument list:
+!
+!   output argument list:
+!
+! attributes:
+!   language: f90
+!   machine:  ibm RS/6000 SP
+!
+!$$$ end documentation block
+    implicit none
+
+!    deallocate variables used in vertical mode transformations:
+
+    deallocate(depths,speeds,vmodes,dualmodes)
+    deallocate(phihat2t,phihat2p,p2phihat,t2phihat)
+
+  end subroutine destroy_vtrans
+
+  subroutine getabc(ahat,bhat,chat)
+!$$$  subprogram documentation block
+!
+! subprogram:    getabc       get pressure constants
+!
+!   prgmmr: parrish          org: np22                date: 2006-05-04
+!
+! abstract: return constants used to get 3d pressure field at interfaces based on
+!            generalized vertical coordinate
+!
+! program history log:
+!   2006-05-04  kleist
+!   2010-12-17  pagowski - add cmaq
+!
+! usage:
+!   input argument list:
+!
+!   output argument list:
+!     ahat       -   p(i,j,k)  = ahat(k) + bhat(k)*psfc(i,j)+chat(k)*(T(i,j,k)/T0(k))**(1/kappa)
+!     bhat       -
+!     chat       -
+!
+!$$$ end documentation block
+    use constants,only: zero,ten
+    use gridmod,only: nsig,ak5,bk5,ck5
+#ifdef USE_ALL_ORIGINAL
+    use gridmod,only: wrf_nmm_regional,nems_nmmb_regional,eta1_ll,eta2_ll,pdtop_ll,pt_ll,cmaq_regional
+    use gridmod,only: fv3_regional
+#endif /* USE_ALL_ORIGINAL */
+    implicit none
+
+!   Declare passed variables
+    real(r_kind),dimension(nsig+1),intent(  out) :: ahat,bhat,chat
+
+!   Declare local variables
+    integer(i_kind) k
+
+#ifdef USE_ALL_ORIGINAL
+    if(wrf_nmm_regional.or.nems_nmmb_regional.or.cmaq_regional) then
+       do k=1,nsig+1
+          ahat(k)=eta1_ll(k)*pdtop_ll-eta2_ll(k)*(pdtop_ll+pt_ll)+pt_ll
+          bhat(k)=eta2_ll(k)
+          chat(k)=zero
+       end do
+    elseif(fv3_regional) then
+       do k=1,nsig+1
+          ahat(k)=eta1_ll(k)*0.01_r_kind
+          bhat(k)=eta2_ll(k)
+          chat(k)=zero
+       end do
+    else
+#endif /* USE_ALL_ORIGINAL */
+       do k=1,nsig+1
+          ahat(k)=ak5(k)*ten
+          bhat(k)=bk5(k)
+          chat(k)=ck5(k)*ten
+       end do
+#ifdef USE_ALL_ORIGINAL
+    end if
+#endif /* USE_ALL_ORIGINAL */
+
+    return
+  end subroutine getabc
+
+  subroutine vtrans_inv(uhat,vhat,phihat,u,v,t,p)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    vtrans_inv
+!
+!   prgrmmr:
+!
+! abstract:
+!
+! program history log:
+!   2008-05-29  safford -- add subprogram doc block
+!
+!   input argument list:
+!     uhat,vhat,phihat
+!
+!   output argument list:
+!     u,v,t
+!     p
+!
+! attributes:
+!   language:  f90
+!   machine:   ibm RS/6000 SP
+!
+!$$$ end documentation block
+
+    use gridmod,only: lat2,lon2,nsig
+    use constants,only: zero
+    implicit none
+
+    real(r_kind),dimension(lat2,lon2,nvmodes_keep),intent(in   ) :: uhat,vhat,phihat
+    real(r_kind),dimension(lat2,lon2,nsig)        ,intent(  out) :: u,v,t
+    real(r_kind),dimension(lat2,lon2)             ,intent(  out) :: p
+
+    integer(i_kind) i,j,k,n
+
+
+!$omp parallel do schedule(dynamic,1) private(n,i,j,k)
+    do k=1,nsig
+       do n=1,nvmodes_keep
+          do j=1,lon2
+             do i=1,lat2
+                u(i,j,k)=u(i,j,k)+vmodes(k,n)*uhat(i,j,n)
+                v(i,j,k)=v(i,j,k)+vmodes(k,n)*vhat(i,j,n)
+                t(i,j,k)=t(i,j,k)+phihat2t(k,n)*phihat(i,j,n)
+             end do
+          end do
+          if( k == 1)then
+             do j=1,lon2
+                do i=1,lat2
+                   p(i,j)=p(i,j)+phihat2p(n)*phihat(i,j,n)
+                end do
+             end do
+          end if
+       end do
+    end do
+
+  end subroutine vtrans_inv
+
+  subroutine vtrans_inv_ad(uhat,vhat,phihat,u,v,t,p)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    vtrans_inv_ad
+!
+!   prgrmmr:
+!
+! abstract:
+!
+! program history log:
+!   2008-05-29  safford -- add subprogram doc block
+!
+!   input argument list:
+!     uhat,vhat,phihat
+!     u,v,t
+!     p
+!
+!   output argument list:
+!     uhat,vhat,phihat
+!
+! attributes:
+!   language:  f90
+!   machine:   ibm RS/6000 SP
+!
+!$$$ end documentation block
+    use gridmod,only: lat2,lon2,nsig
+    use constants,only: zero
+    implicit none
+
+    real(r_kind),dimension(lat2,lon2,nvmodes_keep),intent(inout) :: uhat,vhat,phihat
+    real(r_kind),dimension(lat2,lon2,nsig)        ,intent(in   ) :: u,v,t
+    real(r_kind),dimension(lat2,lon2)             ,intent(in   ) :: p
+
+    integer(i_kind) i,j,k,n
+
+!$omp parallel do schedule(dynamic,1) private(n,i,j,k)
+    do n=1,nvmodes_keep
+       do k=1,nsig
+          do j=1,lon2
+             do i=1,lat2
+                uhat(i,j,n)=uhat(i,j,n)+vmodes(k,n)*u(i,j,k)
+                vhat(i,j,n)=vhat(i,j,n)+vmodes(k,n)*v(i,j,k)
+                phihat(i,j,n)=phihat(i,j,n)+phihat2t(k,n)*t(i,j,k)
+             end do
+          end do
+       end do
+       do j=1,lon2
+          do i=1,lat2
+             phihat(i,j,n)=phihat(i,j,n)+phihat2p(n)*p(i,j)
+          end do
+       end do
+    end do
+
+  end subroutine vtrans_inv_ad
+
+  subroutine vtrans(u,v,t,p,uhat,vhat,phihat)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    vtrans
+!
+!   prgrmmr:
+!
+! abstract:
+!
+! program history log:
+!   2008-05-29  safford -- add subprogram doc block
+!
+!   input argument list:
+!     u,v,t
+!     p
+!
+!   output argument list:
+!     uhat,vhat,phihat
+!
+! attributes:
+!   language:  f90
+!   machine:   ibm RS/6000 SP
+!
+!$$$ end documentation block
+
+    use gridmod,only: lat2,lon2,nsig
+    use constants,only: zero
+    implicit none
+
+    real(r_kind),dimension(lat2,lon2,nsig)        ,intent(in   ) :: u,v,t
+    real(r_kind),dimension(lat2,lon2)             ,intent(in   ) :: p
+    real(r_kind),dimension(lat2,lon2,nvmodes_keep),intent(  out) :: uhat,vhat,phihat
+
+    integer(i_kind) i,j,k,n
+
+
+!$omp parallel do schedule(dynamic,1) private(n,i,j,k)
+    do n=1,nvmodes_keep
+       do j=1,lon2
+          do i=1,lat2
+             uhat(i,j,n)=zero
+             vhat(i,j,n)=zero
+             phihat(i,j,n)=p2phihat(n)*p(i,j)
+          enddo
+       enddo
+       do k=1,nsig
+          do j=1,lon2
+             do i=1,lat2
+                uhat(i,j,n)=uhat(i,j,n)+dualmodes(k,n)*u(i,j,k)
+                vhat(i,j,n)=vhat(i,j,n)+dualmodes(k,n)*v(i,j,k)
+                phihat(i,j,n)=phihat(i,j,n)+t2phihat(k,n)*t(i,j,k)
+             end do
+          end do
+       end do
+    end do
+
+  end subroutine vtrans
+
+  subroutine vtrans_ad(u,v,t,p,uhat,vhat,phihat)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    vtrans_ad
+!
+!   prgrmmr:
+!
+! abstract:
+!
+! program history log:
+!   2008-05-29  safford -- add subprogram doc block
+!
+!   input argument list:
+!     u,v,t
+!     p
+!     uhat,vhat,phihat
+!
+!   output argument list:
+!     u,v,t
+!     p
+!
+! attributes:
+!   language:  f90
+!   machine:   ibm RS/6000 SP
+!
+!$$$ end documentation block
+
+    use gridmod,only: lat2,lon2,nsig
+    implicit none
+ 
+    real(r_kind),dimension(lat2,lon2,nsig)        ,intent(inout) :: u,v,t
+    real(r_kind),dimension(lat2,lon2)             ,intent(inout) :: p
+    real(r_kind),dimension(lat2,lon2,nvmodes_keep),intent(in   ) :: uhat,vhat,phihat
+
+    integer(i_kind) i,j,k,n
+
+!$omp parallel do schedule(dynamic,1) private(n,i,j,k)
+    do k=1,nsig
+       do n=1,nvmodes_keep
+          do j=1,lon2
+             do i=1,lat2
+                u(i,j,k)=u(i,j,k)+dualmodes(k,n)*uhat(i,j,n)
+                v(i,j,k)=v(i,j,k)+dualmodes(k,n)*vhat(i,j,n)
+                t(i,j,k)=t(i,j,k)+t2phihat(k,n)*phihat(i,j,n)
+             end do
+          end do
+          if(k == 1)then
+             do j=1,lon2
+               do i=1,lat2
+                  p(i,j)=p(i,j)+p2phihat(n)*phihat(i,j,n)
+               end do
+             end do
+          end if
+       end do
+    end do
+
+  end subroutine vtrans_ad
+
+end module mod_vtrans
+
+subroutine special_eigvv(qmat0,hmat0,smat0,nmat,swww0,szzz0,swwwd0,szzzd0,nvmodes_keep)
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    special_eigvv   obtain eigenvalues and eigenvecgtors of qmat0
+!   prgmmr: parrish        org: np22         date:  2012-12-18
+!
+! abstract:  Compute eigenvalues and eigenvectors of matrix qmat0.  Input and output
+!            variables are r_kind, but internal calculations are done in r_quad to eliminate
+!            possible failures in the inverse iteration algorithm used to refine
+!            the accuracy of the eigenvectors and eigenvalues so as to agree
+!            with those produced previously by library routine dgeev to 15
+!            digits.  Because it is only necessary that the initial estimate of
+!            eigenvectors and eigenvalues be near (but not too near) the desired
+!            final values, the initial values are obtained using r_kind
+!            precision only (subroutine eigen, located in raflib.F90).
+!            Extensive testing with different initial eigenvalue/vector
+!            estimates confirmed that identical r_kind precision
+!            eigenvalues and eigenvectors are always obtained from the quad precision
+!            inverse iteration algorithm.  This translates to exact
+!            reproducibility on different numbers of processors for the full
+!            analysis.
+!            
+!
+! program history log:
+!   2012-12-18  parrish
+!
+!
+! usage:
+!   input argument list:
+!     qmat0,hmat0,smat0,nmat,nvmodes_keep
+!
+!   output argument list:
+!     swww0,szzz0,swwwd0,szzzd0
+!
+! attributes:
+!   language: f90
+!   machine:  ibm RS/6000 SP
+!
+!$$$ end documentation block
+
+  use m_kinds, only: r_kind,i_kind,r_quad
+  use gsi_io, only: verbose
+
+  implicit none
+
+  integer(i_kind),intent(in)::nmat,nvmodes_keep
+  real(r_kind),intent(in)::qmat0(nmat,nmat),hmat0(nmat),smat0(nmat)
+  real(r_kind),intent(inout):: swww0(nvmodes_keep),swwwd0(nvmodes_keep)
+  real(r_kind),intent(inout):: szzz0(nmat,nvmodes_keep),szzzd0(nmat,nvmodes_keep)
+
+
+  real(r_quad) qmat(nmat,nmat),hmat(nmat),smat(nmat)
+  real(r_quad) swww(nvmodes_keep),swwwd(nvmodes_keep)
+  real(r_quad) szzz(nmat,nvmodes_keep),szzzd(nmat,nvmodes_keep)
+  real(r_quad) rmat(nmat),qtildemat(nmat,nmat),atemp(nmat*nmat),btemp(nmat,nmat)
+  real(r_quad) eigvals(nmat)
+  integer(i_kind) i,j,k,ia,mv,iret,istop
+  real(r_quad) sum
+! real(r_quad) orthoerror
+  real(r_quad) aminv(nmat,nmat),aminvt(nmat,nmat)
+  real(r_quad) eigval_this,eigval_next
+  real(r_quad) zero_quad,half_quad,one_quad
+  real(r_quad) dist_to_closest_eigval,perturb_eigval
+  real(r_quad) err_aminv
+  real(r_kind) atemp8(nmat*nmat),btemp8(nmat,nmat)
+  logical noskip,print_verbose
+
+  print_verbose = .false.
+  if(verbose) print_verbose=.true.
+  zero_quad=0.0_r_quad
+  half_quad=0.5_r_quad
+  one_quad =1.0_r_quad
+  qmat=qmat0
+  hmat=hmat0
+  smat=smat0
+  do i=1,nmat
+     rmat(i)=sqrt(hmat(i)*smat(i))
+  end do
+  do j=1,nmat
+     do i=1,nmat
+        qtildemat(i,j)=rmat(i)*rmat(j)*qmat(i,j)/(hmat(i)*smat(j))
+     end do
+  end do
+
+!  get eigenvalues, eigenvectors of symmetrized version 
+!    of qtildemat (gives most accurate eigenvalue estimates):
+  atemp=0.0_r_quad
+  do i=1,nmat
+     do j=i,nmat
+        ia=i+(j*j-j)/2
+        atemp(ia)=half_quad*(qtildemat(j,i)+qtildemat(i,j))
+     end do
+  end do
+  mv=0
+  atemp8=atemp
+  call eigen(atemp8,btemp8,nmat,mv)
+  btemp=btemp8
+  atemp=atemp8
+  do i=1,nvmodes_keep
+     j=i
+     ia=i+(j*j-j)/2
+     eigvals(i)=atemp(ia)
+  !  write(6,*)' i,ave eigvals(i)=',i,eigvals(i)
+  end do
+
+!      iterative improvement to get eigvals, eigvects of qtildemat
+
+  do i=1,nvmodes_keep
+     szzz(:,i)=btemp(:,i)
+     szzzd(:,i)=btemp(:,i)
+!  renormalize szzz and szzzd
+     sum=zero_quad
+     do j=1,nmat
+        sum=sum+szzz(j,i)**2
+     end do
+     sum=one_quad/sqrt(sum)
+     if(szzz(1,i)<zero_quad) sum=-sum
+     do j=1,nmat
+        szzz(j,i)=sum*szzz(j,i)
+     end do
+     sum=zero_quad
+     do j=1,nmat
+        sum=sum+szzzd(j,i)**2
+     end do
+     sum=one_quad/sqrt(sum)
+     if(szzzd(1,i)<zero_quad) sum=-sum
+     do j=1,nmat
+        szzzd(j,i)=sum*szzzd(j,i)
+     end do
+     eigval_this=eigvals(i)
+     iret=0
+     dist_to_closest_eigval=min( abs(eigvals(i)-eigvals(max(i-1,1           ))), &
+                                 abs(eigvals(i)-eigvals(min(i+1,nvmodes_keep))) )
+     if(i==1) then
+        dist_to_closest_eigval=abs(eigvals(i+1)-eigvals(i))
+     elseif(i==nvmodes_keep) then
+        dist_to_closest_eigval=abs(eigvals(i)-eigvals(i-1))
+     else
+        dist_to_closest_eigval=min( abs(eigvals(i)-eigvals(max(i-1,1           ))), &
+                                    abs(eigvals(i)-eigvals(min(i+1,nvmodes_keep))) )
+     end if
+
+     !write(6,*)' i,eigvals(i),dist_to_closest_eigval=',i,eigvals(i),dist_to_closest_eigval
+     perturb_eigval=0.000001_r_quad*dist_to_closest_eigval
+     !write(6,*)' i,perturb_eigval/eigvals(i)=',i,perturb_eigval/eigvals(i)
+     !write(6,*)' precomputation of aminv with check on err_aminv'
+     call iterative_improvement0(qtildemat,eigval_this,aminv,aminvt,nmat,iret,err_aminv)
+     noskip=.false.
+     if(err_aminv>10._r_quad**(-20).or.iret==1) then
+        noskip=.true.
+        eigval_this=eigval_this+perturb_eigval
+     end if
+     iret=0
+     do j=1,10 
+        if(noskip)  call iterative_improvement0(qtildemat,eigval_this,aminv,aminvt,nmat,iret,err_aminv)
+        noskip=.true.
+        if(iret==1) then
+           if(print_verbose)write(6,*)' det=0 in iterative_improvement0, eigenvalue converged, it = ',j
+           exit
+        end if
+        call iterative_improvement(eigval_this,eigval_next,aminv,aminvt,szzz(:,i),szzzd(:,i),nmat,istop)
+        if(eigval_this==eigval_next) then
+           if(print_verbose)write(6,*)' no change in eigenvalue, convergence to machine precision achieved, it = ',j
+           exit
+        end if
+        eigval_this=eigval_next
+        if(istop==1) then
+           if(print_verbose)write(6,*)' eigval relative change less than 10**(-24), no further iteration necessary, it = ',j
+           exit
+        end if
+     end do
+     swww(i)=eigval_next
+     swwwd(i)=eigval_next
+     !write(6,*)' i,j,swww(i)=',i,j,swww(i)
+  end do
+
+!  compute unscaled left and right eigenvectors of "corrected" matrix qmat_c
+
+  do k=1,nvmodes_keep
+     do i=1,nmat
+        szzz(i,k)=hmat(i)*szzz(i,k)/rmat(i)
+        szzzd(i,k)=smat(i)*szzzd(i,k)/rmat(i)
+     end do
+  end do
+
+!  renormalize szzz and szzzd
+
+  do i=1,nvmodes_keep
+     sum=zero_quad
+     do j=1,nmat
+        sum=sum+szzz(j,i)**2
+     end do
+     sum=one_quad/sqrt(sum)
+     if(szzz(1,i)<zero_quad) sum=-sum
+     do j=1,nmat
+        szzz(j,i)=sum*szzz(j,i)
+     end do
+     sum=zero_quad
+     do j=1,nmat
+        sum=sum+szzzd(j,i)**2
+     end do
+     sum=one_quad/sqrt(sum)
+     if(szzzd(1,i)<zero_quad) sum=-sum
+     do j=1,nmat
+        szzzd(j,i)=sum*szzzd(j,i)
+     end do
+  end do
+
+!  joint normalization:
+
+  do i=1,nvmodes_keep
+     sum=zero_quad
+     do j=1,nmat
+        sum=sum+szzz(j,i)*szzzd(j,i)
+     end do
+     sum=one_quad/sqrt(abs(sum))
+     do j=1,nmat
+        szzz(j,i)=sum*szzz(j,i)
+        szzzd(j,i)=sum*szzzd(j,i)
+     end do
+  end do
+
+ !orthoerror=zero_quad
+ !do i=1,nvmodes_keep
+ !   do j=1,nvmodes_keep
+ !      sum=zero_quad
+ !      if(i==j) sum=-one_quad
+ !      do k=1,nmat
+ !         sum=sum+szzz(k,i)*szzzd(k,j)
+ !      end do
+ !      orthoerror=max(abs(sum),orthoerror)
+ !   end do
+ !end do
+ !write(6,*)' orthoerror for szzz,szzzd=',orthoerror
+
+! check error in qmat*szzz - swww*szzz  and qmat_trans*szzzd - swww*szzzd
+  
+ !do i=1,nvmodes_keep
+ !   sum=zero_quad
+ !   rnorm=zero_quad
+ !   sumd=zero_quad
+ !   rnormd=zero_quad
+ !   do j=1,nmat
+ !      term=-swww(i)*szzz(j,i)
+ !      term2=term
+ !      do k=1,nmat
+ !         term=term+qmat(j,k)*szzz(k,i)
+ !      end do
+ !      sum=sum+term**2
+ !      rnorm=rnorm+term2**2
+ !      term=-swww(i)*szzzd(j,i)
+ !      term2=term
+ !      do k=1,nmat
+ !         term=term+qmat(k,j)*szzzd(k,i)
+ !      end do
+ !      sumd=sumd+term**2
+ !      rnormd=rnormd+term2**2
+ !   end do
+ !   write(6,*)' i,eigval/vect error check: vec,dual errs=',i,sqrt(sum/rnorm),sqrt(sumd/rnormd)
+ !end do
+  swww0 =swww
+  swwwd0=swwwd
+  szzz0 =szzz
+  szzzd0=szzzd
+  !do i=1,nvmodes_keep
+  !   write(6,*)' i,swww0(i),swwwd0(i)=',i,swww0(i),swwwd0(i)
+  !   do j=1,nmat,nmat-1
+  !      write(6,*)' i,j,szzz0(j,i),szzzd0(j,i)=',i,j,szzz0(j,i),szzzd0(j,i)
+  !   end do
+  !end do
+
+end subroutine special_eigvv
+
+subroutine iterative_improvement0(a,mu,aminv,aminvt,na,iret,errormax)
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    iterative_improvement0  compute inverse of a - mu*I
+!   prgmmr: parrish        org: np22         date:  2012-12-18
+!
+! abstract:  Compute inverse of matrix a - mu*I, where mu is current estimate of eigenvalue
+!            in inverse iteration algorithm. 
+!            
+!
+! program history log:
+!   2012-12-18  parrish
+!
+!
+! usage:
+!   input argument list:
+!     a,mu,na
+!
+!   output argument list:
+!     aminv,aminvt,iret
+!
+! attributes:
+!   language: f90
+!   machine:  ibm RS/6000 SP
+!
+!$$$ end documentation block
+
+  use m_kinds, only: r_quad,i_kind
+  use gsi_io, only: verbose
+  implicit none
+
+  integer(i_kind),intent(in)::na
+  real(r_quad),intent(in)::a(na,na),mu
+  real(r_quad),intent(inout)::aminv(na,na)
+  real(r_quad),intent(inout)::aminvt(na,na)
+  real(r_quad),intent(out):: errormax
+  integer(i_kind),intent(out)::iret
+
+  real(r_quad) am(na,na)
+  real(r_quad) sum,detam,errlimit
+  integer(i_kind) i,j,k,lpivot(na),mpivot(na)
+  real(r_quad) zero_quad,one_quad
+  logical print_verbose
+
+  print_verbose=.false.
+  if(verbose)print_verbose=.true.
+  errlimit=1000._r_quad
+  zero_quad=0._r_quad
+  one_quad=1._r_quad
+
+!  compute (A-mu*I)**(-1)
+
+  iret=0
+
+  am=zero_quad
+  do j=1,na
+     am(j,j)=-mu
+  end do
+  do j=1,na
+     do i=1,na
+        am(i,j)=am(i,j)+a(i,j)
+     end do
+  end do
+  aminv=am
+  call iminv_quad(aminv,na,detam,lpivot,mpivot)
+  if(detam==zero_quad) then
+     iret=1
+     return
+  end if
+  do j=1,na
+     do i=1,na
+        aminvt(i,j)=aminv(j,i)
+     end do
+  end do
+
+!   check inverse
+
+  errormax=zero_quad
+  do j=1,na
+     do i=1,na
+        sum=zero_quad
+        if(i==j) sum=-one_quad
+        do k=1,na
+           sum=sum+am(i,k)*aminv(k,j)
+        end do
+        errormax=max(abs(sum),errormax)
+     end do
+  end do
+  if(print_verbose)write(6,*)' delta in aminv =',errormax
+  if(errormax>errlimit) iret=-1
+
+end subroutine iterative_improvement0
+
+subroutine iterative_improvement(mu,mu_next,aminv,aminvt,bv,bw,na,istop)
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    iterative_improvement  complete one iteration of inverse iteration
+!   prgmmr: parrish        org: np22         date:  2012-12-18
+!
+! abstract:  Apply one iteration of inverse iteration, producing a new estimate for eigenvalue
+!            and eigenvector.
+!            
+!
+! program history log:
+!   2012-12-18  parrish
+!
+!
+! usage:
+!   input argument list:
+!     mu,aminv,aminvt,bv,bw,na
+!
+!   output argument list:
+!     mu_next,bv,bw,istop
+!
+! attributes:
+!   language: f90
+!   machine:  ibm RS/6000 SP
+!
+!$$$ end documentation block
+
+  use m_kinds, only: r_quad,i_kind
+  implicit none
+
+  integer(i_kind),intent(in)::na
+  integer(i_kind),intent(inout)::istop
+  real(r_quad),intent(in)::mu
+  real(r_quad),intent(in)::aminv(na,na),aminvt(na,na)
+  real(r_quad),intent(inout):: mu_next
+  real(r_quad),intent(inout)::bv(na),bw(na)
+
+  real(r_quad) bnextv(na),bnextw(na)
+  real(r_quad) factorv,factorw,sumv,sumw
+  real(r_quad) zero_quad,half_quad,one_quad,two_quad,tol_quad
+  integer(i_kind) i,j
+
+  istop=0
+  zero_quad=0.0_r_quad
+  half_quad=0.5_r_quad
+  one_quad=1.0_r_quad
+  two_quad=2.0_r_quad
+  tol_quad=10.0_r_quad**(-24)
+  bnextv=zero_quad
+  bnextw=zero_quad
+  do i=1,na
+     do j=1,na
+        bnextv(i)=bnextv(i)+aminv(i,j)*bv(j)
+        bnextw(i)=bnextw(i)+aminvt(i,j)*bw(j)
+     end do
+  end do
+
+!  compute dot prod of bnext with b
+
+  sumv=zero_quad
+  sumw=zero_quad
+  do i=1,na
+     sumv=sumv+bnextv(i)*bv(i)
+     sumw=sumw+bnextw(i)*bw(i)
+  end do
+  mu_next=mu+half_quad/sumv+half_quad/sumw
+  if(two_quad*abs(mu_next-mu)/abs(mu+mu_next) < tol_quad) istop=1
+     
+
+!   normalize bnextv and bnextw
+
+  factorv=zero_quad
+  factorw=zero_quad
+  do i=1,na
+     factorv=factorv+bnextv(i)**2
+     factorw=factorw+bnextw(i)**2
+  end do
+  factorv=one_quad/sqrt(factorv)
+  factorw=one_quad/sqrt(factorw)
+  if(bnextv(1)<zero_quad) factorv=-factorv
+  if(bnextw(1)<zero_quad) factorw=-factorw
+  do i=1,na
+     bv(i)=factorv*bnextv(i)
+     bw(i)=factorw*bnextw(i)
+  end do
+
+end subroutine iterative_improvement
+
+      subroutine iminv_quad (a,n,d,l,m)                                              
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    iminv    invert a matrix
+!
+!   prgrmmr:
+!
+! abstract:      the standard gauss-jordan method is used. the determinant           
+!                is also calculated. a determinant of zero indicates that            
+!                the matrix is singular.                                             
+!                                                                               
+! remarks        matrix a must be a general matrix                                   
+!
+! program history log:
+!   2008-06-04  safford -- add subprogram doc block
+!   2012-12-18  parrish -- create r_quad precision version
+!   2013-01-10  parrish -- change so d is absolute value of determinant and
+!                            is bounded by 1e50.  The variable d is only used
+!                            in this application if it is exactly zero, so there
+!                            is no harm in bounding by a large number.  This was
+!                            done to prevent overflow trap in debug mode.
+!
+!   input argument list:
+!     a - input matrix, destroyed in computation and replaced by resultant inverse
+!     n - order of matrix a                                               
+!     d - resultant determinant                                           
+!     l - work vector of length n                                         
+!     m - work vector of length n                                         
+!
+!   output argument list:
+!     a - input matrix, destroyed in computation and replaced by resultant inverse
+!
+! attributes:
+!   language:  f90
+!   machine:   ibm RS/6000 SP
+!
+!$$$ end documentation block
+
+        use m_kinds,only: r_quad,i_kind
+        implicit none
+
+        integer(i_kind)             ,intent(in   ) :: n
+        integer(i_kind),dimension(n),intent(inout) :: l,m
+        real(r_quad)                ,intent(inout) :: d
+        real(r_quad),dimension(n*n) ,intent(inout) :: a
+
+        integer(i_kind):: nk,k,j,iz,i,ij
+        integer(i_kind):: kj,ik,jr,jq,jk,ki,kk,jp,ji
+
+        real(r_quad):: biga,hold
+        real(r_quad):: zero_quad,one_quad
+        real(r_quad) dmax
+!                                                                               
+!        if a double precision version of this routine is desired, the          
+!        ! in column 1 should be removed from the double precision              
+!        statement which follows.                                               
+!                                                                               
+!     double precision a, d, biga, hold                                         
+!                                                                               
+!        the ! must also be removed from double precision statements            
+!        appearing in other routines used in conjunction with this              
+!        routine.                                                               
+!                                                                               
+!        the double precision version of this sr........ must also              
+!        contain double precision fortran functions.  abs in statemen           
+!        10 must be changed to dabs  .                                          
+!                                                                               
+!        ...............................................................        
+
+         zero_quad=0.0_r_quad
+         one_quad=1.0_r_quad
+         dmax=(10.0_r_quad)**50
+!                                                                               
+!        search for largest element                                             
+!                                                                               
+         d=one_quad
+         nk=-n
+         do 80 k=1,n
+            nk=nk+n
+            l(k)=k
+            m(k)=k
+            kk=nk+k
+            biga=a(kk)
+            do 20 j=k,n
+               iz=n*(j-1)
+               do 20 i=k,n
+                  ij=iz+i
+   10             if(abs(biga)-abs(a(ij))) 15,20,20
+   15             biga=a(ij)
+                  l(k)=i
+                  m(k)=j
+   20       continue
+!
+!        interchange rows
+!
+            j=l(k)
+            if(j-k) 35,35,25
+   25       ki=k-n
+            do 30 i=1,n
+               ki=ki+n
+               hold=-a(ki)
+               ji=ki-k+j
+               a(ki)=a(ji)
+   30          a(ji) =hold
+!
+!        interchange columns
+!
+   35          i=m(k)
+               if(i-k) 45,45,38
+   38          jp=n*(i-1)
+               do 40 j=1,n
+                  jk=nk+j
+                  ji=jp+j
+                  hold=-a(jk)
+                  a(jk)=a(ji)
+   40             a(ji) =hold
+!
+!        divide column by minus pivot (value of pivot element is
+!        contained in biga)
+!
+   45             if(biga) 48,46,48
+   46             d=zero_quad
+                  return
+   48             do 55 i=1,n
+                     if(i-k) 50,55,50
+   50                ik=nk+i
+                     a(ik)=a(ik)/(-biga)
+   55             continue
+!
+!        reduce matrix
+!
+                  do 65 i=1,n
+                     ik=nk+i
+                     ij=i-n
+                     do 65 j=1,n
+                        ij=ij+n
+                        if(i-k) 60,65,60
+   60                   if(j-k) 62,65,62
+   62                   kj=ij-i+k
+                        a(ij)=a(ik)*a(kj)+a(ij)
+   65             continue
+!
+!        divide row by pivot
+!
+                  kj=k-n
+                  do 75 j=1,n
+                     kj=kj+n
+                     if(j-k) 70,75,70
+   70                a(kj)=a(kj)/biga
+   75             continue
+!
+!        product of pivots
+!
+                  d=min(dmax,abs(d*biga))
+!
+!        replace pivot by reciprocal
+!
+                  a(kk)=one_quad/biga
+   80    continue
+!
+!        final row and column interchange
+!
+         k=n
+         do 
+  100       k=(k-1)
+            if(k) 150,150,105
+  105       i=l(k)
+            if(i-k) 120,120,108
+  108       jq=n*(k-1)
+            jr=n*(i-1)
+            do 110 j=1,n
+               jk=jq+j
+               hold=a(jk)
+               ji=jr+j
+               a(jk)=-a(ji)
+               a(ji) =hold
+  110       continue
+  120       j=m(k)
+            if(j-k) 100,100,125
+  125       ki=k-n
+            do 130 i=1,n
+               ki=ki+n
+               hold=a(ki)
+               ji=ki-k+j
+               a(ki)=-a(ji)
+               a(ji) =hold
+  130       continue
+         end do
+  150    return
+      end subroutine iminv_quad

--- a/src/gsibec/gsi/psichi2uv_reg.f90
+++ b/src/gsibec/gsi/psichi2uv_reg.f90
@@ -1,0 +1,456 @@
+subroutine psichi2uv_reg( psi, chi,  u, v)
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    psichi2uv_reg
+!     prgmmr:    barker, d   org:  np22              date:  2000-02-03
+!
+! abstract:  Calculate wind components u and v from psi and chi 
+!            (streamfunction and velocity potential, respectively)
+!
+! program history log:
+!   2000/02/03   barker, dale - creation of F90 version
+!   2001/10/30   barker       - parallel version
+!   2003/09/05   parrish      - adapted to unified NCEP 3dvar
+!   2003/10/17   wu, wanshu   - first index Y second X
+!   2004-06-22   treadon      - update documentation
+!   2008-04-23   safford      - rm unused vars
+!   2009-04-19   derber       - modify to fit gsi
+!
+!   input argument list:
+!     psi - streamfunction
+!     chi - velocity potential
+!
+!   output argument list:
+!     u - zonal wind component
+!     v - meridional wind component
+!
+! remarks:
+!    The method used is 
+!       u = ( -dpsi/dy + dchi/dx )
+!       v = (  dpsi/dx + dchi/dy )
+!
+!    The assumptions made in this routine are:
+!       - unstaggered grid,
+!       - lateral boundary conditions - dpsi/dn, dchi/dn = 0 (FCT)
+!       - dy=rearth*dph , dx=cos(ph)*rearth*dlm (dx,dy is rotated grid)
+!
+! attributes:
+!   language: f90
+!   machine:  ibm rs/6000 sp
+!
+!$$$ end documentation block
+
+  use m_kinds, only: r_kind,i_kind
+  use constants, only: half
+  use gridmod, only: coeffx,coeffy,nlat,nlon
+  
+  implicit none
+  
+  real(r_kind), intent(in   ) :: psi(nlat,nlon) ! Stream function
+  real(r_kind), intent(in   ) :: chi(nlat,nlon) ! Velocity potential
+  real(r_kind), intent(  out) :: u(nlat,nlon)   ! u wind comp (m/s)
+  real(r_kind), intent(  out) :: v(nlat,nlon)   ! v wind comp (m/s)
+  
+  integer(i_kind)             :: i, j           ! Loop counters.
+  
+
+
+!------------------------------------------------------------------------------
+!  [2.0] Compute u, v at interior points (2nd order central finite diffs):
+!------------------------------------------------------------------------------
+
+  do j = 2,nlon-1
+     do i = 2,nlat-1
+        u(i,j) = -( psi(i+1,j  ) - psi(i-1,j  ) )*coeffy(i,j) + &
+                  ( chi(i  ,j+1) - chi(i  ,j-1) )*coeffx(i,j)
+
+        v(i,j) =  ( psi(i  ,j+1) - psi(i  ,j-1) )*coeffx(i,j) + &
+                  ( chi(i+1,j  ) - chi(i-1,j  ) )*coeffy(i,j)
+     end do
+  end do
+     
+
+!------------------------------------------------------------------------------
+!  [3.0] Compute u, v at domain boundaries:
+!------------------------------------------------------------------------------
+
+!    [3.1] Western boundaries:
+
+  j = 1
+  do i = 2,nlat-1
+     u(i,j) = -( psi(i+1,j  ) - psi(i-1,j  ) )*coeffy(i,j) + &
+               ( chi(i  ,j+2) - chi(i  ,j  ) )*coeffx(i,j)
+     v(i,j) =  ( psi(i  ,j+2) - psi(i  ,j  ) )*coeffx(i,j) + &
+               ( chi(i+1,j  ) - chi(i-1,j  ) )*coeffy(i,j)
+  end do
+     
+!    [3.2] Eastern boundaries:
+
+  j = nlon
+  do i = 2,nlat-1
+     u(i,j) = -( psi(i+1,j  ) - psi(i-1,j  ) )*coeffy(i,j) + &
+               ( chi(i  ,j  ) - chi(i  ,j-2) )*coeffx(i,j)
+     v(i,j) =  ( psi(i  ,j  ) - psi(i  ,j-2) )*coeffx(i,j) + &
+               ( chi(i+1,j  ) - chi(i-1,j  ) )*coeffy(i,j)
+  end do
+     
+!    [3.3] Southern boundaries:
+
+  i = 1
+  do j = 2,nlon-1
+     u(i,j) = -( psi(i+2,j  ) - psi(i  ,j  ) )*coeffy(i,j) + &
+               ( chi(i  ,j+1) - chi(i  ,j-1) )*coeffx(i,j)
+ 
+     v(i,j) =  ( psi(i  ,j+1) - psi(i  ,j-1) )*coeffx(i,j) + &
+               ( chi(i+2,j  ) - chi(i  ,j  ) )*coeffy(i,j)
+           
+  end do
+     
+!    [3.4] Northern boundaries:
+
+  i = nlat
+  do j = 2,nlon-1
+     u(i,j) = -( psi(i  ,j  ) - psi(i-2,j  ) )*coeffy(i,j) + &
+               ( chi(i  ,j+1) - chi(i  ,j-1) )*coeffx(i,j)
+
+     v(i,j) =  ( psi(i  ,j+1) - psi(i  ,j-1) )*coeffx(i,j) + &
+               ( chi(i  ,j  ) - chi(i-2,j  ) )*coeffy(i,j)
+  end do
+     
+!------------------------------------------------------------------------------
+!    [4.0] Corner points (assume average of surrounding points - poor?):
+!------------------------------------------------------------------------------
+
+!    [4.1] Bottom-left point:
+
+  u(1,1) = half * ( u(2,1) + u(1,2) )
+  v(1,1) = half * ( v(2,1) + v(1,2) )
+  
+!    [4.2] Top-left point:
+
+  u(nlat,1) = half * ( u(nlat-1,1) + u(nlat,2) )
+  v(nlat,1) = half * ( v(nlat-1,1) + v(nlat,2) )
+     
+!    [4.3] Bottom-right point:
+
+  u(1,nlon) = half * ( u(2,nlon) + u(1,nlon-1) )
+  v(1,nlon) = half * ( v(2,nlon) + v(1,nlon-1) )
+     
+!    [4.4] Top-right point:
+
+  u(nlat,nlon) = half * ( u(nlat-1,nlon) + u(nlat,nlon-1) )
+  v(nlat,nlon) = half * ( v(nlat-1,nlon) + v(nlat,nlon-1) )
+     
+  
+end subroutine psichi2uv_reg
+
+subroutine delx_reg( chi,  u,vector)
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    psichi2uv_reg
+!     prgmmr:    barker, d   org:  np22              date:  2000-02-03
+!
+! abstract:  Calculate wind components u and v from psi and chi 
+!            (streamfunction and velocity potential, respectively)
+!
+! program history log:
+!   2000/02/03   barker, dale - creation of F90 version
+!   2001/10/30   barker       - parallel version
+!   2003/09/05   parrish      - adapted to unified NCEP 3dvar
+!   2003/10/17   wu, wanshu   - first index Y second X
+!   2004-06-22   treadon      - update documentation
+!   2009-04-19   derber       - modify to fit gsi
+!
+!   input argument list:
+!     chi - velocity potential
+!     vector
+!
+!   output argument list:
+!     u
+!
+! remarks:
+!    The method used is 
+!       u = ( -dpsi/dy + dchi/dx )
+!
+!    The assumptions made in this routine are:
+!       - unstaggered grid,
+!       - lateral boundary conditions - dpsi/dn, dchi/dn = 0 (FCT)
+!       - dy=rearth*dph , dx=cos(ph)*rearth*dlm (dx,dy is rotated grid)
+!
+! attributes:
+!   language: f90
+!   machine:  ibm rs/6000 sp
+!
+!$$$
+  use m_kinds, only: r_kind,i_kind
+  use constants, only: half
+  use gridmod, only: coeffx,nlat,nlon,region_dy,region_dyi
+  
+  implicit none
+  
+  
+  logical     , intent(in   ) :: vector
+  real(r_kind), intent(in   ) :: chi(nlat,nlon) ! Velocity potential
+  real(r_kind), intent(  out) :: u(nlat,nlon)   ! v wind comp (m/s)
+  
+  integer(i_kind)             :: i, j           ! Loop counters.
+  real(r_kind)                :: ch2(nlat,nlon)
+
+  if(vector) then
+     do j=1,nlon
+        do i=1,nlat
+           ch2(i,j)=chi(i,j)*region_dy(i,j)
+        end do
+     end do
+
+!------------------------------------------------------------------------------
+!  [2.0] Compute u, v at interior points (2nd order central finite diffs):
+!------------------------------------------------------------------------------
+
+     do j = 2,nlon-1
+        do i = 1,nlat
+           u(i,j) =  ( ch2(i  ,j+1) - ch2(i  ,j-1) )*coeffx(i,j)
+
+        end do
+     end do
+     
+
+!------------------------------------------------------------------------------
+!  [3.0] Compute u, v at domain boundaries:
+!------------------------------------------------------------------------------
+
+!    [3.1] Western boundaries:
+
+     j = 1
+     do i = 1,nlat
+        u(i,j) = ( ch2(i  ,j+2) - ch2(i  ,j         ) )*coeffx(i,j)
+     end do
+
+!    [3.2] Eastern boundaries:
+
+     j = nlon
+     do i = 1,nlat
+        u(i,j) = ( ch2(i  ,j  ) - ch2(i  ,j-2) )*coeffx(i,j)
+     end do
+
+  else
+
+!------------------------------------------------------------------------------
+!  [2.0] Compute u, v at interior points (2nd order central finite diffs):
+!------------------------------------------------------------------------------
+
+     do j = 2,nlon-1
+        do i = 1,nlat
+           u(i,j) =  ( chi(i  ,j+1) - chi(i  ,j-1) )*coeffx(i,j)
+
+        end do
+     end do
+
+
+!------------------------------------------------------------------------------
+!  [3.0] Compute u, v at domain boundaries:
+!------------------------------------------------------------------------------
+
+!    [3.1] Western boundaries:
+
+     j = 1
+     do i = 1,nlat
+        u(i,j) = ( chi(i  ,j+2) - chi(i  ,j  ) )*coeffx(i,j)
+     end do
+
+!    [3.2] Eastern boundaries:
+
+     j = nlon
+     do i = 1,nlat
+        u(i,j) = ( chi(i  ,j  ) - chi(i  ,j-2) )*coeffx(i,j)
+     end do
+
+  end if
+
+!------------------------------------------------------------------------------
+!    [4.0] Corner points (assume average of surrounding points - poor?):
+!------------------------------------------------------------------------------
+
+!    [4.1] Bottom-left point:
+
+  u(1   ,1   ) = half * ( u(2     ,1   ) + u(1   ,2  ) )
+ 
+!    [4.2] Top-left point:
+
+  u(nlat,1   ) = half * ( u(nlat-1,1   ) + u(nlat,2  ) )
+     
+!    [4.3] Bottom-right point:
+
+  u(1,nlon   ) = half * ( u(2     ,nlon) + u(1   ,nlon-1) )
+     
+!    [4.4] Top-right point:
+
+  u(nlat,nlon) = half * ( u(nlat-1,nlon) + u(nlat,nlon-1) )
+
+  if(vector) then
+     do j=1,nlon
+        do i=1,nlat
+           u(i,j)=u(i,j)*region_dyi(i,j)
+        end do
+     end do
+  end if
+     
+end subroutine delx_reg
+
+subroutine dely_reg( chi,  v,vector) 
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    psichi2uv_reg
+!     prgmmr:    barker, d   org:  np22              date:  2000-02-03
+!
+! abstract:  Calculate wind components u and v from psi and chi 
+!            (streamfunction and velocity potential, respectively)
+!
+! program history log:
+!   2000/02/03   barker, dale - creation of F90 version
+!   2001/10/30   barker       - parallel version
+!   2003/09/05   parrish      - adapted to unified NCEP 3dvar
+!   2003/10/17   wu, wanshu   - first index Y second X
+!   2004-06-22   treadon      - update documentation
+!   2009-04-19   derber       - modify to fit gsi
+!
+!   input argument list:
+!     chi - velocity potential
+!     vector
+!
+!   output argument list:
+!     v - meridional wind component
+!
+! remarks:
+!    The method used is 
+!       u = ( dchi/dx )
+!
+!    The assumptions made in this routine are:
+!       - unstaggered grid,
+!       - lateral boundary conditions - dpsi/dn, dchi/dn = 0 (FCT)
+!       - dy=rearth*dph , dx=cos(ph)*rearth*dlm (dx,dy is rotated grid)
+!
+! attributes:
+!   language: f90
+!   machine:  ibm rs/6000 sp
+!
+!$$$
+  use m_kinds, only: r_kind,i_kind
+  use constants, only: half
+  use gridmod, only: coeffy,nlat,nlon,region_dx,region_dxi
+  
+  implicit none
+  
+  logical     , intent(in   ) :: vector
+  real(r_kind), intent(in   ) :: chi(nlat,nlon) ! Velocity potential
+  real(r_kind), intent(  out) :: v(nlat,nlon)   ! v wind comp (m/s)
+  
+  integer(i_kind)             :: i, j           ! Loop counters.
+  real(r_kind)                :: ch2(nlat,nlon)
+  
+  if(vector) then
+     do j=1,nlon
+        do i=1,nlat
+           ch2(i,j)=chi(i,j)*region_dx(i,j)
+        end do
+     end do
+
+!------------------------------------------------------------------------------
+!  [2.0] Compute u, v at interior points (2nd order central finite diffs):
+!------------------------------------------------------------------------------
+
+     do j = 1,nlon
+        do i = 2,nlat-1
+
+           v(i,j) =  ( ch2(i+1,j  ) - ch2(i-1,j  ) ) * coeffy(i,j)
+        end do
+     end do
+     
+
+!------------------------------------------------------------------------------
+!  [3.0] Compute u, v at domain boundaries:
+!------------------------------------------------------------------------------
+
+!    [3.3] Southern boundaries:
+
+     i = 1
+     do j = 1,nlon
+ 
+        v(i,j) = ( ch2(i+2,j  ) - ch2(i  ,j  ) ) * coeffy(i,j)
+
+     end do
+     
+!    [3.4] Northern boundaries:
+
+     i = nlat
+     do j = 1,nlon
+ 
+        v(i,j) = ( ch2(i  ,j  ) - ch2(i-2,j  ) ) * coeffy(i,j)
+     end do
+     
+  else
+
+!------------------------------------------------------------------------------
+!  [2.0] Compute u, v at interior points (2nd order central finite diffs):
+!------------------------------------------------------------------------------
+
+     do j = 1,nlon
+        do i = 2,nlat-1
+
+           v(i,j) =  ( chi(i+1,j  ) - chi(i-1,j  ) ) * coeffy(i,j)
+        end do
+     end do
+
+
+!------------------------------------------------------------------------------
+!  [3.0] Compute u, v at domain boundaries:
+!------------------------------------------------------------------------------
+
+!    [3.3] Southern boundaries:
+
+     i = 1
+     do j = 1,nlon
+
+        v(i,j) = ( chi(i+2,j  ) - chi(i  ,j  ) ) * coeffy(i,j)
+
+     end do
+
+!    [3.4] Northern boundaries:
+
+     i = nlat
+     do j = 1,nlon
+
+        v(i,j) = ( chi(i  ,j  ) - chi(i-2,j  ) ) * coeffy(i,j)
+     end do
+
+  end if
+
+!------------------------------------------------------------------------------
+!    [4.0] Corner points (assume average of surrounding points - poor?):
+!------------------------------------------------------------------------------
+
+!    [4.1] Bottom-left point:
+
+  v(1   ,1   ) = half * ( v(2     ,1   ) + v(1   ,2  ) )
+  
+!    [4.2] Top-left point:
+
+  v(nlat,1   ) = half * ( v(nlat-1,1   ) + v(nlat,2  ) )
+     
+!    [4.3] Bottom-right point:
+
+  v(1   ,nlon) = half * ( v(2     ,nlon) + v(1   ,nlon-1) )
+     
+!    [4.4] Top-right point:
+
+  v(nlat,nlon) = half * ( v(nlat-1,nlon) + v(nlat,nlon-1) )
+     
+  if(vector) then
+     do j=1,nlon
+        do i=1,nlat
+           v(i,j)=v(i,j)*region_dxi(i,j)
+        end do
+     end do
+  end if
+  
+end subroutine dely_reg

--- a/src/gsibec/gsi/psichi2uvt_reg.f90
+++ b/src/gsibec/gsi/psichi2uvt_reg.f90
@@ -1,0 +1,522 @@
+subroutine psichi2uvt_reg( u, v,  psi, chi)
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    psichi2uvt_reg
+!     prgmmr:    barker, d   org:  np22              date:  2000-02-03
+!
+! abstract:  Calculate adjoint of psi and chi from adjoint of 
+!            wind components u and v.
+!
+! program history log:
+!   2000/02/03   barker, dale - creation of F90 version
+!   2001/10/30   barker       - parallel version
+!   2003/09/05   parrish      - adapted to unified NCEP 3dvar
+!   2003/10/17   wu, wanshu   - first index Y second X
+!   2004-06-22   treadon      - update documentation
+!   2008-04-23   safford      - rm unused vars
+!   2009-04-19   derber       - modify to fit gsi
+!
+!   input argument list:
+!     u - adjoint of zonal wind component
+!     v - adjoint of meridional wind component
+!
+!   output argument list:
+!     psi - adjoint of streamfunction
+!     chi - adjoint of velocity potential
+!
+! remarks:
+!    The method used is 
+!       u = ( -dpsi/dy + dchi/dx )
+!       v = (  dpsi/dx + dchi/dy )
+!
+!    The assumptions made in this routine are:
+!       - unstaggered grid,
+!       - lateral boundary conditions - dpsi/dn, dchi/dn = 0 (FCT)
+!       - dy=rearth*dph , dx=cos(ph)*rearth*dlm (dx,dy is rotated grid)
+!
+! attributes:
+!   language: f90
+!   machine:  ibm rs/6000 sp
+!
+!$$$
+  use m_kinds, only: r_kind,i_kind
+  use constants, only: zero,half
+  use gridmod, only:  coeffx,coeffy,nlat,nlon
+  implicit none
+  
+  
+  real(r_kind),intent(inout) :: u(nlat,nlon)   ! u wind comp (m/s)
+  real(r_kind),intent(inout) :: v(nlat,nlon)   ! v wind comp (m/s)
+  real(r_kind),intent(inout) :: psi(nlat,nlon) ! Stream function
+  real(r_kind),intent(inout) :: chi(nlat,nlon) ! Velocity potential
+  
+  integer(i_kind)           :: i, j           ! Loop counters.
+  real(r_kind)              :: coeffx_u       ! Multiplicative coefficient.
+  real(r_kind)              :: coeffy_u       ! Multiplicative coefficient.
+  real(r_kind)              :: coeffx_v       ! Multiplicative coefficient.
+  real(r_kind)              :: coeffy_v       ! Multiplicative coefficient.
+  
+!------------------------------------------------------------------------------
+!  [1.0] Initialise:
+!------------------------------------------------------------------------------
+
+  psi=zero
+  chi=zero
+
+   
+!------------------------------------------------------------------------------
+!     [4.0] Corner points (assume average of surrounding points - poor?):
+!------------------------------------------------------------------------------
+
+!    [4.1] Bottom-left point:
+
+  u(2,1) = u(2,1) + half * u(1,1)
+  u(1,2) = u(1,2) + half * u(1,1)
+  v(2,1) = v(2,1) + half * v(1,1)
+  v(1,2) = v(1,2) + half * v(1,1)
+     
+!    [4.2] Top-left point:
+
+  u(nlat-1,1) = u(nlat-1,1) + half * u(nlat,1)
+  u(nlat  ,2) = u(nlat  ,2) + half * u(nlat,1)
+  v(nlat-1,1) = v(nlat-1,1) + half * v(nlat,1)
+  v(nlat  ,2) = v(nlat  ,2) + half * v(nlat,1)
+   
+!    [4.3] Bottom-right point:
+
+  u(2,nlon  ) = u(2,nlon  ) + half * u(1,nlon)
+  u(1,nlon-1) = u(1,nlon-1) + half * u(1,nlon)
+  v(2,nlon  ) = v(2,nlon  ) + half * v(1,nlon)
+  v(1,nlon-1) = v(1,nlon-1) + half * v(1,nlon)
+
+!    [4.4] Top-right point:
+
+  u(nlat-1,nlon  ) = u(nlat-1,nlon  ) + half * u(nlat,nlon)
+  u(nlat  ,nlon-1) = u(nlat  ,nlon-1) + half * u(nlat,nlon)
+  v(nlat-1,nlon  ) = v(nlat-1,nlon  ) + half * v(nlat,nlon)
+  v(nlat  ,nlon-1) = v(nlat  ,nlon-1) + half * v(nlat,nlon)
+     
+!------------------------------------------------------------------------------
+! [3.0] Compute u, v at domain boundaries:
+!------------------------------------------------------------------------------
+
+   
+!    [3.4] Northern boundaries:
+
+        
+  do j = 2,nlon-1
+     coeffy_u = coeffy(nlat,j) * u(nlat,j)
+     coeffx_u = coeffx(nlat,j) * u(nlat,j)
+     coeffy_v = coeffy(nlat,j) * v(nlat,j)
+     coeffx_v = coeffx(nlat,j) * v(nlat,j)
+ 
+     psi(nlat  ,j+1) = psi(nlat  ,j+1) + coeffx_v
+     psi(nlat  ,j-1) = psi(nlat  ,j-1) - coeffx_v
+     chi(nlat  ,j  ) = chi(nlat  ,j  ) + coeffy_v
+     chi(nlat-2,j  ) = chi(nlat-2,j  ) - coeffy_v
+           
+     psi(nlat  ,j  ) = psi(nlat  ,j  ) - coeffy_u
+     psi(nlat-2,j  ) = psi(nlat-2,j  ) + coeffy_u
+     chi(nlat  ,j+1) = chi(nlat  ,j+1) + coeffx_u
+     chi(nlat  ,j-1) = chi(nlat  ,j-1) - coeffx_u
+  end do
+      
+!    [3.3] Southern boundaries:
+
+ 
+  do j = 2,nlon-1
+     coeffy_u = coeffy(1,j) * u(1,j)
+     coeffx_u = coeffx(1,j) * u(1,j)
+     coeffy_v = coeffy(1,j) * v(1,j)
+     coeffx_v = coeffx(1,j) * v(1,j)
+ 
+     psi(1,j+1) = psi(1,j+1) + coeffx_v
+     psi(1,j-1) = psi(1,j-1) - coeffx_v
+     chi(3,j  ) = chi(3,j  ) + coeffy_v
+     chi(1,j  ) = chi(1,j  ) - coeffy_v
+ 
+     psi(3,j  ) = psi(3,j  ) - coeffy_u
+     psi(1,j  ) = psi(1,j  ) + coeffy_u
+     chi(1,j+1) = chi(1,j+1) + coeffx_u
+     chi(1,j-1) = chi(1,j-1) - coeffx_u
+ 
+  end do
+      
+!    [3.2] Eastern boundaries:
+
+ 
+  do i = 2,nlat-1
+     coeffy_u = coeffy(i,nlon) * u(i,nlon)
+     coeffx_u = coeffx(i,nlon) * u(i,nlon)
+     coeffy_v = coeffy(i,nlon) * v(i,nlon)
+     coeffx_v = coeffx(i,nlon) * v(i,nlon)
+ 
+     psi(i  ,nlon  ) = psi(i  ,nlon  ) + coeffx_v
+     psi(i  ,nlon-2) = psi(i  ,nlon-2) - coeffx_v
+     chi(i+1,nlon  ) = chi(i+1,nlon  ) + coeffy_v
+     chi(i-1,nlon  ) = chi(i-1,nlon  ) - coeffy_v
+
+     psi(i+1,nlon  ) = psi(i+1,nlon  ) - coeffy_u
+     psi(i-1,nlon  ) = psi(i-1,nlon  ) + coeffy_u
+     chi(i  ,nlon  ) = chi(i  ,nlon  ) + coeffx_u
+     chi(i  ,nlon-2) = chi(i  ,nlon-2) - coeffx_u
+
+  end do
+ 
+!    [3.1] Western boundaries:
+ 
+  do i = 2,nlat-1
+     coeffy_u = coeffy(i,1) * u(i,1)
+     coeffx_u = coeffx(i,1) * u(i,1)
+     coeffy_v = coeffy(i,1) * v(i,1)
+     coeffx_v = coeffx(i,1) * v(i,1)
+
+     psi(i  ,3) = psi(i  ,3) + coeffx_v
+     psi(i  ,1) = psi(i  ,1) - coeffx_v
+     chi(i+1,1) = chi(i+1,1) + coeffy_v
+     chi(i-1,1) = chi(i-1,1) - coeffy_v
+ 
+     psi(i+1,1) = psi(i+1,1) - coeffy_u
+     psi(i-1,1) = psi(i-1,1) + coeffy_u
+     chi(i  ,3) = chi(i  ,3) + coeffx_u
+     chi(i  ,1) = chi(i  ,1) - coeffx_u
+ 
+  end do
+     
+!------------------------------------------------------------------------------
+!  [2.0] Compute u, v at interior points (2nd order central finite diffs):
+!------------------------------------------------------------------------------
+
+  do j = 2,nlon-1
+     do i = 2,nlat-1
+        coeffy_u = coeffy(i,j) * u(i,j)
+        coeffx_u = coeffx(i,j) * u(i,j)
+        coeffy_v = coeffy(i,j) * v(i,j)
+        coeffx_v = coeffx(i,j) * v(i,j)
+ 
+        psi(i+1,j  ) = psi(i+1,j   ) - coeffy_u
+        psi(i-1,j  ) = psi(i-1,j   ) + coeffy_u
+        chi(i  ,j+1) = chi(i  ,j+1) + coeffx_u
+        chi(i  ,j-1) = chi(i  ,j-1) - coeffx_u
+ 
+        psi(i  ,j+1) = psi(i  ,j+1) + coeffx_v
+        psi(i  ,j-1) = psi(i  ,j-1) - coeffx_v
+        chi(i+1,j  ) = chi(i+1,j  ) + coeffy_v
+        chi(i-1,j  ) = chi(i-1,j  ) - coeffy_v
+ 
+     end do
+  end do
+  
+end subroutine psichi2uvt_reg
+
+subroutine tdelx_reg( u,  chi,vector) 
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    psichi2uvt_reg
+!     prgmmr:    barker, d   org:  np22              date:  2000-02-03
+!
+! abstract:  Calculate adjoint of psi and chi from adjoint of 
+!            wind components u and v.
+!
+! program history log:
+!   2000/02/03   barker, dale - creation of F90 version
+!   2001/10/30   barker       - parallel version
+!   2003/09/05   parrish      - adapted to unified NCEP 3dvar
+!   2003/10/17   wu, wanshu   - first index Y second X
+!   2004-06-22   treadon      - update documentation
+!   2009-04-19   derber       - modify to fit gsi
+!
+!   input argument list:
+!     u - adjoint of zonal wind component
+!     vector
+!
+!   output argument list:
+!     chi - adjoint of x derivative
+!
+! remarks:
+!    The method used is 
+!
+!    The assumptions made in this routine are:
+!       - unstaggered grid,
+!       - lateral boundary conditions - dchi/dn = 0 (FCT)
+!       - dy=rearth*dph , dx=cos(ph)*rearth*dlm (dx,dy is rotated grid)
+!
+! attributes:
+!   language: f90
+!   machine:  ibm rs/6000 sp
+!
+!$$$
+  use m_kinds, only: r_kind,i_kind
+  use constants, only: zero,half
+  use gridmod, only: coeffx,nlat,nlon,region_dy,region_dyi
+  implicit none
+  
+  
+  logical     ,intent(in   ) :: vector
+  real(r_kind),intent(inout) :: u(nlat,nlon)   ! u wind comp (m/s)
+  real(r_kind),intent(inout) :: chi(nlat,nlon) ! Velocity potential
+  
+  integer(i_kind)            :: i, j           ! Loop counters.
+  real(r_kind)               :: coeffx_u       ! Multiplicative coefficient.
+  real(r_kind)               :: ch2(nlat,nlon)
+  real(r_kind)               :: u2(nlat,nlon)
+  
+  if(vector) then
+     do j=1,nlon
+        do i=1,nlat
+           u2(i,j)=u(i,j)*region_dyi(i,j)
+        end do
+     end do
+  else
+     do j=1,nlon
+        do i=1,nlat
+           u2(i,j)=u(i,j)
+        end do
+     end do
+  end if
+  
+   
+!------------------------------------------------------------------------------
+!     [4.0] Corner points (assume average of surrounding points - poor?):
+!------------------------------------------------------------------------------
+
+!    [4.1] Bottom-left point:
+
+  u2(2,1) = u2(2,1) + half * u2(1,1)
+  u2(1,2) = u2(1,2) + half * u2(1,1)
+  u2(1,1) = zero
+
+!    [4.2] Top-left point:
+
+  u2(nlat-1,1) = u2(nlat-1,1) + half * u2(nlat,1)
+  u2(nlat  ,2) = u2(nlat  ,2) + half * u2(nlat,1)
+  u2(nlat  ,1) = zero
+ 
+!    [4.3] Bottom-right point:
+
+  u2(2,nlon  ) = u2(2,nlon  ) + half * u2(1,nlon)
+  u2(1,nlon-1) = u2(1,nlon-1) + half * u2(1,nlon)
+  u2(1,nlon)   = zero
+
+!    [4.4] Top-right point:
+
+  u2(nlat-1,nlon  ) = u2(nlat-1,nlon  ) + half * u2(nlat,nlon)
+  u2(nlat  ,nlon-1) = u2(nlat  ,nlon-1) + half * u2(nlat,nlon)
+  u2(nlat,nlon)=zero
+
+  ch2=zero
+
+!------------------------------------------------------------------------------
+! [3.0] Compute u at domain boundaries:
+!------------------------------------------------------------------------------
+ 
+ 
+!    [3.2] Eastern boundaries:
+
+  j = nlon
+ 
+  do i = 1,nlat
+     coeffx_u = coeffx(i,j) * u2(i,j)
+ 
+     ch2(i,j  ) = ch2(i,j  ) + coeffx_u
+     ch2(i,j-2) = ch2(i,j-2) - coeffx_u
+ 
+  end do
+
+!    [3.1] Western boundaries:
+  j = 1
+ 
+  do i = 1,nlat
+     coeffx_u = coeffx(i,j) * u2(i,j)
+ 
+     ch2(i,j+2) = ch2(i,j+2) + coeffx_u
+     ch2(i,j  ) = ch2(i,j  ) - coeffx_u
+ 
+  end do
+ 
+!------------------------------------------------------------------------------
+!  [2.0] Compute u, v at interior points (2nd order central finite diffs):
+!------------------------------------------------------------------------------
+
+  do j = 2,nlon-1
+     do i = 1,nlat
+        coeffx_u = coeffx(i,j) * u2(i,j)
+
+        ch2(i,j+1) = ch2(i,j+1) + coeffx_u
+        ch2(i,j-1) = ch2(i,j-1) - coeffx_u
+ 
+ 
+     end do
+  end do
+
+  if(vector) then
+     do j=1,nlon
+        do i=1,nlat
+           chi(i,j)=chi(i,j)+ch2(i,j)*region_dy(i,j)
+        end do
+     end do
+  else
+     do j=1,nlon
+        do i=1,nlat
+           chi(i,j)=chi(i,j)+ch2(i,j)
+        end do
+     end do
+  end if
+  
+end subroutine tdelx_reg
+
+
+subroutine tdely_reg( v,  chi,vector)
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    psichi2uvt_reg
+!     prgmmr:    barker, d   org:  np22              date:  2000-02-03
+!
+! abstract:  Calculate adjoint of psi and chi from adjoint of 
+!            wind components u and v.
+!
+! program history log:
+!   2000/02/03   barker, dale - creation of F90 version
+!   2001/10/30   barker       - parallel version
+!   2003/09/05   parrish      - adapted to unified NCEP 3dvar
+!   2003/10/17   wu, wanshu   - first index Y second X
+!   2004-06-22   treadon      - update documentation
+!   2005-09-28   parrish      - fix bug in computing derivatives
+!                               along western boundaries
+!   2009-04-19   derber       - modify to fit gsi
+!
+!   input argument list:
+!     v - adjoint of meridional wind component
+!     vector
+!
+!   output argument list:
+!     chi - adjoint of y derivative
+!
+! remarks:
+!    The method used is 
+!       v = (  dchi/dy )
+!
+!    The assumptions made in this routine are:
+!       - unstaggered grid,
+!       - lateral boundary conditions - dpsi/dn, dchi/dn = 0 (FCT)
+!       - dy=rearth*dph , dx=cos(ph)*rearth*dlm (dx,dy is rotated grid)
+!
+! attributes:
+!   language: f90
+!   machine:  ibm rs/6000 sp
+!
+!$$$
+  use m_kinds, only: r_kind,i_kind
+  use constants, only: zero,half
+  use gridmod, only: coeffy,nlat,nlon,region_dx,region_dxi
+  implicit none
+  
+  logical     ,intent(in   ) :: vector
+  real(r_kind),intent(inout) :: v(nlat,nlon)   ! v wind comp (m/s)
+  real(r_kind),intent(inout) :: chi(nlat,nlon) ! Velocity potential
+  
+  integer(i_kind)           :: i, j                       ! Loop counters.
+  real(r_kind)              :: coeffy_v                   ! Multiplicative coefficient.
+  real(r_kind)              :: ch2(nlat,nlon)
+  real(r_kind)              :: v2(nlat,nlon)
+  
+  if(vector) then
+     do j=1,nlon
+        do i=1,nlat
+           v2(i,j)=v(i,j)*region_dxi(i,j)
+        end do
+     end do
+  else
+     do j=1,nlon
+        do i=1,nlat
+           v2(i,j)=v(i,j)
+        end do
+     end do
+  end if
+
+
+!------------------------------------------------------------------------------
+!     [4.0] Corner points (assume average of surrounding points - poor?):
+!------------------------------------------------------------------------------
+
+!    [4.1] Bottom-left point:
+
+  v2(2,1) = v2(2,1) + half * v2(1,1)
+  v2(1,2) = v2(1,2) + half * v2(1,1)
+  v2(1,1) = zero
+ 
+!    [4.2] Top-left point:
+
+  v2(nlat-1,1) = v2(nlat-1,1) + half * v2(nlat,1)
+  v2(nlat  ,2) = v2(nlat  ,2) + half * v2(nlat,1)
+  v2(nlat,1)      = zero
+ 
+!    [4.3] Bottom-right point:
+
+  v2(2,nlon  ) = v2(2,nlon  ) + half * v2(1,nlon)
+  v2(1,nlon-1) = v2(1,nlon-1) + half * v2(1,nlon)
+  v2(1,nlon  ) = zero
+
+!    [4.4] Top-right point:
+
+  v2(nlat-1,nlon  ) = v2(nlat-1,nlon  ) + half * v2(nlat,nlon)
+  v2(nlat  ,nlon-1) = v2(nlat  ,nlon-1) + half * v2(nlat,nlon)
+  v2(nlat  ,nlon  ) = zero
+ 
+!------------------------------------------------------------------------------
+! [3.0] Compute u, v at domain boundaries:
+!------------------------------------------------------------------------------
+
+  ch2=zero
+
+  i=nlat
+  do j = 1,nlon
+     coeffy_v = coeffy(i,j) * v2(i,j)
+ 
+     ch2(i  ,j) = ch2(i  ,j) + coeffy_v
+     ch2(i-2,j) = ch2(i-2,j) - coeffy_v
+ 
+  end do
+      
+!    [3.3] Southern boundaries:
+
+  i = 1
+
+  do j = 1,nlon
+     coeffy_v = coeffy(i,j) * v2(i,j)
+ 
+     ch2(i+2,j) = ch2(i+2,j) + coeffy_v
+     ch2(i  ,j) = ch2(i  ,j) - coeffy_v
+ 
+  end do
+ 
+ 
+!------------------------------------------------------------------------------
+!  [2.0] Compute u, v at interior points (2nd order central finite diffs):
+!------------------------------------------------------------------------------
+
+  do j = 1,nlon
+     do i = 2,nlat-1
+        coeffy_v = coeffy(i,j) * v2(i,j)
+
+        ch2(i+1,j) = ch2(i+1,j) + coeffy_v
+        ch2(i-1,j) = ch2(i-1,j) - coeffy_v
+ 
+     end do
+  end do
+
+  if(vector) then
+     do j=1,nlon
+        do i=1,nlat
+           chi(i,j)=chi(i,j)+ch2(i,j)*region_dx(i,j)
+        end do
+     end do
+  else
+     do j=1,nlon
+        do i=1,nlat
+           chi(i,j)=chi(i,j)+ch2(i,j)
+        end do
+     end do
+  end if
+  
+end subroutine tdely_reg

--- a/src/gsibec/gsi/rtlnmc_version3.f90
+++ b/src/gsibec/gsi/rtlnmc_version3.f90
@@ -1,0 +1,4396 @@
+! following contains library for version 3 of rtlnmc (regional tangent linear normal mode constraint.
+!  
+!
+
+module helmholtz_fmg_mod
+
+!  multigrid solver on fixed domain with 5 point stencil and dirichlet bc.
+
+!     TO DO:
+
+!   coded       tested     (NOTE:  pay special attention to boundary treatment--likely several errors to fix)
+
+!  20090215    20090215         grid heirarchy generator
+!  20090216    20090216         transfer operators
+!  20090216    20090216         bilinear interpolation operator
+!  20090216    20090216         bicubic  interpolation operaror
+!  20090216    20090217         forward operator  ( f = delsqr(v) - r*v )
+!  20090216    20090220         relaxation operator
+!  20090216    20090225         fmg algorithm
+!  20090227    20090309         fmg_ad
+
+  use m_kinds, only: r_kind,i_kind
+  implicit none
+  private
+  public :: mgvar
+  public :: generate_grids
+  public :: check_xbdy_err
+  public :: check_ybdy_err
+  public :: f2c_full_weight
+  public :: c2f_bilinear
+  public :: c2f_bicubic
+  public :: init_mgvars
+  public :: fmg
+  public :: fmg_ad
+
+  type mgvar
+
+    sequence
+    integer(i_kind) nx                                ! x dimension is 0:nx       east-west
+    integer(i_kind) ny                                ! y dimension is 0:ny       north-south
+    real(r_kind)    phi0                              ! scale geopotential
+    real(r_kind) a_east,b_east,a_east_inv             !  for dirichlet boundary conditions, interpolation
+    real(r_kind) a_north,b_north,a_north_inv          !  boundary weights on east and north bdy
+    real(r_kind) b_over_a_east,b_over_a_east_neg      !  boundary values (note, with fmg these all = 0 except
+    real(r_kind) b_over_a_north,b_over_a_north_neg    !   on finest grid, where solution is desired.
+    real(r_kind) half_b_over_a_east_neg               !  but this code is specific to zero bc.
+    real(r_kind) half_b_over_a_north_neg              !
+    real(r_kind) half_b_over_a_east_north_neg         !  boundary formula (weights are for lin interp):
+                                                      !
+                                                      !  a_east*v(j,nx)+b_east*v(j,nx-1) = 0
+                                                      !               for j=1,ny-1
+                                                      !
+                                                      !  a_north*v(ny,i)+b_north*v(ny-1,i) = 0
+                                                      !               for i=1,nx-1
+
+    real(r_kind),pointer:: f(:,:)      => NULL()    !  residual (forcing on finest grid)
+    real(r_kind),pointer:: v(:,:)      => NULL()    !  correction (solution on finest grid)
+    real(r_kind),pointer:: w(:,:)      => NULL()    !  scratch space
+    real(r_kind),pointer:: w2(:,:)     => NULL()    !  scratch space
+    real(r_kind),pointer:: y(:,:)      => NULL()    !  scratch space
+    real(r_kind),pointer:: z(:,:)      => NULL()    !  scratch space
+    real(r_kind),pointer:: yy(:,:)     => NULL()    !  scratch space
+    real(r_kind),pointer:: zz(:,:)     => NULL()    !  scratch space
+    real(r_kind),pointer:: x00(:,:)       => NULL() ! increment in x direction (meters)
+    real(r_kind),pointer:: y00(:,:)       => NULL() ! increment in y direction (meters)
+    real(r_kind),pointer:: h00(:,:)       => NULL() ! all forward
+    real(r_kind),pointer:: r00(:,:)       => NULL() !  operator constants
+    real(r_kind),pointer:: h0m(:,:)       => NULL() ! all forward
+    real(r_kind),pointer:: h0p(:,:)       => NULL() !  operator constants
+    real(r_kind),pointer:: hm0(:,:)       => NULL() ! all forward
+    real(r_kind),pointer:: hp0(:,:)       => NULL() !  operator constants
+    real(r_kind),pointer:: dbarx(:,:)     => NULL() !  x direction  (for poisson problem)
+    real(r_kind),pointer:: ubarx(:,:)     => NULL() !   adi
+    real(r_kind),pointer:: obarx(:,:)     => NULL() !    coefs
+    real(r_kind),pointer:: dbary(:,:)     => NULL() !  y direction
+    real(r_kind),pointer:: ubary(:,:)     => NULL() !   adi
+    real(r_kind),pointer:: obary(:,:)     => NULL() !    coefs
+    real(r_kind),pointer:: dbarxh(:,:)    => NULL() !  x direction  (for helmholtz problem)
+    real(r_kind),pointer:: ubarxh(:,:)    => NULL() !   adi
+    real(r_kind),pointer:: obarxh(:,:)    => NULL() !    coefs
+    real(r_kind),pointer:: dbaryh(:,:)    => NULL() !  y direction
+    real(r_kind),pointer:: ubaryh(:,:)    => NULL() !   adi
+    real(r_kind),pointer:: obaryh(:,:)    => NULL() !    coefs
+    logical,pointer:: bicubic_mask(:,:)   => NULL() !  flags points that are covered by bicubic interpolation
+    
+  end type mgvar
+
+  integer(i_kind) mgridx,mgridy                     ! number of possible grids in each direction
+  integer(i_kind) mgrid                             ! number of grids used in multigrid solution
+                                                    !    ( = min(mgridx,mgridy)
+
+  integer(i_kind) nxall(100),nyall(100)             ! dimensions of each grid
+  integer(i_kind) nxa,nya                           ! dimensions of analysis grid  (nya,nxa)
+                                                    !  nxall(1)
+  type(mgvar),save:: mg(100)
+
+contains
+
+  subroutine generate_grids(nxa_in,nya_in)
+
+    use constants, only: half,one
+    integer(i_kind),intent(in):: nxa_in,nya_in
+
+!      grids have south and west row in common, but allow north and east row to go one grid point beyond
+!      north and east boundary of finest grid.  by doing this, it is not necessary to have any particular
+!      number of points, ie 2**p+1, so that all boundaries are part of every grid.  except for the north
+!      and east points outside the analysis domain, all interior points of all grids coincide with points
+!      of the target analysis grid.
+
+!  w                                                                   e
+!  .....................................................................
+!  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+!  .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .
+!  .       .       .       .       .       .       .       .       .   x   .
+!  .               .               .               .               .   x           . 
+!  .                               .                               .   x                           .
+
+    integer(i_kind) k
+    real(r_kind) a_end(100),b_end(100)
+
+    nxa=nxa_in
+    nya=nya_in
+    call generate_1d_grid(nxa-1,nxall,mgridx,a_end,b_end)
+    do k=1,mgridx
+      mg(k)%nx=nxall(k)
+      mg(k)%a_east=a_end(k)
+      mg(k)%a_east_inv=one/a_end(k)
+      mg(k)%b_east=b_end(k)
+      mg(k)%b_over_a_east=b_end(k)/a_end(k)
+      mg(k)%b_over_a_east_neg=-b_end(k)/a_end(k)
+      mg(k)%half_b_over_a_east_neg=-half*b_end(k)/a_end(k)
+    end do
+    call generate_1d_grid(nya-1,nyall,mgridy,a_end,b_end)
+    do k=1,mgridy
+      mg(k)%ny=nyall(k)
+      mg(k)%a_north=a_end(k)
+      mg(k)%a_north_inv=one/a_end(k)
+      mg(k)%b_north=b_end(k)
+      mg(k)%b_over_a_north=b_end(k)/a_end(k)
+      mg(k)%b_over_a_north_neg=-b_end(k)/a_end(k)
+      mg(k)%half_b_over_a_north_neg=-half*b_end(k)/a_end(k)
+    end do
+    mgrid=min(mgridx,mgridy)
+    do k=1,mgrid
+      mg(k)%half_b_over_a_east_north_neg=mg(k)%half_b_over_a_east_neg+mg(k)%half_b_over_a_north_neg
+    end do
+      write(6,*)' in generate_grids, mgridx,mgridy,mgrid=',mgridx,mgridy,mgrid
+      do k=1,mgrid
+        write(6,'(" k,nx,a_east,a_east_inv,b_east=",i3,i5,3f14.7)') &
+                   k,mg(k)%nx,mg(k)%a_east,mg(k)%a_east_inv,mg(k)%b_east
+      end do
+      do k=1,mgrid
+        write(6,'(" k,ny,a_north,a_north_inv,b_north=",i3,i5,3f14.7)') &
+                   k,mg(k)%ny,mg(k)%a_north,mg(k)%a_north_inv,mg(k)%b_north
+      end do
+
+  end subroutine generate_grids
+
+  subroutine generate_1d_grid(nxf,nxall,mgridx,a_east,b_east)
+
+    use constants, only: zero,one
+
+    integer(i_kind),intent(in):: nxf
+    integer(i_kind),intent(out):: mgridx
+    integer(i_kind),intent(out):: nxall(100)
+    real(r_kind),intent(out)::    a_east(100),b_east(100)
+
+    integer(i_kind) ifactor,k,next
+    real(r_kind) end,thisend,factor
+
+    nxall(1)=nxf
+    end=nxall(1)
+    k=1
+    ifactor=1
+    a_east(1)=one
+    b_east(1)=zero
+    do 
+      next=nxall(k)/2
+      ifactor=2*ifactor
+      if(next*ifactor <  nxall(1)) next=next+1
+      if(next <  3) exit
+      factor=ifactor
+      thisend=next*factor
+      k=k+1
+      nxall(k)=next
+      b_east(k)=(thisend-end)/factor
+      a_east(k)=one-b_east(k)
+    end do
+    mgridx=k
+
+  end subroutine generate_1d_grid
+
+  subroutine check_xbdy_err
+
+    use constants, only: zero,one,two
+
+    real(r_kind) factor,xend,errmax,xend_interp
+    integer(i_kind) k
+
+    factor=one
+    xend=mg(1)%nx
+    errmax=zero
+    do k=1,mgridx
+      xend_interp=factor*mg(k)%nx*mg(k)%a_east+factor*(mg(k)%nx-one)*mg(k)%b_east
+      errmax=max(abs(xend_interp-xend),errmax)
+      factor=two*factor
+    end do
+    write(6,*)' for nx=',mg(1)%nx,', mgridx,mgrid,east errmax=',mgridx,mgrid,errmax
+
+  end subroutine check_xbdy_err
+
+  subroutine check_ybdy_err
+
+    use constants, only: zero,one,two
+
+    real(r_kind) factor,yend,errmax,yend_interp
+    integer(i_kind) k
+
+    factor=one
+    yend=mg(1)%ny
+    errmax=zero
+    do k=1,mgridy
+      yend_interp=factor*mg(k)%ny*mg(k)%a_north+factor*(mg(k)%ny-one)*mg(k)%b_north
+      errmax=max(abs(yend_interp-yend),errmax)
+      factor=two*factor
+    end do
+    write(6,*)' for ny=',mg(1)%ny,', mgridy,mgrid,north errmax=',mgridy,mgrid,errmax
+
+  end subroutine check_ybdy_err
+
+  subroutine init_mgvars(region_dx,region_dy,region_lat,phi0)
+
+    use constants, only: zero,half,one,two,omega
+
+    real(r_kind),dimension(0:nya-1,0:nxa-1),intent(in):: region_dx,region_dy,region_lat
+    real(r_kind),intent(in):: phi0
+
+    integer(i_kind) i,j,nx,ny
+    integer(i_kind) k,jump
+    integer(i_kind) ii,im,ip,jj,jm,jp
+    real(r_kind) x00,y00,x0p,x0m,xp0,xm0,y0p,y0m,yp0,ym0
+
+    real(r_kind),dimension(0:nya-1,0:nxa-1):: dx_fine,dy_fine,coriolis_fine
+    real(r_kind),allocatable:: d(:),dh(:),u(:),o(:)
+    real(r_kind),allocatable:: dbar(:),ubar(:),obar(:)
+    real(r_kind),allocatable:: dbarh(:),ubarh(:),obarh(:)
+    integer(i_kind) ibad,jbad
+    integer(i_kind) ic,if,jc,jf
+
+    nx=mg(1)%nx ; ny=mg(1)%ny
+    if(nx /= nxa-1.or.ny /= nya-1) then
+      write(6,*)' inconsistent args in init_mgvars, nx,nxa-1,ny,nya-1=',nx,nxa-1,ny,nya-1
+      stop
+    end if
+    do i=0,nx
+      do j=0,ny
+        dx_fine(j,i)=region_dx(j,i)
+        dy_fine(j,i)=region_dy(j,i)
+        coriolis_fine(j,i)=two*omega*sin(region_lat(j,i))
+      end do
+    end do
+
+!       allocate grids at all levels
+
+    do k=1,mgrid
+      nx=mg(k)%nx ; ny=mg(k)%ny
+      mg(k)%phi0=phi0
+      allocate(mg(k)%f(0:ny,0:nx),mg(k)%v(0:ny,0:nx),mg(k)%w(0:ny,0:nx))
+      allocate(mg(k)%w2(0:ny,0:nx))
+      allocate(mg(k)%y(0:ny,0:nx),mg(k)%z(0:ny,0:nx))
+      allocate(mg(k)%yy(0:ny,0:nx),mg(k)%zz(0:ny,0:nx))
+      allocate(mg(k)%x00(0:ny,0:nx),mg(k)%y00(0:ny,0:nx))
+      allocate(mg(k)%h00(0:ny,0:nx),mg(k)%r00(0:ny,0:nx))
+      allocate(mg(k)%h0m(0:ny,0:nx),mg(k)%h0p(0:ny,0:nx))
+      allocate(mg(k)%hm0(0:ny,0:nx),mg(k)%hp0(0:ny,0:nx))
+      allocate(mg(k)%dbarx(0:ny,0:nx),mg(k)%dbary(0:ny,0:nx))
+      allocate(mg(k)%ubarx(0:ny,0:nx),mg(k)%ubary(0:ny,0:nx))
+      allocate(mg(k)%obarx(0:ny,0:nx),mg(k)%obary(0:ny,0:nx))
+      allocate(mg(k)%dbarxh(0:ny,0:nx),mg(k)%dbaryh(0:ny,0:nx))
+      allocate(mg(k)%ubarxh(0:ny,0:nx),mg(k)%ubaryh(0:ny,0:nx))
+      allocate(mg(k)%obarxh(0:ny,0:nx),mg(k)%obaryh(0:ny,0:nx))
+      allocate(mg(k)%bicubic_mask(0:ny,0:nx))
+      mg(k)%f=zero ; mg(k)%v=zero ; mg(k)%w=zero ; mg(k)%y=zero ; mg(k)%z=zero
+      mg(k)%x00=zero ; mg(k)%y00=zero
+      mg(k)%h00=zero ; mg(k)%r00=zero
+      mg(k)%h0m=zero ; mg(k)%h0p=zero ; mg(k)%hm0=zero ; mg(k)%hp0=zero
+      mg(k)%dbarx=zero ; mg(k)%dbary=zero
+      mg(k)%ubarx=zero ; mg(k)%ubary=zero
+      mg(k)%obarx=zero ; mg(k)%obary=zero
+      mg(k)%dbarxh=zero ; mg(k)%dbaryh=zero
+      mg(k)%ubarxh=zero ; mg(k)%ubaryh=zero
+      mg(k)%obarxh=zero ; mg(k)%obaryh=zero
+      mg(k)%bicubic_mask=.false.
+    end do
+
+!      create x00, y00 and r00 on each grid
+
+    do k=1,mgrid
+      nx=nxall(k) ; ny=nyall(k)
+      jump=2**(k-1)
+      ibad=0
+      jbad=0
+      i=-1
+      do ii=0,nxall(1),jump
+        i=i+1
+        j=-1
+        do jj=0,nyall(1),jump
+          j=j+1
+          mg(k)%x00(j,i)=dx_fine(jj,ii)*jump
+          mg(k)%y00(j,i)=dy_fine(jj,ii)*jump
+          mg(k)%r00(j,i)=coriolis_fine(jj,ii)**2/mg(k)%phi0
+        end do
+        if(j <  nyall(k)-1.or.j >  nyall(k)) jbad=jbad+1
+        if(j == nyall(k)-1) then
+          j=nyall(k)
+          jj=nyall(1)
+          mg(k)%x00(j,i)=dx_fine(jj,ii)*jump
+          mg(k)%y00(j,i)=dy_fine(jj,ii)*jump
+          mg(k)%r00(j,i)=coriolis_fine(jj,ii)**2/mg(k)%phi0
+        end if
+      end do
+      if(i <  nxall(k)-1.or.i >  nxall(k)) ibad=ibad+1
+      if(i == nxall(k)-1) then
+        i=nxall(k)
+        ii=nxall(1)
+        j=-1
+        do jj=0,nyall(1),jump
+          j=j+1
+          mg(k)%x00(j,i)=dx_fine(jj,ii)*jump
+          mg(k)%y00(j,i)=dy_fine(jj,ii)*jump
+          mg(k)%r00(j,i)=coriolis_fine(jj,ii)**2/mg(k)%phi0
+        end do
+        if(j <  nyall(k)-1) jbad=jbad+1
+        if(j >  nyall(k))   jbad=jbad+1
+        if(j == nyall(k)-1) then
+          j=nyall(k)
+          jj=nyall(1)
+          mg(k)%x00(j,i)=dx_fine(jj,ii)*jump
+          mg(k)%y00(j,i)=dy_fine(jj,ii)*jump
+          mg(k)%r00(j,i)=coriolis_fine(jj,ii)**2/mg(k)%phi0
+        end if
+      end if
+                        write(6,*)' in init_mgvars, k,ibad,jbad=',k,ibad,jbad
+    end do
+
+!      next create forward operators
+
+    do k=1,mgrid
+      nx=nxall(k) ; ny=nyall(k)
+      do i=0,nx
+        ip=min(i+1,nx) ; im=max(i-1,0)
+        do j=0,ny
+          jp=min(j+1,ny) ; jm=max(j-1,0)
+          x00=mg(k)%x00(j,i)
+          y00=mg(k)%y00(j,i)
+          x0p=half*(x00+mg(k)%x00(j ,ip))
+          x0m=half*(x00+mg(k)%x00(j ,im))
+          xp0=half*(x00+mg(k)%x00(jp,i ))
+          xm0=half*(x00+mg(k)%x00(jm,i ))
+          y0p=half*(y00+mg(k)%y00(j ,ip))
+          y0m=half*(y00+mg(k)%y00(j ,im))
+          yp0=half*(y00+mg(k)%y00(jp,i ))
+          ym0=half*(y00+mg(k)%y00(jm,i ))
+          mg(k)%h0m(j,i)=y0m/(x0m*x00*y00)
+          mg(k)%h0p(j,i)=y0p/(x0p*x00*y00)
+          mg(k)%hm0(j,i)=xm0/(ym0*x00*y00)
+          mg(k)%hp0(j,i)=xp0/(yp0*x00*y00)
+          mg(k)%h00(j,i)=mg(k)%h0m(j,i)+mg(k)%h0p(j,i)+mg(k)%hm0(j,i)+mg(k)%hp0(j,i)
+        end do
+      end do
+    end do
+
+!      next create implicit x operators
+
+    do k=1,mgrid
+      nx=nxall(k) ; ny=nyall(k)
+      allocate(d(nx-1),dh(nx-1),u(nx-2),o(nx-2))
+      allocate(dbar(nx-1),ubar(nx-2),obar(nx-2))
+      allocate(dbarh(nx-1),ubarh(nx-2),obarh(nx-2))
+
+!                              dirichlet boundary conditions
+      do j=1,ny-1
+        ii=0
+        do i=1,nx-1
+          ii=ii+1
+          d(ii)=mg(k)%h00(j,i)
+          if(i == nx-1) d(ii)=d(ii)+mg(k)%h0p(j,i)*mg(k)%b_over_a_east
+          dh(ii)=d(ii)+mg(k)%r00(j,i)
+          if(i <  nx-1) o(ii)=-mg(k)%h0p(j,i)
+          if(i >  1) u(ii-1)=-mg(k)%h0m(j,i)
+        end do
+        call multi_factorize(d,u,o,nx-1,dbar,ubar,obar)
+        call multi_factorize(dh,u,o,nx-1,dbarh,ubarh,obarh)
+        ii=0
+        do i=1,nx-1
+          ii=ii+1
+          mg(k)%dbarx(j,i)=dbar(ii)
+          mg(k)%dbarxh(j,i)=dbarh(ii)
+        end do
+        ii=0
+        do i=1,nx-2
+          ii=ii+1
+          mg(k)%ubarx(j,i)=ubar(ii)
+          mg(k)%obarx(j,i)=obar(ii)
+          mg(k)%ubarxh(j,i)=ubarh(ii)
+          mg(k)%obarxh(j,i)=obarh(ii)
+        end do
+      end do
+
+      deallocate(d,dh,u,o,dbar,ubar,obar,dbarh,ubarh,obarh)
+
+    end do
+
+!      next create implicit y operators
+
+    do k=1,mgrid
+      nx=nxall(k) ; ny=nyall(k)
+      allocate(d(ny-1),dh(ny-1),u(ny-2),o(ny-2))
+      allocate(dbar(ny-1),ubar(ny-2),obar(ny-2))
+      allocate(dbarh(ny-1),ubarh(ny-2),obarh(ny-2))
+
+!                              dirichlet boundary conditions
+      do i=1,nx-1
+        jj=0
+        do j=1,ny-1
+          jj=jj+1
+          d(jj)=mg(k)%h00(j,i)
+          if(j == ny-1) d(jj)=d(jj)+mg(k)%hp0(j,i)*mg(k)%b_north/mg(k)%a_north
+          dh(jj)=d(jj)+mg(k)%r00(j,i)
+          if(j <  ny-1) o(jj)=-mg(k)%hp0(j,i)
+          if(j >  1) u(jj-1)=-mg(k)%hm0(j,i)
+        end do
+        call multi_factorize(d,u,o,ny-1,dbar,ubar,obar)
+        call multi_factorize(dh,u,o,ny-1,dbarh,ubarh,obarh)
+        jj=0
+        do j=1,ny-1
+          jj=jj+1
+          mg(k)%dbary(j,i)=dbar(jj)
+          mg(k)%dbaryh(j,i)=dbarh(jj)
+        end do
+        jj=0
+        do j=1,ny-2
+          jj=jj+1
+          mg(k)%ubary(j,i)=ubar(jj)
+          mg(k)%obary(j,i)=obar(jj)
+          mg(k)%ubaryh(j,i)=ubarh(jj)
+          mg(k)%obaryh(j,i)=obarh(jj)
+        end do
+      end do
+
+      deallocate(d,dh,u,o,dbar,ubar,obar,dbarh,ubarh,obarh)
+
+    end do
+
+!       set bicubic_mask
+
+    do k=2,mgrid
+      do ic=1,mg(k)%nx-1
+        if=2*ic
+        do jf=3,mg(k-1)%ny-3,2
+          mg(k-1)%bicubic_mask(jf,if)=.true.
+        end do
+      end do
+      do if=3,mg(k-1)%nx-3,2
+        do jc=1,mg(k)%ny-1
+          jf=2*jc
+          mg(k-1)%bicubic_mask(jf,if)=.true.
+        end do
+      end do
+      do if=3,mg(k-1)%nx-3,2
+        do jf=3,mg(k-1)%ny-3,2
+          mg(k-1)%bicubic_mask(jf,if)=.true.
+        end do
+      end do
+    end do
+
+  end subroutine init_mgvars
+
+  subroutine eval_bdys(f,mgk,nx,ny)
+
+!   evaluate boundary point values for field f
+
+    use constants, only: zero,half,one
+
+    integer(i_kind),intent(in):: nx,ny
+    real(r_kind),intent(inout):: f(0:ny,0:nx)
+    type(mgvar):: mgk
+
+    integer(i_kind) i,j
+
+    if(mgk%nx /= nx.or.mgk%ny /= ny) then
+        write(6,*)' argument error in call to eval_ne_bdys, mgk%nx,nx,mgk%ny,ny=',mgk%nx,nx,mgk%ny,ny
+        stop
+    end if
+
+ 
+!    north and south boundaries
+
+    do i=1,nx-1
+      f(ny,i)=mgk%b_over_a_north_neg*f(ny-1,i)
+      f(0,i)=zero
+    end do
+
+!    east and west boundaries
+
+    do j=1,ny-1
+      f(j,nx)=mgk%b_over_a_east_neg*f(j,nx-1)
+      f(j,0) =zero
+    end do
+
+!     corners--just average of adjacent points on each boundary
+
+    f( 0, 0)=zero
+    f(ny, 0)=mgk%half_b_over_a_north_neg*f(ny-1,1)
+    f( 0,nx)=mgk%half_b_over_a_east_neg*f(1,nx-1)
+    f(ny,nx)=f(ny-1,nx-1)*mgk%half_b_over_a_east_north_neg
+
+  end subroutine eval_bdys
+
+  subroutine eval_bdys_ad(f,mgk,nx,ny)
+
+!   evaluate boundary point values for field f
+
+    use constants, only: zero,half,one
+
+    integer(i_kind),intent(in):: nx,ny
+    real(r_kind),intent(inout):: f(0:ny,0:nx)
+    type(mgvar):: mgk
+
+    integer(i_kind) i,j
+
+    if(mgk%nx /= nx.or.mgk%ny /= ny) then
+        write(6,*)' argument error in call to eval_ne_bdys, mgk%nx,nx,mgk%ny,ny=',mgk%nx,nx,mgk%ny,ny
+        stop
+    end if
+
+!     adjoint of corners--just average of adjacent points on each boundary
+
+    f(ny-1,nx-1)=f(ny-1,nx-1)+f(ny,nx)*mgk%half_b_over_a_east_north_neg
+    f(ny,nx)=zero
+    f(1,nx-1)=f(1,nx-1)+f(0,nx)*mgk%half_b_over_a_east_neg
+    f(0,nx)=zero
+    f(ny-1,1)=f(ny-1,1)+f(ny,0)*mgk%half_b_over_a_north_neg
+    f(ny,0)=zero
+    f(0,0)=zero
+
+!    adjoint of east and west boundaries
+
+    do j=1,ny-1
+      f(j,0) =zero
+      f(j,nx-1)=f(j,nx-1)+f(j,nx)*mgk%b_over_a_east_neg
+      f(j,nx)=zero
+    end do
+ 
+!    adjoint of north and south boundaries
+
+    do i=1,nx-1
+      f(0,i)=zero
+      f(ny-1,i)=f(ny-1,i)+f(ny,i)*mgk%b_over_a_north_neg
+      f(ny,i)=zero
+    end do
+
+  end subroutine eval_bdys_ad
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!  following is section containing transfer operators!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+! NOTES ABOUT TRANSFER OPERATORS:
+!
+!  c
+! I       transfer operator:  transfer from fine grid to coarse grid using full weighting
+!  f
+!             implemented by subroutine f2c_full_weight
+!
+!              the full weighting stencil is
+!
+!                       1/16     1/8     1/16
+!
+!                        1/8     1/4     1/8
+!
+!                       1/16     1/8     1/16
+!
+!                where the central point coincides with a coarse grid point, and the surrounding
+!                points are fine grid points in between the coarse points.
+!
+!  f
+! I       transfer operator:  transfer from coarse grid to fine grid using bilinear interpolation
+!  c
+!             implemented by subroutine c2f_bilinear
+!
+!   f
+! II      transfer operator:  transfer from coarse grid to fine grid using bicubic interpolation
+!   c
+!             implemented by subroutine c2f_bicubic
+!
+!
+!      NOTE 1:  all grids in this multigrid system have common point (0,0).
+!                the grid dimensions are f(0:nyf,0:nxf), c(0:nyc,0:nxc)
+!
+!
+!      NOTE 2:  the coarse grid increment is exactly twice the fine grid increment, so
+!                every other point of the fine grid moving away from 0, coincides with
+!                a coarse grid point.
+!
+!      NOTE 3:  the east (nxc) and north (nyc) edges of the coarse grid are defined using
+!                boundary interpolation weights, since in general they do not coincide with
+!                the boundary of the finest grid (this is because there is no condition on
+!                the number of points, so grid coarsening can result in requiring an extra
+!                row beyond east/north edges of the domain.
+!
+!      NOTE 4:  weights used here correspond to adjoint of bilinear interpolation from coarse to fine
+!                with the exception that the weights are normalized to preserve area integral.
+!
+!
+!
+
+  subroutine f2c_full_weight(f,c,nxf,nyf,nxc,nyc)
+
+!  full weighting fine to coarse transfer similar to adjoint of coarse to fine bilinear interpolation
+!   except coefficients are normalized by their sum and only points interior to fine grid
+!   are updated.
+
+    use m_kinds, only: r_kind,i_kind
+    use constants, only: zero
+    implicit none
+
+    integer(i_kind),intent(in):: nxc,nyc,nxf,nyf
+    real(r_kind),intent(in)::    f(0:nyf,0:nxf)
+    real(r_kind),intent(out)::   c(0:nyc,0:nxc)
+
+    real(r_kind),parameter:: one_quarter=1._8/4._8,one_eighth=1._8/8._8,one_sixteenth=1._8/16._8
+
+    integer(i_kind) if,ic,jf,jc,jfp,jfm,ifp,ifm
+
+    c=zero
+    do ic=1,nxc-1
+      if=2*ic
+      ifp=if+1
+      ifm=if-1
+      do jc=1,nyc-1
+        jf=2*jc
+        jfp=jf+1
+        jfm=jf-1
+        c(jc,ic)=one_quarter* f(jf ,if ) &
+                          +one_eighth*(f(jf ,ifp)+f(jf ,ifm)+f(jfp, if)+f(jfm, if)) &
+                       +one_sixteenth*(f(jfm,ifm)+f(jfm,ifp)+f(jfp,ifm)+f(jfp,ifp))
+      end do
+    end do
+
+  end subroutine f2c_full_weight
+
+  subroutine f2c_full_weight_ad(f,c,nxf,nyf,nxc,nyc)
+
+!  full weighting fine to coarse transfer similar to adjoint of coarse to fine bilinear interpolation
+!   except coefficients are normalized by their sum and only points interior to fine grid
+!   are updated.
+
+    use m_kinds, only: r_kind,i_kind
+    use constants, only: zero
+    implicit none
+
+    integer(i_kind),intent(in):: nxc,nyc,nxf,nyf
+    real(r_kind),intent(out)::    f(0:nyf,0:nxf)
+    real(r_kind),intent(in):: c(0:nyc,0:nxc)
+
+    real(r_kind),parameter:: one_quarter=1._8/4._8,one_eighth=1._8/8._8,one_sixteenth=1._8/16._8
+
+    integer(i_kind) if,ic,jf,jc,jfp,jfm,ifp,ifm
+
+    f=zero
+    do ic=1,nxc-1
+      if=2*ic
+      ifp=if+1
+      ifm=if-1
+      do jc=1,nyc-1
+        jf=2*jc
+        jfp=jf+1
+        jfm=jf-1
+        f(jf ,if )=f(jf ,if ) + one_quarter  *c(jc,ic)
+        f(jf ,ifp)=f(jf ,ifp) + one_eighth   *c(jc,ic)
+        f(jf ,ifm)=f(jf ,ifm) + one_eighth   *c(jc,ic)
+        f(jfp,if )=f(jfp,if ) + one_eighth   *c(jc,ic)
+        f(jfm,if )=f(jfm,if ) + one_eighth   *c(jc,ic)
+        f(jfm,ifm)=f(jfm,ifm) + one_sixteenth*c(jc,ic)
+        f(jfm,ifp)=f(jfm,ifp) + one_sixteenth*c(jc,ic)
+        f(jfp,ifm)=f(jfp,ifm) + one_sixteenth*c(jc,ic)
+        f(jfp,ifp)=f(jfp,ifp) + one_sixteenth*c(jc,ic)
+      end do
+    end do
+
+  end subroutine f2c_full_weight_ad
+
+  subroutine c2f_bilinear(c,f,nxc,nyc,nxf,nyf)
+
+!  bilinear interpolation from coarse to fine grid
+!    note:  c boundary should be filled in to get correct results on 1st interior row of f
+
+    use m_kinds, only: r_kind,i_kind
+    use constants, only: zero,quarter,half
+    implicit none
+
+    integer(i_kind),intent(in):: nxc,nyc,nxf,nyf
+    real(r_kind),intent(in)::    c(0:nyc,0:nxc)
+    real(r_kind),intent(out)::   f(0:nyf,0:nxf)
+
+    integer(i_kind) if,ic,jf,jc,icm,icp,jcm,jcp
+
+!  fill in coincident points:
+
+    f=zero
+    do ic=1,nxc-1
+      if=2*ic
+      do jc=1,nyc-1
+        jf=2*jc
+        f(jf,if)=c(jc,ic)
+      end do
+    end do
+
+!  fill in y blanks on coincident x lines
+
+    do ic=1,nxc-1
+      if=2*ic
+      do jf=1,nyf-1,2
+        jcm=(jf-1)/2
+        jcp=(jf+1)/2
+        f(jf,if)=half*(c(jcm,ic)+c(jcp,ic))
+      end do
+    end do
+
+!  fill in x blanks on coincident y lines
+    do if=1,nxf-1,2
+      icm=(if-1)/2
+      icp=(if+1)/2
+      do jc=1,nyc-1
+        jf=2*jc
+        f(jf,if)=half*(c(jc,icm)+c(jc,icp))
+      end do
+    end do
+
+!  fill in remaining holes
+    do if=1,nxf-1,2
+      icm=(if-1)/2
+      icp=(if+1)/2
+      do jf=1,nyf-1,2
+        jcm=(jf-1)/2
+        jcp=(jf+1)/2
+        f(jf,if)=quarter*(c(jcm,icm)+c(jcm,icp)+c(jcp,icm)+c(jcp,icp))
+      end do
+    end do
+
+  end subroutine c2f_bilinear
+
+  subroutine c2f_bilinear_ad(c,f,nxc,nyc,nxf,nyf)
+
+!   adjoint of c2f_bilinear
+
+    use m_kinds, only: r_kind,i_kind
+    use constants, only: zero,quarter,half
+
+    integer(i_kind),intent(in):: nxc,nyc,nxf,nyf
+    real(r_kind),intent(out)::    c(0:nyc,0:nxc)
+    real(r_kind),intent(in)::   f(0:nyf,0:nxf)
+
+    integer(i_kind) if,ic,jf,jc,icm,icp,jcm,jcp
+
+    c=zero
+
+!  adjoint of fill in remaining holes
+
+    do if=1,nxf-1,2
+      icm=(if-1)/2
+      icp=(if+1)/2
+      do jf=1,nyf-1,2
+        jcm=(jf-1)/2
+        jcp=(jf+1)/2
+        c(jcm,icm)=c(jcm,icm)+quarter*f(jf,if)
+        c(jcm,icp)=c(jcm,icp)+quarter*f(jf,if)
+        c(jcp,icm)=c(jcp,icm)+quarter*f(jf,if)
+        c(jcp,icp)=c(jcp,icp)+quarter*f(jf,if)
+      end do
+    end do
+
+!  adjoint of fill in x blanks on coincident y lines
+
+    do if=1,nxf-1,2
+      icm=(if-1)/2
+      icp=(if+1)/2
+      do jc=1,nyc-1
+        jf=2*jc
+        c(jc,icm)=c(jc,icm)+half*f(jf,if)
+        c(jc,icp)=c(jc,icp)+half*f(jf,if)
+      end do
+    end do
+
+!  adjoint of fill in y blanks on coincident x lines
+
+    do ic=1,nxc-1
+      if=2*ic
+      do jf=1,nyf-1,2
+        jcm=(jf-1)/2
+        jcp=(jf+1)/2
+        c(jcm,ic)=c(jcm,ic)+half*f(jf,if)
+        c(jcp,ic)=c(jcp,ic)+half*f(jf,if)
+      end do
+    end do
+
+!  adjoint of fill in coincident points:
+
+    do ic=1,nxc-1
+      if=2*ic
+      do jc=1,nyc-1
+        jf=2*jc
+        c(jc,ic)=c(jc,ic)+f(jf,if)
+      end do
+    end do
+
+  end subroutine c2f_bilinear_ad
+
+  subroutine c2f_bicubic(c,f,nxc,nyc,nxf,nyf,bicubic_mask)
+
+!  bicubic interpolation from coarse to fine grid
+
+    use m_kinds, only: r_kind,i_kind
+    use constants, only: zero,quarter,half
+    implicit none
+
+    integer(i_kind),intent(in):: nxc,nyc,nxf,nyf
+    real(r_kind),intent(in)::    c(0:nyc,0:nxc)
+    real(r_kind),intent(out)::   f(0:nyf,0:nxf)
+    logical,intent(in)::         bicubic_mask(0:nyf,0:nxf)
+
+    real(r_kind),parameter:: one_sixteenth=1._8/16._8,nine_sixteenths=9._8/16._8
+    real(r_kind),parameter:: one_sixt2=one_sixteenth**2,onenine_sixt2=one_sixteenth*nine_sixteenths
+    real(r_kind),parameter:: nine_sixt2=nine_sixteenths**2
+
+    integer(i_kind) if,ic,jf,jc
+    integer(i_kind) icm2,icp,icp2,icm,jcm2,jcm,jcp2,jcp
+
+!    start with coincident points and points closest to boundary that are linearly interpolated:
+
+!  fill in coincident points:
+
+    f=zero
+    do ic=1,nxc-1
+      if=2*ic
+      do jc=1,nyc-1
+        jf=2*jc
+        if(.not.bicubic_mask(jf,if)) f(jf,if)=c(jc,ic)
+      end do
+    end do
+
+!  fill in y blanks with linear interpolation on coincident x lines adjacent to y boundarys
+
+    do ic=1,nxc-1
+      if=2*ic
+      do jf=1,nyf-1,2
+        jcm=(jf-1)/2
+        jcp=(jf+1)/2
+        if(.not.bicubic_mask(jf,if)) f(jf,if)=half*(c(jcm,ic)+c(jcp,ic))
+      end do
+    end do
+
+!  fill in x blanks on coincident y lines
+    do if=1,nxf-1,2
+      icm=(if-1)/2
+      icp=(if+1)/2
+      do jc=1,nyc-1
+        jf=2*jc
+        if(.not.bicubic_mask(jf,if)) f(jf,if)=half*(c(jc,icm)+c(jc,icp))
+      end do
+    end do
+
+!  fill in remaining holes
+    do if=1,nxf-1,2
+      icm=(if-1)/2
+      icp=(if+1)/2
+      do jf=1,nyf-1,2
+        jcm=(jf-1)/2
+        jcp=(jf+1)/2
+        if(.not.bicubic_mask(jf,if)) f(jf,if)=quarter*(c(jcm,icm)+c(jcm,icp)+c(jcp,icm)+c(jcp,icp))
+      end do
+    end do
+
+!  fill in y blanks on coincident interior x lines
+
+    do ic=1,nxc-1
+      if=2*ic
+      do jf=3,nyf-3,2
+        jcm=(jf-1)/2 ; jcm2=(jf-3)/2 ; jcp=(jf+1)/2 ; jcp2=(jf+3)/2
+        f(jf,if)=nine_sixteenths*(c(jcm,ic)+c(jcp,ic))-one_sixteenth*(c(jcm2,ic)+c(jcp2,ic))
+      end do
+    end do
+
+!  fill in x blanks on coincident interior y lines
+
+    do if=3,nxf-3,2
+      icm=(if-1)/2 ; icm2=(if-3)/2 ; icp=(if+1)/2 ; icp2=(if+3)/2
+      do jc=1,nyc-1
+        jf=2*jc
+        f(jf,if)=nine_sixteenths*(c(jc,icm)+c(jc,icp))-one_sixteenth*(c(jc,icm2)+c(jc,icp2))
+      end do
+    end do
+
+!  fill in remaining interior holes
+
+    do if=3,nxf-3,2
+      icm=(if-1)/2 ; icm2=(if-3)/2 ; icp=(if+1)/2 ; icp2=(if+3)/2
+      do jf=3,nyf-3,2
+        jcm=(jf-1)/2 ; jcm2=(jf-3)/2 ; jcp=(jf+1)/2 ; jcp2=(jf+3)/2
+        f(jf,if)=nine_sixt2*(c(jcm ,icm )+c(jcm ,icp )+c(jcp ,icm )+c(jcp ,icp ))     &
+             -onenine_sixt2*(c(jcm ,icm2)+c(jcm ,icp2)+c(jcp ,icm2)+c(jcp ,icp2)      &
+                            +c(jcm2,icm )+c(jcp2,icm )+c(jcm2,icp )+c(jcp2,icp ))     &
+                 +one_sixt2*(c(jcm2,icm2)+c(jcm2,icp2)+c(jcp2,icm2)+c(jcp2,icp2))
+      end do
+    end do
+
+  end subroutine c2f_bicubic
+
+  subroutine c2f_bicubic_ad(c,f,nxc,nyc,nxf,nyf,bicubic_mask)
+
+!  bicubic interpolation from coarse to fine grid
+
+    use m_kinds, only: r_kind,i_kind
+    use constants, only: zero,quarter,half
+    implicit none
+
+    integer(i_kind),intent(in):: nxc,nyc,nxf,nyf
+    real(r_kind),intent(out)::    c(0:nyc,0:nxc)
+    real(r_kind),intent(in)::     f(0:nyf,0:nxf)
+    logical,intent(in)::          bicubic_mask(0:nyf,0:nxf)
+
+    real(r_kind),parameter:: one_sixteenth=1._8/16._8,nine_sixteenths=9._8/16._8
+    real(r_kind),parameter:: one_sixt2=one_sixteenth**2,onenine_sixt2=one_sixteenth*nine_sixteenths
+    real(r_kind),parameter:: nine_sixt2=nine_sixteenths**2
+
+    integer(i_kind) if,ic,jf,jc
+    integer(i_kind) icm2,icp,icp2,icm,jcm2,jcm,jcp2,jcp
+
+    c=zero
+
+!  adjoint of fill in remaining interior holes
+
+    do if=3,nxf-3,2
+      icm=(if-1)/2 ; icm2=(if-3)/2 ; icp=(if+1)/2 ; icp2=(if+3)/2
+      do jf=3,nyf-3,2
+        jcm=(jf-1)/2 ; jcm2=(jf-3)/2 ; jcp=(jf+1)/2 ; jcp2=(jf+3)/2
+        c(jcm ,icm )=c(jcm ,icm )+f(jf,if)*nine_sixt2
+        c(jcm ,icp )=c(jcm ,icp )+f(jf,if)*nine_sixt2
+        c(jcp ,icm )=c(jcp ,icm )+f(jf,if)*nine_sixt2
+        c(jcp ,icp )=c(jcp ,icp )+f(jf,if)*nine_sixt2
+        c(jcm ,icm2)=c(jcm ,icm2)-f(jf,if)*onenine_sixt2
+        c(jcm ,icp2)=c(jcm ,icp2)-f(jf,if)*onenine_sixt2
+        c(jcp ,icm2)=c(jcp ,icm2)-f(jf,if)*onenine_sixt2
+        c(jcp ,icp2)=c(jcp ,icp2)-f(jf,if)*onenine_sixt2
+        c(jcm2,icm )=c(jcm2,icm )-f(jf,if)*onenine_sixt2
+        c(jcp2,icm )=c(jcp2,icm )-f(jf,if)*onenine_sixt2
+        c(jcm2,icp )=c(jcm2,icp )-f(jf,if)*onenine_sixt2
+        c(jcp2,icp )=c(jcp2,icp )-f(jf,if)*onenine_sixt2
+        c(jcm2,icm2)=c(jcm2,icm2)+f(jf,if)*one_sixt2
+        c(jcm2,icp2)=c(jcm2,icp2)+f(jf,if)*one_sixt2
+        c(jcp2,icm2)=c(jcp2,icm2)+f(jf,if)*one_sixt2
+        c(jcp2,icp2)=c(jcp2,icp2)+f(jf,if)*one_sixt2
+      end do
+    end do
+
+!  adjoint of fill in x blanks on coincident interior y lines
+
+    do if=3,nxf-3,2
+      icm=(if-1)/2 ; icm2=(if-3)/2 ; icp=(if+1)/2 ; icp2=(if+3)/2
+      do jc=1,nyc-1
+        jf=2*jc
+        c(jc,icm )=c(jc,icm )+f(jf,if)*nine_sixteenths
+        c(jc,icp )=c(jc,icp )+f(jf,if)*nine_sixteenths
+        c(jc,icm2)=c(jc,icm2)-f(jf,if)*one_sixteenth
+        c(jc,icp2)=c(jc,icp2)-f(jf,if)*one_sixteenth
+      end do
+    end do
+
+!  adjoint of fill in y blanks on coincident interior x lines
+
+    do ic=1,nxc-1
+      if=2*ic
+      do jf=3,nyf-3,2
+        jcm=(jf-1)/2 ; jcm2=(jf-3)/2 ; jcp=(jf+1)/2 ; jcp2=(jf+3)/2
+        c(jcm ,ic)=c(jcm ,ic)+f(jf,if)*nine_sixteenths
+        c(jcp ,ic)=c(jcp ,ic)+f(jf,if)*nine_sixteenths
+        c(jcm2,ic)=c(jcm2,ic)-f(jf,if)*one_sixteenth
+        c(jcp2,ic)=c(jcp2,ic)-f(jf,if)*one_sixteenth
+      end do
+    end do
+
+!    adjoint of start with coincident points and points closest to boundary that are linearly interpolated:
+
+!  adjoint of fill in remaining holes
+
+    do if=1,nxf-1,2
+      icm=(if-1)/2
+      icp=(if+1)/2
+      do jf=1,nyf-1,2
+        jcm=(jf-1)/2
+        jcp=(jf+1)/2
+        if(.not.bicubic_mask(jf,if)) then
+          c(jcm,icm)=c(jcm,icm)+f(jf,if)*quarter
+          c(jcm,icp)=c(jcm,icp)+f(jf,if)*quarter
+          c(jcp,icm)=c(jcp,icm)+f(jf,if)*quarter
+          c(jcp,icp)=c(jcp,icp)+f(jf,if)*quarter
+        end if
+      end do
+    end do
+
+!  adjoint of fill in x blanks on coincident y lines
+
+    do if=1,nxf-1,2
+      icm=(if-1)/2
+      icp=(if+1)/2
+      do jc=1,nyc-1
+        jf=2*jc
+        if(.not.bicubic_mask(jf,if)) then
+          c(jc,icm)=c(jc,icm)+f(jf,if)*half
+          c(jc,icp)=c(jc,icp)+f(jf,if)*half
+        end if
+      end do
+    end do
+
+!  adjoint of fill in y blanks with linear interpolation on coincident x lines adjacent to y boundarys
+
+    do ic=1,nxc-1
+      if=2*ic
+      do jf=1,nyf-1,2
+        jcm=(jf-1)/2
+        jcp=(jf+1)/2
+        if(.not.bicubic_mask(jf,if)) then
+          c(jcm,ic)=c(jcm,ic)+f(jf,if)*half
+          c(jcp,ic)=c(jcp,ic)+f(jf,if)*half
+        end if
+      end do
+    end do
+
+!  adjoint of fill in coincident points:
+
+    do ic=1,nxc-1
+      if=2*ic
+      do jc=1,nyc-1
+        jf=2*jc
+        if(.not.bicubic_mask(jf,if)) then
+          c(jc,ic)=c(jc,ic)+f(jf,if)
+        end if
+      end do
+    end do
+
+  end subroutine c2f_bicubic_ad
+
+  subroutine multi_factorize(d,u,o,nx,dbar,ubar,obar)
+
+!    factorize special input matrix into lower times upper triangular matrices (illustrated for nx=5):
+!                                       _                                  _      _
+! |d(1)   o(1)   0      0      0   |   |d(1)   0      0      0      0   | |d(1)   o(1)   0      0      0   |
+! |                                |   |_      _                        | |       _      _                 |
+! |u(1)   d(2)   o(2)   0      0   |   |u(1)   d(2)   0      0      0   | |0      d(2)   o(2)   0      0   |
+! |                                |   |       _      _                 | |              _      _          |
+! |0      u(2)   d(3)   o(3)   0   | = |0      u(2)   d(2)   0      0   |*|0      0      d(3)   o(3)   0   |
+! |                                |   |              _      _          | |                     _      _   |
+! |0      0      u(3)   d(4)   o(4)|   |0      0      u(2)   d(4)   0   | |0      0      0      d(4)   o(4)|
+! |                                |   |                     _      _   | |                            _   |
+! |0      0      0      u(4)   d(5)|   |0      0      0      u(4)   d(5)| |0      0      0      0      d(5)|
+
+    integer(i_kind),intent(in):: nx
+    real(r_kind),intent(in):: d(nx),u(nx-1),o(nx-1)
+    real(r_kind),intent(out):: dbar(nx),ubar(nx-1),obar(nx-1)
+
+    integer(i_kind) i
+
+    dbar(1)=sqrt(d(1))
+    obar(1)=o(1)/dbar(1)
+    ubar(1)=u(1)/dbar(1)
+
+    do i=2,nx-1
+      dbar(i)=sqrt(d(i)-ubar(i-1)*obar(i-1))
+      obar(i)=o(i)/dbar(i)
+      ubar(i)=u(i)/dbar(i)
+    end do
+    i=nx
+    dbar(i)=sqrt(d(i)-ubar(i-1)*obar(i-1))
+
+  end subroutine multi_factorize
+
+  subroutine forward_op_x1(v,f,d,u,o,nx)
+
+    use constants, only: zero
+    integer(i_kind),intent(in)::nx
+    real(r_kind),intent(in):: v(nx),d(nx),u(nx-1),o(nx-1)
+    real(r_kind),intent(out)::f(nx)
+
+    integer(i_kind) i
+
+    f(1)=d(1)*v(1)+o(1)*v(2)
+    do i=2,nx-1
+      f(i)=u(i-1)*v(i-1)+d(i)*v(i)+o(i)*v(i+1)
+    end do
+    f(nx)=u(nx-1)*v(nx-1)+d(nx)*v(nx)
+
+  end subroutine forward_op_x1
+
+  subroutine inverse_op_x1(f,v,dbar,ubar,obar,nx)
+
+    use constants, only: zero
+    integer(i_kind),intent(in)::nx
+    real(r_kind),intent(in):: f(nx),dbar(nx),ubar(nx-1),obar(nx-1)
+    real(r_kind),intent(out)::v(nx)
+
+    integer(i_kind) i
+    real(r_kind) temp(nx)
+
+    temp(1)=f(1)/dbar(1)
+    do i=2,nx
+      temp(i)=(f(i)-ubar(i-1)*temp(i-1))/dbar(i)
+    end do
+
+    v(nx)=temp(nx)/dbar(nx)
+    do i=nx-1,1,-1
+      v(i)=(temp(i)-obar(i)*v(i+1))/dbar(i)
+    end do
+
+  end subroutine inverse_op_x1
+
+  subroutine forward_op_x(v,f,nx,ny,j,k,helmholtz)
+
+    use constants, only: zero
+    integer(i_kind),intent(in)::nx,ny,j,k
+    real(r_kind),intent(in)::helmholtz
+    real(r_kind),intent(in):: v(0:ny,0:nx)
+    real(r_kind),intent(out)::f(0:ny,0:nx)
+
+    integer(i_kind) i,im1,ip1
+
+    do i=1,nx-1
+      im1=i-1 ; ip1=i+1
+      f(j,i)=mg(k)%h0m(j,i)*v(j,  im1)+mg(k)%h0p(j,i)*v(j,ip1) &
+               -(mg(k)%h00(j,i)+helmholtz*mg(k)%r00(j,i))*v(j,i)
+    end do
+
+  end subroutine forward_op_x
+
+  subroutine inverse_luop_x_1(rhs,v,dbarx,ubarx,obarx,nx,ny,j)
+
+    integer(i_kind),intent(in):: nx,ny,j
+    real(r_kind),dimension(0:ny,0:nx),intent(in)::    rhs,dbarx,ubarx,obarx
+    real(r_kind),dimension(0:ny,0:nx),intent(inout):: v
+
+    integer(i_kind) i,im1,ip1
+    real(r_kind) temp(0:ny,0:nx)
+
+!   inverse of lower triangle first:
+
+    temp(j,1)=rhs(j,1)/dbarx(j,1)
+    do i=2,nx-1
+      im1=i-1
+      temp(j,i)=(rhs(j,i)-ubarx(j,im1)*temp(j,im1))/dbarx(j,i)
+    end do
+
+!   finish with inverse of upper triangle:
+
+    v(j,nx-1)=temp(j,nx-1)/dbarx(j,nx-1)
+    do i=nx-2,1,-1
+      ip1=i+1
+      v(j,i)=(temp(j,i)-obarx(j,i)*v(j,ip1))/dbarx(j,i)
+    end do
+
+  end subroutine inverse_luop_x_1
+
+  subroutine forward_op_y(v,f,nx,ny,i,k,helmholtz)
+
+    use constants, only: zero
+    integer(i_kind),intent(in)::nx,ny,i,k
+    real(r_kind),intent(in)::helmholtz
+    real(r_kind),intent(in):: v(0:ny,0:nx)
+    real(r_kind),intent(out)::f(0:ny,0:nx)
+
+    integer(i_kind) j,jm1,jp1
+
+    do j=1,ny-1
+      jm1=j-1 ; jp1=j+1
+      f(j,i)=mg(k)%hm0(j,i)*v(jm1,i  )+mg(k)%hp0(j,i)*v(jp1,i) &
+               -(mg(k)%h00(j,i)+helmholtz*mg(k)%r00(j,i))*v(j,i)
+    end do
+
+  end subroutine forward_op_y
+
+  subroutine inverse_luop_y_1(rhs,v,dbary,ubary,obary,nx,ny,i)
+
+    integer(i_kind),intent(in):: nx,ny,i
+    real(r_kind),dimension(0:ny,0:nx),intent(in)::    rhs,dbary,ubary,obary
+    real(r_kind),dimension(0:ny,0:nx),intent(inout):: v
+
+    integer(i_kind) j
+    real(r_kind) temp(0:ny)
+
+
+!   inverse of lower triangle first:
+
+      temp(1)=rhs(1,i)/dbary(1,i)
+      do j=2,ny-1
+        temp(j)=(rhs(j,i)-ubary(j-1,i)*temp(j-1))/dbary(j,i)
+      end do
+
+!   finish with inverse of upper triangle:
+
+      v(ny-1,i)=temp(ny-1)/dbary(ny-1,i)
+      do j=ny-2,1,-1
+        v(j,i)=(temp(j)-obary(j,i)*v(j+1,i))/dbary(j,i)
+      end do
+
+  end subroutine inverse_luop_y_1
+
+  subroutine forward_op(v,f,nx,ny,k,helmholtz)
+
+    use constants, only: zero
+    integer(i_kind),intent(in)::nx,ny,k
+    real(r_kind),intent(in)::helmholtz
+    real(r_kind),intent(in):: v(0:ny,0:nx)
+    real(r_kind),intent(out)::f(0:ny,0:nx)
+
+    integer(i_kind) i,im1,ip1,j
+
+!      check that nx,ny are correct values for level k:
+    if(mg(k)%nx /= nx.or.mg(k)%ny /= ny) then
+      write(6,*)' inconsistent input nx,ny for fmg_forward_op, program stops'
+      stop
+    end if
+
+    f=zero
+    do i=1,nx-1
+      im1=i-1 ; ip1=i+1
+      do j=1,ny-1
+        f(j,i)=mg(k)%h0m(j,i)*v(j,  im1)+mg(k)%h0p(j,i)*v(j,ip1) &
+              +mg(k)%hm0(j,i)*v(j-1,i  )+mg(k)%hp0(j,i)*v(j+1,i) &
+               -(mg(k)%h00(j,i)+helmholtz*mg(k)%r00(j,i))*v(j,i)
+      end do
+    end do
+
+  end subroutine forward_op
+
+  subroutine forward_op_ad(v,f,nx,ny,k,helmholtz)
+
+    use constants, only: zero
+    integer(i_kind),intent(in)::nx,ny,k
+    real(r_kind),intent(in)::helmholtz
+    real(r_kind),intent(out):: v(0:ny,0:nx)
+    real(r_kind),intent(in)::f(0:ny,0:nx)
+
+    integer(i_kind) i,im1,ip1,j
+
+!      check that nx,ny are correct values for level k:
+    if(mg(k)%nx /= nx.or.mg(k)%ny /= ny) then
+      write(6,*)' inconsistent input nx,ny for fmg_forward_op_ad, program stops'
+      stop
+    end if
+
+    v=zero
+    do i=1,nx-1
+      im1=i-1 ; ip1=i+1
+      do j=1,ny-1
+        v(j  ,im1)=v(j  ,im1)+mg(k)%h0m(j,i)*f(j,i)
+        v(j  ,ip1)=v(j  ,ip1)+mg(k)%h0p(j,i)*f(j,i)
+        v(j-1,i  )=v(j-1,i  )+mg(k)%hm0(j,i)*f(j,i)
+        v(j+1,i  )=v(j+1,i  )+mg(k)%hp0(j,i)*f(j,i)
+        v(j  ,i  )=v(j  ,i  )-(mg(k)%h00(j,i)+helmholtz*mg(k)%r00(j,i))*f(j,i)
+      end do
+    end do
+
+  end subroutine forward_op_ad
+
+  subroutine relax(v,f,dbarx,ubarx,obarx,dbary,ubary,obary,h0p,h0m,hp0,hm0,nx,ny, &
+                   b_over_a_east_neg,b_over_a_north_neg)
+    
+    use constants, only: zero
+
+!    do one iteration of adi relaxation, first in x direction, then in y direction
+
+    integer(i_kind),intent(in):: nx,ny
+    real(r_kind),dimension(0:ny,0:nx),intent(inout):: v
+    real(r_kind),dimension(0:ny,0:nx),intent(in)::    f
+    real(r_kind),dimension(0:ny,0:nx),intent(in)::    dbarx,ubarx,obarx
+    real(r_kind),dimension(0:ny,0:nx),intent(in)::    dbary,ubary,obary
+    real(r_kind),dimension(0:ny,0:nx),intent(in)::    h0p,h0m,hp0,hm0
+    real(r_kind),intent(in)::                         b_over_a_east_neg,b_over_a_north_neg
+
+    integer(i_kind) i,ii,im1,ip1,j,jj
+    real(r_kind) rhs(0:ny,0:nx)
+
+!      do x lines first:
+
+    ii=1
+    do jj=1,2
+      do i=1,nx-1
+        do j=jj,ny-1,2
+          rhs(j,i)=-f(j,i)+hp0(j,i)*v(j+1,i)+hm0(j,i)*v(j-1,i)
+        end do
+      end do
+      call inverse_luop_x(rhs,v,dbarx,ubarx,obarx,nx,ny,jj,ii)
+      do j=jj,ny-1,2
+        v(j,0)=zero
+        v(j,nx)=b_over_a_east_neg*v(j,nx-1)
+      end do
+    end do
+
+!      now do y lines:
+
+    jj=1
+    do ii=1,2
+      do i=ii,nx-1,2
+        ip1=i+1 ; im1=i-1
+        do j=1,ny-1
+          rhs(j,i)=-f(j,i)+h0p(j,i)*v(j,ip1)+h0m(j,i)*v(j,im1)
+        end do
+      end do
+      call inverse_luop_y(rhs,v,dbary,ubary,obary,nx,ny,ii,jj)
+      do i=ii,nx-1,2
+        v(0,i)=zero
+        v(ny,i)=b_over_a_north_neg*v(ny-1,i)
+      end do
+    end do
+
+  end subroutine relax
+
+  subroutine relax_ad(v,f,dbarx,ubarx,obarx,dbary,ubary,obary,h0p,h0m,hp0,hm0,nx,ny, &
+                   b_over_a_east_neg,b_over_a_north_neg)
+    
+    use constants, only: zero
+
+!    do one iteration of adi relaxation, first in x direction, then in y direction
+
+    integer(i_kind),intent(in):: nx,ny
+    real(r_kind),dimension(0:ny,0:nx),intent(inout):: v
+    real(r_kind),dimension(0:ny,0:nx),intent(inout):: f
+    real(r_kind),dimension(0:ny,0:nx),intent(in)::    dbarx,ubarx,obarx
+    real(r_kind),dimension(0:ny,0:nx),intent(in)::    dbary,ubary,obary
+    real(r_kind),dimension(0:ny,0:nx),intent(in)::    h0p,h0m,hp0,hm0
+    real(r_kind),intent(in)::                         b_over_a_east_neg,b_over_a_north_neg
+
+    integer(i_kind) i,ii,im1,ip1,j,jj
+    real(r_kind) rhs(0:ny,0:nx)
+
+
+!      adjoint of now do y lines:
+
+    jj=1
+    do ii=2,1,-1
+      do i=ii,nx-1,2
+        v(ny-1,i)=v(ny-1,i)+b_over_a_north_neg*v(ny,i)
+        v(ny,i)=zero
+        v(0,i)=zero
+      end do
+      call inverse_luop_y_ad(rhs,v,dbary,ubary,obary,nx,ny,ii,jj)
+      do i=ii,nx-1,2
+        ip1=i+1 ; im1=i-1
+        do j=ny-1,1,-1
+          f(j,i)=f(j,i)-rhs(j,i)
+          v(j,ip1)=v(j,ip1)+h0p(j,i)*rhs(j,i)
+          v(j,im1)=v(j,im1)+h0m(j,i)*rhs(j,i)
+          v(j,i)=zero
+        end do
+      end do
+    end do
+
+!      adjoint of do x lines first:
+
+    ii=1
+    do jj=2,1,-1
+      do j=jj,ny-1,2
+        v(j,nx-1)=v(j,nx-1)+b_over_a_east_neg*v(j,nx)
+        v(j,nx)=zero
+        v(j,0)=zero
+      end do
+      call inverse_luop_x_ad(rhs,v,dbarx,ubarx,obarx,nx,ny,jj,ii)
+      do i=nx-1,1,-1
+        do j=jj,ny-1,2
+          f(j,i)=f(j,i)-rhs(j,i)
+          v(j+1,i)=v(j+1,i)+hp0(j,i)*rhs(j,i)
+          v(j-1,i)=v(j-1,i)+hm0(j,i)*rhs(j,i)
+          v(j,i)=zero
+        end do
+      end do
+    end do
+
+  end subroutine relax_ad
+
+  subroutine inverse_luop_x(rhs,v,dbarx,ubarx,obarx,nx,ny,jj,ii)
+
+    integer(i_kind),intent(in):: nx,ny,jj,ii
+    real(r_kind),dimension(0:ny,0:nx),intent(in)::    rhs,dbarx,ubarx,obarx
+    real(r_kind),dimension(0:ny,0:nx),intent(inout):: v
+
+    integer(i_kind) i,im1,ip1,j
+    real(r_kind) temp(0:ny,0:nx)
+
+!   inverse of lower triangle first:
+
+    do j=jj,ny-1,2
+      temp(j,ii)=rhs(j,ii)/dbarx(j,ii)
+    end do
+    do i=ii+1,nx-ii
+      im1=i-1
+      do j=jj,ny-1,2
+        temp(j,i)=(rhs(j,i)-ubarx(j,im1)*temp(j,im1))/dbarx(j,i)
+      end do
+    end do
+
+!   finish with inverse of upper triangle:
+
+    do j=jj,ny-1,2
+      v(j,nx-ii)=temp(j,nx-ii)/dbarx(j,nx-ii)
+    end do
+    do i=nx-ii-1,ii,-1
+      ip1=i+1
+      do j=jj,ny-1,2
+        v(j,i)=(temp(j,i)-obarx(j,i)*v(j,ip1))/dbarx(j,i)
+      end do
+    end do
+
+  end subroutine inverse_luop_x
+
+  subroutine inverse_luop_x_ad(rhs,v,dbarx,ubarx,obarx,nx,ny,jj,ii)
+
+    use constants, only: zero
+
+    integer(i_kind),intent(in):: nx,ny,jj,ii
+    real(r_kind),dimension(0:ny,0:nx),intent(in)::    dbarx,ubarx,obarx
+    real(r_kind),dimension(0:ny,0:nx),intent(inout):: rhs
+    real(r_kind),dimension(0:ny,0:nx),intent(inout):: v
+
+    integer(i_kind) i,im1,ip1,j
+    real(r_kind) temp(0:ny,0:nx)
+
+!   adjoint of finish with inverse of upper triangle:
+
+    do i=ii,nx-ii-1
+      do j=jj,ny-1,2
+        temp(j,i)=zero
+      end do
+    end do
+    do j=jj,ny-1,2
+      temp(j,nx-ii)=zero
+    end do
+
+    do i=ii,nx-ii-1
+      ip1=i+1
+      do j=jj,ny-1,2
+        temp(j,i)=temp(j,i)+v(j,i)/dbarx(j,i)
+        v(j,ip1)=v(j,ip1)-obarx(j,i)*v(j,i)/dbarx(j,i)
+        v(j,i)=zero                                       !???
+      end do
+    end do
+    do j=jj,ny-1,2
+      temp(j,nx-ii)=temp(j,nx-ii)+v(j,nx-ii)/dbarx(j,nx-ii)
+    end do
+
+!   adjoint of inverse of lower triangle first:
+
+    do i=nx-ii,ii+1,-1
+      do j=jj,ny-1,2
+        rhs(j,i)=zero
+      end do
+    end do
+    do j=jj,ny-1,2
+      rhs(j,ii)=zero
+    end do
+
+    do i=nx-ii,ii+1,-1
+      im1=i-1
+      do j=jj,ny-1,2
+        rhs(j,i)=rhs(j,i)+temp(j,i)/dbarx(j,i)
+        temp(j,im1)=temp(j,im1)-ubarx(j,im1)*temp(j,i)/dbarx(j,i)
+      end do
+    end do
+    do j=jj,ny-1,2
+      rhs(j,ii)=rhs(j,ii)+temp(j,ii)/dbarx(j,ii)
+    end do
+
+  end subroutine inverse_luop_x_ad
+
+  subroutine inverse_luop_y(rhs,v,dbary,ubary,obary,nx,ny,ii,jj)
+
+    integer(i_kind),intent(in):: nx,ny,ii,jj
+    real(r_kind),dimension(0:ny,0:nx),intent(in)::    rhs,dbary,ubary,obary
+    real(r_kind),dimension(0:ny,0:nx),intent(inout):: v
+
+    integer(i_kind) i,j
+    real(r_kind) temp(0:ny)
+
+    do i=ii,nx-1,2
+
+!   inverse of lower triangle first:
+
+      temp(jj)=rhs(jj,i)/dbary(jj,i)
+      do j=jj+1,ny-jj
+        temp(j)=(rhs(j,i)-ubary(j-1,i)*temp(j-1))/dbary(j,i)
+      end do
+
+!   finish with inverse of upper triangle:
+
+      v(ny-jj,i)=temp(ny-jj)/dbary(ny-jj,i)
+      do j=ny-jj-1,jj,-1
+        v(j,i)=(temp(j)-obary(j,i)*v(j+1,i))/dbary(j,i)
+      end do
+    end do
+
+  end subroutine inverse_luop_y
+
+  subroutine inverse_luop_y_ad(rhs,v,dbary,ubary,obary,nx,ny,ii,jj)
+
+    use constants, only: zero
+
+    integer(i_kind),intent(in):: nx,ny,ii,jj
+    real(r_kind),dimension(0:ny,0:nx),intent(in)::    dbary,ubary,obary
+    real(r_kind),dimension(0:ny,0:nx),intent(inout)::    rhs
+    real(r_kind),dimension(0:ny,0:nx),intent(inout):: v
+
+    integer(i_kind) i,j
+    real(r_kind) temp(0:ny)
+
+    do i=ii,nx-1,2
+
+!   adjoint of finish with inverse of upper triangle:
+
+      do j=jj,ny-jj-1
+        temp(j)=zero
+      end do
+      temp(ny-jj)=zero
+
+      do j=jj,ny-jj-1
+        temp(j)=temp(j)+v(j,i)/dbary(j,i)
+        v(j+1,i)=v(j+1,i)-obary(j,i)*v(j,i)/dbary(j,i)
+        v(j,i)=zero
+      end do
+      temp(ny-jj)=temp(ny-jj)+v(ny-jj,i)/dbary(ny-jj,i)
+
+!   adjoint of inverse of lower triangle first:
+
+      do j=ny-jj,jj+1,-1
+        rhs(j,i)=zero
+      end do
+      rhs(jj,i)=zero
+
+      do j=ny-jj,jj+1,-1
+        rhs(j,i)=rhs(j,i)+temp(j)/dbary(j,i)
+        temp(j-1)=temp(j-1)-ubary(j-1,i)*temp(j)/dbary(j,i)
+      end do
+      rhs(jj,i)=rhs(jj,i)+temp(jj)/dbary(jj,i)
+
+    end do
+
+  end subroutine inverse_luop_y_ad
+
+  subroutine fmg(v,f,helmholtz,nrelax1,nrelax2,nrelax_solve,nx,ny)
+
+!   full multigrid solution on fixed domain with homogeneous dirichlet boundary conditions
+
+!      solve delsqr(v)    = f   helmholtz=.false.
+!           (delsqr-R)(v) = f   helmholtz=.true.
+
+    use constants, only: zero,one
+
+    integer(i_kind),intent(in)::nx,ny,nrelax1,nrelax2,nrelax_solve
+    logical,intent(in)::        helmholtz
+    real(r_kind),intent(in)::   f(0:ny,0:nx)     !  !  in actual use, f is in, and v is out, but
+    real(r_kind),intent(out)::  v(0:ny,0:nx)     !   !  make both inout for adjoint test purposes
+
+    integer(i_kind) irelax,k,m
+    real(r_kind) helmholtz_factor
+
+    if(nxall(1) /= nx.or.nyall(1) /= ny) then
+       write(6,*)' inconsistent input nx,ny in fmg, program stops'
+       stop
+    end if
+
+    helmholtz_factor=zero
+    if(helmholtz) helmholtz_factor=one
+
+            !write(6,'(" at 1 in fmg, min,max f =",2e15.4)')minval(f),maxval(f)
+    mg(1)%f=f
+    mg(1)%v=zero
+    do k=2,mgrid
+      call f2c_full_weight(mg(k-1)%f,mg(k)%f,mg(k-1)%nx,mg(k-1)%ny,mg(k)%nx,mg(k)%ny)
+      mg(k)%v=zero
+    end do
+            !write(6,'(" at 2 in fmg, min,max f =",2e15.4)')minval(f),maxval(f)
+
+!      main fmg loop:
+
+    do m=mgrid,1,-1
+
+!      exact solution at level mgrid
+
+      k=mgrid
+      do irelax=1,nrelax_solve
+        if(helmholtz) then
+          call relax(mg(k)%v,mg(k)%f, &
+                     mg(k)%dbarxh,mg(k)%ubarxh,mg(k)%obarxh, &
+                     mg(k)%dbaryh,mg(k)%ubaryh,mg(k)%obaryh, &
+                     mg(k)%h0p,mg(k)%h0m,mg(k)%hp0,mg(k)%hm0,mg(k)%nx,mg(k)%ny, &
+                     mg(k)%b_over_a_east_neg,mg(k)%b_over_a_north_neg)
+        else
+          call relax(mg(k)%v,mg(k)%f, &
+                     mg(k)%dbarx,mg(k)%ubarx,mg(k)%obarx, &
+                     mg(k)%dbary,mg(k)%ubary,mg(k)%obary, &
+                     mg(k)%h0p,mg(k)%h0m,mg(k)%hp0,mg(k)%hm0,mg(k)%nx,mg(k)%ny, &
+                     mg(k)%b_over_a_east_neg,mg(k)%b_over_a_north_neg)
+        end if
+      end do
+
+      do k=mgrid-1,m,-1
+
+!        update v(k) with v(k+1)
+
+        call eval_bdys(mg(k+1)%v,mg(k+1),mg(k+1)%nx,mg(k+1)%ny)
+        call c2f_bilinear(mg(k+1)%v,mg(k)%w,mg(k+1)%nx,mg(k+1)%ny,mg(k)%nx,mg(k)%ny)
+        call eval_bdys(mg(k)%w,mg(k),mg(k)%nx,mg(k)%ny)
+        mg(k)%v=mg(k)%v+mg(k)%w
+
+!         relax
+
+        do irelax=1,nrelax2
+          if(helmholtz) then
+            call relax(mg(k)%v,mg(k)%f, &
+                       mg(k)%dbarxh,mg(k)%ubarxh,mg(k)%obarxh, &
+                       mg(k)%dbaryh,mg(k)%ubaryh,mg(k)%obaryh, &
+                       mg(k)%h0p,mg(k)%h0m,mg(k)%hp0,mg(k)%hm0,mg(k)%nx,mg(k)%ny, &
+                     mg(k)%b_over_a_east_neg,mg(k)%b_over_a_north_neg)
+          else
+            call relax(mg(k)%v,mg(k)%f, &
+                       mg(k)%dbarx,mg(k)%ubarx,mg(k)%obarx, &
+                       mg(k)%dbary,mg(k)%ubary,mg(k)%obary, &
+                       mg(k)%h0p,mg(k)%h0m,mg(k)%hp0,mg(k)%hm0,mg(k)%nx,mg(k)%ny, &
+                     mg(k)%b_over_a_east_neg,mg(k)%b_over_a_north_neg)
+          end if
+        end do
+
+      end do
+
+      if(m >  1) then
+        call eval_bdys(mg(m)%v,mg(m),mg(m)%nx,mg(m)%ny)
+        call c2f_bicubic(mg(m)%v,mg(m-1)%v,mg(m)%nx,mg(m)%ny,mg(m-1)%nx,mg(m-1)%ny,mg(m-1)%bicubic_mask)
+        call eval_bdys(mg(m-1)%v,mg(m-1),mg(m-1)%nx,mg(m-1)%ny)
+      end if
+
+      if(m == 1) exit
+
+      do k=m-1,mgrid-1
+
+!         relax
+
+        do irelax=1,nrelax1
+          if(helmholtz) then
+            call relax(mg(k)%v,mg(k)%f, &
+                       mg(k)%dbarxh,mg(k)%ubarxh,mg(k)%obarxh, &
+                       mg(k)%dbaryh,mg(k)%ubaryh,mg(k)%obaryh, &
+                       mg(k)%h0p,mg(k)%h0m,mg(k)%hp0,mg(k)%hm0,mg(k)%nx,mg(k)%ny, &
+                     mg(k)%b_over_a_east_neg,mg(k)%b_over_a_north_neg)
+          else
+            call relax(mg(k)%v,mg(k)%f, &
+                       mg(k)%dbarx,mg(k)%ubarx,mg(k)%obarx, &
+                       mg(k)%dbary,mg(k)%ubary,mg(k)%obary, &
+                       mg(k)%h0p,mg(k)%h0m,mg(k)%hp0,mg(k)%hm0,mg(k)%nx,mg(k)%ny, &
+                     mg(k)%b_over_a_east_neg,mg(k)%b_over_a_north_neg)
+          end if
+        end do
+
+!        compute residual
+
+        call eval_bdys(mg(k)%v,mg(k),mg(k)%nx,mg(k)%ny)
+        mg(k)%w=zero
+        call forward_op(mg(k)%v,mg(k)%w,mg(k)%nx,mg(k)%ny,k,helmholtz_factor)
+
+        mg(k)%w=mg(k)%f-mg(k)%w      !  now have residual in mg(k)%w
+
+!        transfer residual to next coarser grid
+
+          !write(6,'(" k, max val new residual=",i4,e14.5)')k, &
+          !               maxval(abs(mg(k)%w(1:mg(k)%ny-1,1:mg(k)%nx-1)))
+          !write(6,'(" k+1, max val prev residual=",i4,e14.5)')k+1, &
+          !             maxval(abs(mg(k+1)%f(1:mg(k+1)%ny-1,1:mg(k+1)%nx-1)))
+        call f2c_full_weight(mg(k)%w,mg(k+1)%f,mg(k)%nx,mg(k)%ny,mg(k+1)%nx,mg(k+1)%ny)
+          !write(6,'(" k+1, max val transfered residual=",i4,e14.5)')k+1, &
+          !             maxval(abs(mg(k+1)%f(1:mg(k+1)%ny-1,1:mg(k+1)%nx-1)))
+        mg(k+1)%v=zero
+
+      end do
+
+    end do
+            !write(6,'(" at 3 in fmg, min,max f =",2e15.4)')minval(f),maxval(f)
+
+    v=mg(1)%v
+            !write(6,'(" at 4 in fmg, min,max f =",2e15.4)')minval(f),maxval(f)
+
+  end subroutine fmg
+
+  subroutine fmg_ad(v,f,helmholtz,nrelax1,nrelax2,nrelax_solve,nx,ny)
+
+!   adjoint of full multigrid solution on fixed domain with homogeneous dirichlet boundary conditions
+
+!      solve delsqr(v)    = f   helmholtz=.false.
+!           (delsqr-R)(v) = f   helmholtz=.true.
+
+    use constants, only: zero,one
+
+    integer(i_kind),intent(in)::nx,ny,nrelax1,nrelax2,nrelax_solve
+    logical,intent(in)::        helmholtz
+    real(r_kind),intent(inout)::   f(0:ny,0:nx)   ! ! in actual practice, v is in and 
+    real(r_kind),intent(in)::      v(0:ny,0:nx)   ! !    f is inout, but make both inout for adjoint test
+
+    integer(i_kind) irelax,k,m
+    real(r_kind) helmholtz_factor
+
+    if(nxall(1) /= nx.or.nyall(1) /= ny) then
+       write(6,*)' inconsistent input nx,ny in fmg, program stops'
+       stop
+    end if
+
+    helmholtz_factor=zero
+    if(helmholtz) helmholtz_factor=one
+
+    mg(1)%v=v
+    mg(1)%f=f
+
+!      adjoint of main fmg loop:
+
+    do m=1,mgrid
+
+      if(m >  1) then
+        do k=mgrid-1,m-1,-1
+
+!        adjoint of transfer residual to next coarser grid
+          call f2c_full_weight_ad(mg(k)%w,mg(k+1)%f,mg(k)%nx,mg(k)%ny,mg(k+1)%nx,mg(k+1)%ny)
+
+!        adjoint of compute residual
+
+         mg(k)%f=mg(k)%w+mg(k)%f
+         call forward_op_ad(mg(k)%w2,mg(k)%w,mg(k)%nx,mg(k)%ny,k,helmholtz_factor)
+         mg(k)%v=mg(k)%v-mg(k)%w2
+         call eval_bdys_ad(mg(k)%v,mg(k),mg(k)%nx,mg(k)%ny)
+
+!           adjoint of relax
+          do irelax=1,nrelax1
+            if(helmholtz) then
+              call relax_ad(mg(k)%v,mg(k)%f, &
+                         mg(k)%dbarxh,mg(k)%ubarxh,mg(k)%obarxh, &
+                         mg(k)%dbaryh,mg(k)%ubaryh,mg(k)%obaryh, &
+                         mg(k)%h0p,mg(k)%h0m,mg(k)%hp0,mg(k)%hm0,mg(k)%nx,mg(k)%ny, &
+                       mg(k)%b_over_a_east_neg,mg(k)%b_over_a_north_neg)
+            else
+              call relax_ad(mg(k)%v,mg(k)%f, &
+                         mg(k)%dbarx,mg(k)%ubarx,mg(k)%obarx, &
+                         mg(k)%dbary,mg(k)%ubary,mg(k)%obary, &
+                         mg(k)%h0p,mg(k)%h0m,mg(k)%hp0,mg(k)%hm0,mg(k)%nx,mg(k)%ny, &
+                       mg(k)%b_over_a_east_neg,mg(k)%b_over_a_north_neg)
+            end if
+          end do
+
+        end do
+
+        call eval_bdys_ad(mg(m-1)%v,mg(m-1),mg(m-1)%nx,mg(m-1)%ny)
+        call c2f_bicubic_ad(mg(m)%v,mg(m-1)%v,mg(m)%nx,mg(m)%ny,mg(m-1)%nx,mg(m-1)%ny,mg(m-1)%bicubic_mask)
+        call eval_bdys_ad(mg(m)%v,mg(m),mg(m)%nx,mg(m)%ny)
+        mg(m)%f=zero
+
+      end if
+
+      do k=m,mgrid-1
+
+!         adjoint of relax
+
+        do irelax=1,nrelax2
+          if(helmholtz) then
+            call relax_ad(mg(k)%v,mg(k)%f, &
+                       mg(k)%dbarxh,mg(k)%ubarxh,mg(k)%obarxh, &
+                       mg(k)%dbaryh,mg(k)%ubaryh,mg(k)%obaryh, &
+                       mg(k)%h0p,mg(k)%h0m,mg(k)%hp0,mg(k)%hm0,mg(k)%nx,mg(k)%ny, &
+                     mg(k)%b_over_a_east_neg,mg(k)%b_over_a_north_neg)
+          else
+            call relax_ad(mg(k)%v,mg(k)%f, &
+                       mg(k)%dbarx,mg(k)%ubarx,mg(k)%obarx, &
+                       mg(k)%dbary,mg(k)%ubary,mg(k)%obary, &
+                       mg(k)%h0p,mg(k)%h0m,mg(k)%hp0,mg(k)%hm0,mg(k)%nx,mg(k)%ny, &
+                     mg(k)%b_over_a_east_neg,mg(k)%b_over_a_north_neg)
+          end if
+        end do
+
+!        adjoint of update v(k) with v(k+1)
+
+        mg(k)%w=mg(k)%v
+        call eval_bdys_ad(mg(k)%w,mg(k),mg(k)%nx,mg(k)%ny)
+        call c2f_bilinear_ad(mg(k+1)%v,mg(k)%w,mg(k+1)%nx,mg(k+1)%ny,mg(k)%nx,mg(k)%ny)
+        call eval_bdys_ad(mg(k+1)%v,mg(k+1),mg(k+1)%nx,mg(k+1)%ny)
+        mg(k+1)%f=zero
+
+      end do
+
+!      adjoint of exact solution at level mgrid
+
+      k=mgrid
+      do irelax=1,nrelax_solve
+        if(helmholtz) then
+          call relax_ad(mg(k)%v,mg(k)%f, &
+                     mg(k)%dbarxh,mg(k)%ubarxh,mg(k)%obarxh, &
+                     mg(k)%dbaryh,mg(k)%ubaryh,mg(k)%obaryh, &
+                     mg(k)%h0p,mg(k)%h0m,mg(k)%hp0,mg(k)%hm0,mg(k)%nx,mg(k)%ny, &
+                     mg(k)%b_over_a_east_neg,mg(k)%b_over_a_north_neg)
+        else
+          call relax_ad(mg(k)%v,mg(k)%f, &
+                     mg(k)%dbarx,mg(k)%ubarx,mg(k)%obarx, &
+                     mg(k)%dbary,mg(k)%ubary,mg(k)%obary, &
+                     mg(k)%h0p,mg(k)%h0m,mg(k)%hp0,mg(k)%hm0,mg(k)%nx,mg(k)%ny, &
+                     mg(k)%b_over_a_east_neg,mg(k)%b_over_a_north_neg)
+        end if
+      end do
+
+    end do
+
+    do k=mgrid,2,-1
+      call f2c_full_weight_ad(mg(k-1)%w,mg(k)%f,mg(k-1)%nx,mg(k-1)%ny,mg(k)%nx,mg(k)%ny)
+      mg(k-1)%f=mg(k-1)%f+mg(k-1)%w
+    end do
+    f=mg(1)%f
+
+  end subroutine fmg_ad
+
+  subroutine vcycle(f,v,nx,ny,mgrid2,nrelax1,nrelax2,nrelax_solve,helmholtz)
+
+!       vcycle over mgrid2 grid levels, using nrelax1 relaxation cycles going from fine to coarse
+!        with residuals, nrelax_solve relaxation cycles on coarsest grid, and nrelax2 relaxation
+!        cycles going back up from coarse to fine with corrections.
+
+    use constants, only: zero,one
+
+    integer(i_kind),intent(in)::nx,ny,mgrid2,nrelax1,nrelax2,nrelax_solve
+    logical,intent(in)::        helmholtz
+    real(r_kind),intent(in):: f(0:ny,0:nx)
+    real(r_kind),intent(inout):: v(0:ny,0:nx)
+
+    integer(i_kind) irelax,k
+    real(r_kind) helmholtz_factor
+
+    helmholtz_factor=zero
+    if(helmholtz) helmholtz_factor=one
+
+    mg(1)%f=f
+  ! mg(1)%v=zero
+    mg(1)%v=v
+
+!                    fine to coarse residuals (descend left side of V cycle)
+    do k=1,mgrid2-1
+
+!       relax
+
+      do irelax=1,nrelax1
+        if(helmholtz) then
+          call relax(mg(k)%v,mg(k)%f, &
+                     mg(k)%dbarxh,mg(k)%ubarxh,mg(k)%obarxh, &
+                     mg(k)%dbaryh,mg(k)%ubaryh,mg(k)%obaryh, &
+                     mg(k)%h0p,mg(k)%h0m,mg(k)%hp0,mg(k)%hm0,mg(k)%nx,mg(k)%ny, &
+                     mg(k)%b_over_a_east_neg,mg(k)%b_over_a_north_neg)
+        else
+          call relax(mg(k)%v,mg(k)%f, &
+                     mg(k)%dbarx,mg(k)%ubarx,mg(k)%obarx, &
+                     mg(k)%dbary,mg(k)%ubary,mg(k)%obary, &
+                     mg(k)%h0p,mg(k)%h0m,mg(k)%hp0,mg(k)%hm0,mg(k)%nx,mg(k)%ny, &
+                     mg(k)%b_over_a_east_neg,mg(k)%b_over_a_north_neg)
+        end if
+      end do
+
+!        compute residual
+    
+      call eval_bdys(mg(k)%v,mg(k),mg(k)%nx,mg(k)%ny)
+      mg(k)%w=zero
+      call forward_op(mg(k)%v,mg(k)%w,mg(k)%nx,mg(k)%ny,k,helmholtz_factor)
+    
+      mg(k)%w=mg(k)%f-mg(k)%w      !  now have residual in mg(k)%w
+
+!        transfer residual to next coarser grid
+
+      call f2c_full_weight(mg(k)%w,mg(k+1)%f,mg(k)%nx,mg(k)%ny,mg(k+1)%nx,mg(k+1)%ny)
+      mg(k+1)%v=zero
+
+    end do
+
+!                 solve (bottom of V cycle)
+    k=mgrid2
+    do irelax=1,nrelax_solve
+      if(helmholtz) then
+        call relax(mg(k)%v,mg(k)%f, &
+                   mg(k)%dbarxh,mg(k)%ubarxh,mg(k)%obarxh, &
+                   mg(k)%dbaryh,mg(k)%ubaryh,mg(k)%obaryh, &
+                   mg(k)%h0p,mg(k)%h0m,mg(k)%hp0,mg(k)%hm0,mg(k)%nx,mg(k)%ny, &
+                   mg(k)%b_over_a_east_neg,mg(k)%b_over_a_north_neg)
+      else
+        call relax(mg(k)%v,mg(k)%f, &
+                   mg(k)%dbarx,mg(k)%ubarx,mg(k)%obarx, &
+                   mg(k)%dbary,mg(k)%ubary,mg(k)%obary, &
+                   mg(k)%h0p,mg(k)%h0m,mg(k)%hp0,mg(k)%hm0,mg(k)%nx,mg(k)%ny, &
+                   mg(k)%b_over_a_east_neg,mg(k)%b_over_a_north_neg)
+      end if
+    end do
+
+!                   coarse to fine corrections (ascend right side of V cycle)
+
+    do k=mgrid2-1,1,-1
+
+!        update v(k) with v(k+1)
+
+      call eval_bdys(mg(k+1)%v,mg(k+1),mg(k+1)%nx,mg(k+1)%ny)
+      call c2f_bilinear(mg(k+1)%v,mg(k)%w,mg(k+1)%nx,mg(k+1)%ny,mg(k)%nx,mg(k)%ny)
+      call eval_bdys(mg(k)%w,mg(k),mg(k)%nx,mg(k)%ny)
+      mg(k)%v=mg(k)%v+mg(k)%w
+
+!         relax
+
+      do irelax=1,nrelax2
+        if(helmholtz) then
+          call relax(mg(k)%v,mg(k)%f, &
+                     mg(k)%dbarxh,mg(k)%ubarxh,mg(k)%obarxh, &
+                     mg(k)%dbaryh,mg(k)%ubaryh,mg(k)%obaryh, &
+                     mg(k)%h0p,mg(k)%h0m,mg(k)%hp0,mg(k)%hm0,mg(k)%nx,mg(k)%ny, &
+                   mg(k)%b_over_a_east_neg,mg(k)%b_over_a_north_neg)
+        else
+          call relax(mg(k)%v,mg(k)%f, &
+                     mg(k)%dbarx,mg(k)%ubarx,mg(k)%obarx, &
+                     mg(k)%dbary,mg(k)%ubary,mg(k)%obary, &
+                     mg(k)%h0p,mg(k)%h0m,mg(k)%hp0,mg(k)%hm0,mg(k)%nx,mg(k)%ny, &
+                   mg(k)%b_over_a_east_neg,mg(k)%b_over_a_north_neg)
+        end if
+      end do
+
+    end do
+
+    v=mg(1)%v
+
+  end subroutine vcycle
+
+  subroutine vcycle_ad(f,v,nx,ny,mgrid2,nrelax1,nrelax2,nrelax_solve,helmholtz)
+
+!       vcycle over mgrid2 grid levels, using nrelax1 relaxation cycles going from fine to coarse
+!        with residuals, nrelax_solve relaxation cycles on coarsest grid, and nrelax2 relaxation
+!        cycles going back up from coarse to fine with corrections.
+
+    use constants, only: zero,one
+
+    integer(i_kind),intent(in)::nx,ny,mgrid2,nrelax1,nrelax2,nrelax_solve
+    logical,intent(in)::        helmholtz
+    real(r_kind),intent(inout):: f(0:ny,0:nx)
+    real(r_kind),intent(inout):: v(0:ny,0:nx)
+
+    integer(i_kind) irelax,k
+    real(r_kind) helmholtz_factor
+
+    helmholtz_factor=zero
+    if(helmholtz) helmholtz_factor=one
+
+    mg(1)%v=v
+    mg(1)%f=f
+
+!                   adjoint of coarse to fine corrections (ascend right side of V cycle)
+
+    do k=1,mgrid2-1
+
+!         adjoint of relax
+
+      do irelax=1,nrelax2
+        if(helmholtz) then
+          call relax_ad(mg(k)%v,mg(k)%f, &
+                     mg(k)%dbarxh,mg(k)%ubarxh,mg(k)%obarxh, &
+                     mg(k)%dbaryh,mg(k)%ubaryh,mg(k)%obaryh, &
+                     mg(k)%h0p,mg(k)%h0m,mg(k)%hp0,mg(k)%hm0,mg(k)%nx,mg(k)%ny, &
+                   mg(k)%b_over_a_east_neg,mg(k)%b_over_a_north_neg)
+        else
+          call relax_ad(mg(k)%v,mg(k)%f, &
+                     mg(k)%dbarx,mg(k)%ubarx,mg(k)%obarx, &
+                     mg(k)%dbary,mg(k)%ubary,mg(k)%obary, &
+                     mg(k)%h0p,mg(k)%h0m,mg(k)%hp0,mg(k)%hm0,mg(k)%nx,mg(k)%ny, &
+                   mg(k)%b_over_a_east_neg,mg(k)%b_over_a_north_neg)
+        end if
+      end do
+
+!        adjoint of update v(k) with v(k+1)
+
+      mg(k)%w=mg(k)%v
+      call eval_bdys_ad(mg(k)%w,mg(k),mg(k)%nx,mg(k)%ny)
+      call c2f_bilinear_ad(mg(k+1)%v,mg(k)%w,mg(k+1)%nx,mg(k+1)%ny,mg(k)%nx,mg(k)%ny)
+      call eval_bdys_ad(mg(k+1)%v,mg(k+1),mg(k+1)%nx,mg(k+1)%ny)
+      mg(k+1)%f=zero
+
+    end do
+
+!                 adjoint of solve (bottom of V cycle)
+    k=mgrid2
+    do irelax=1,nrelax_solve
+      if(helmholtz) then
+        call relax_ad(mg(k)%v,mg(k)%f, &
+                   mg(k)%dbarxh,mg(k)%ubarxh,mg(k)%obarxh, &
+                   mg(k)%dbaryh,mg(k)%ubaryh,mg(k)%obaryh, &
+                   mg(k)%h0p,mg(k)%h0m,mg(k)%hp0,mg(k)%hm0,mg(k)%nx,mg(k)%ny, &
+                   mg(k)%b_over_a_east_neg,mg(k)%b_over_a_north_neg)
+      else
+        call relax_ad(mg(k)%v,mg(k)%f, &
+                   mg(k)%dbarx,mg(k)%ubarx,mg(k)%obarx, &
+                   mg(k)%dbary,mg(k)%ubary,mg(k)%obary, &
+                   mg(k)%h0p,mg(k)%h0m,mg(k)%hp0,mg(k)%hm0,mg(k)%nx,mg(k)%ny, &
+                   mg(k)%b_over_a_east_neg,mg(k)%b_over_a_north_neg)
+      end if
+    end do
+
+!                    adjoint of fine to coarse residuals (descend left side of V cycle)
+    do k=mgrid2-1,1,-1
+
+!        adjoint of transfer residual to next coarser grid
+
+      call f2c_full_weight_ad(mg(k)%w,mg(k+1)%f,mg(k)%nx,mg(k)%ny,mg(k+1)%nx,mg(k+1)%ny)
+
+!        adjoint of compute residual
+    
+      call forward_op_ad(mg(k)%w2,mg(k)%w,mg(k)%nx,mg(k)%ny,k,helmholtz_factor)
+      mg(k)%v=mg(k)%v-mg(k)%w2
+      mg(k)%f=mg(k)%f+mg(k)%w
+      call eval_bdys_ad(mg(k)%v,mg(k),mg(k)%nx,mg(k)%ny)
+
+!       adjoint of relax
+
+      do irelax=1,nrelax1
+        if(helmholtz) then
+          call relax_ad(mg(k)%v,mg(k)%f, &
+                     mg(k)%dbarxh,mg(k)%ubarxh,mg(k)%obarxh, &
+                     mg(k)%dbaryh,mg(k)%ubaryh,mg(k)%obaryh, &
+                     mg(k)%h0p,mg(k)%h0m,mg(k)%hp0,mg(k)%hm0,mg(k)%nx,mg(k)%ny, &
+                     mg(k)%b_over_a_east_neg,mg(k)%b_over_a_north_neg)
+        else
+          call relax_ad(mg(k)%v,mg(k)%f, &
+                     mg(k)%dbarx,mg(k)%ubarx,mg(k)%obarx, &
+                     mg(k)%dbary,mg(k)%ubary,mg(k)%obary, &
+                     mg(k)%h0p,mg(k)%h0m,mg(k)%hp0,mg(k)%hm0,mg(k)%nx,mg(k)%ny, &
+                     mg(k)%b_over_a_east_neg,mg(k)%b_over_a_north_neg)
+        end if
+      end do
+
+    end do
+
+    v=mg(1)%v
+    f=mg(1)%f
+
+  end subroutine vcycle_ad
+
+  subroutine test_hop(test_div,nx1,ny1,helmholtz_on)
+
+    use constants, only: zero,one,two
+
+    integer(i_kind),intent(in):: nx1,ny1
+    real(r_kind),intent(in):: test_div(0:ny1,0:nx1)
+    logical,intent(in):: helmholtz_on
+
+    real(r_kind) helmholtz
+    real(r_kind),allocatable:: f(:,:),v(:,:),w(:,:)
+!             real(r_kind) time0,timef
+
+!             run tests with test_div_full
+    allocate(f(0:ny1,0:nx1))
+    allocate(v(0:ny1,0:nx1))
+    allocate(w(0:ny1,0:nx1))
+    f=test_div
+        write(6,'(" min,max f before call fmg=",2e15.4)')minval(f),maxval(f)
+        call fmg(v,f,helmholtz_on,1,1,20,mg(1)%nx,mg(1)%ny)
+!              write(6,'(" time in fmg =",f15.6," seconds")') .001*(timef()-time0)
+        w=zero
+        helmholtz=zero
+        if(helmholtz_on) helmholtz=one
+        call forward_op(v,w,mg(1)%nx,mg(1)%ny,1,helmholtz)
+        w=f-w
+              write(6,'(" min,max f after  call fmg=",2e15.4)') &
+                          minval(f(1:ny1-1,1:nx1-1)), &
+                          maxval(f(1:ny1-1,1:nx1-1))
+              write(6,'(" min,max r after  call fmg=",2e15.4)') &
+                          minval(w(1:ny1-1,1:nx1-1)), &
+                          maxval(w(1:ny1-1,1:nx1-1))
+             if(helmholtz_on) then
+               call outgrad1(v,'vhs_test20x',mg(1)%nx+1,mg(1)%ny+1)
+               call outgrad1(f,'fhs_test20x',mg(1)%nx+1,mg(1)%ny+1)
+               call outgrad1(w,'rhs_test20x',mg(1)%nx+1,mg(1)%ny+1)
+             else
+               call outgrad1(v,'v_test20x',mg(1)%nx+1,mg(1)%ny+1)
+               call outgrad1(f,'f_test20x',mg(1)%nx+1,mg(1)%ny+1)
+               call outgrad1(w,'r_test20x',mg(1)%nx+1,mg(1)%ny+1)
+             end if
+
+  end subroutine test_hop
+
+  subroutine test_relax
+
+    use constants, only: zero,one
+
+    integer(i_kind) i,k,nx,ny
+    character(50) string
+
+   !do k=1,mgrid
+    do k=1,1
+      nx=mg(k)%nx
+      ny=mg(k)%ny
+                write(6,*)' at 1 in test_relax, k,nx,ny=',k,nx,ny
+      call random_number(mg(k)%v)
+      call eval_bdys(mg(k)%v,mg(k),mg(k)%nx,mg(k)%ny)
+      mg(k)%z=mg(k)%v
+    ! mg(k)%v=zero
+    ! mg(k)%v=mg(k)%r00
+    ! mg(k)%z=mg(k)%r00
+    ! do j=-ny+1,ny-1
+    !!  mg(k)%v=mg(k)%r00
+    !!  mg(k)%z=mg(k)%r00
+    !   call forward_op_x(mg(k)%v,mg(k)%f,nx,ny,j,k,zero)
+    ! end do
+    !   mg(k)%w=-mg(k)%f
+    ! do j=1,ny-1
+    !   mg(k)%w(j,1   )=mg(k)%w(j,    1)+mg(k)%h0m(j,    1)*mg(k)%v(j,  0)
+    !   mg(k)%w(j,nx-1)=mg(k)%w(j, nx-1)+mg(k)%h0p(j, nx-1)*mg(k)%v(j, nx)
+    !   call inverse_luop_x_1(mg(k)%w,mg(k)%v,mg(k)%dbarx,mg(k)%ubarx,mg(k)%obarx,nx,ny,j)
+    ! end do
+    !   call outgrad1(mg(k)%z,'exact_v_xtest',nx+1,ny+1)
+    !   call outgrad1(mg(k)%v,'solve_v_xtest',nx+1,ny+1)
+    !        if(1 /= 0) stop
+
+      call eval_bdys(mg(k)%v,mg(k),mg(k)%nx,mg(k)%ny)
+      mg(k)%f=zero
+      call forward_op(mg(k)%v,mg(k)%f,nx,ny,k,zero)
+      mg(k)%v(1:ny-1,1:nx-1)=zero
+     !do i=1,1000
+      do i=1,60
+        call relax(mg(k)%v,mg(k)%f,mg(k)%dbarx,mg(k)%ubarx,mg(k)%obarx,mg(k)%dbary,mg(k)%ubary,mg(k)%obary,&
+                        mg(k)%h0p,mg(k)%h0m,mg(k)%hp0,mg(k)%hm0,nx,ny, &
+                        mg(k)%b_over_a_east_neg,mg(k)%b_over_a_north_neg)
+        call eval_bdys(mg(k)%v,mg(k),mg(k)%nx,mg(k)%ny)
+        mg(k)%w=zero
+        call forward_op(mg(k)%v,mg(k)%w,nx,ny,k,zero)
+        mg(k)%w=mg(k)%f-mg(k)%w
+           write(6,'(" iter,max(|r|)/max(|f| = ",i5,e15.4)') i,maxval(abs(mg(k)%w(1:ny-1,1:nx-1)))/ &
+                                                               maxval(abs(mg(k)%f(1:ny-1,1:nx-1)))
+           write(6,'(" iter,max(|v-v0|)/max(|v0| = ",i5,e15.4)') &
+                         i,maxval(abs(mg(k)%v-mg(k)%z))/maxval(abs(mg(k)%z))
+        if(i >  20) cycle
+        write(string,'("f",i2.2)')i
+        call outgrad1(mg(k)%f,trim(string),nx+1,ny+1)
+        write(string,'("r_odev_xy",i2.2)')i
+        call outgrad1(mg(k)%w,trim(string),nx+1,ny+1)
+      end do
+        call outgrad1(mg(k)%z,'exact_solution',nx+1,ny+1)
+        call outgrad1(mg(k)%v,'relax60_solution',nx+1,ny+1)
+    end do
+
+  end subroutine test_relax
+
+  subroutine test_adjoint
+
+    use constants, only: zero,two
+
+    real(r_kind) xtz,yty,helmholtz_factor,errmax
+    integer(i_kind) i,ii,j,jj,kc,kf,ihem,nrelax1,nrelax2,nrelax_solve
+    logical helmholtz
+    integer(i_kind) mgrid2,ivar
+
+!              c2f_bilinear
+
+    errmax=zero
+    do kf=1,mgrid-1
+      kc=kf+1
+      call random_number(mg(kc)%v)
+      mg(kc)%w=mg(kc)%v
+      call c2f_bilinear(mg(kc)%v,mg(kf)%f,mg(kc)%nx,mg(kc)%ny,mg(kf)%nx,mg(kf)%ny)
+      yty=zero
+      do i=0,mg(kf)%nx
+        do j=0,mg(kf)%ny
+          yty=yty+mg(kf)%f(j,i)**2
+        end do
+      end do
+      call c2f_bilinear_ad(mg(kc)%v,mg(kf)%f,mg(kc)%nx,mg(kc)%ny,mg(kf)%nx,mg(kf)%ny)
+      xtz=zero
+      do i=0,mg(kc)%nx
+        do j=0,mg(kc)%ny
+          xtz=xtz+mg(kc)%v(j,i)*mg(kc)%w(j,i)
+        end do
+      end do
+      write(6,'(" c2f_bilinear_ad (aT*a), kc,kf,xtz,yty=",2i3,2e22.15,e10.3)') &
+                     kc,kf,xtz,yty,abs(two*(xtz-yty)/(abs(xtz)+abs(yty)))
+                     if(abs(xtz)+abs(yty) /= zero) errmax=max(abs(two*(xtz-yty)/(abs(xtz)+abs(yty))),errmax)
+    end do
+
+    do kf=1,mgrid-1
+      kc=kf+1
+      call random_number(mg(kf)%v)
+      mg(kf)%w=mg(kf)%v
+      call c2f_bilinear_ad(mg(kc)%f,mg(kf)%v,mg(kc)%nx,mg(kc)%ny,mg(kf)%nx,mg(kf)%ny)
+      yty=zero
+      do i=0,mg(kc)%nx
+        do j=0,mg(kc)%ny
+          yty=yty+mg(kc)%f(j,i)**2
+        end do
+      end do
+      call c2f_bilinear(mg(kc)%f,mg(kf)%v,mg(kc)%nx,mg(kc)%ny,mg(kf)%nx,mg(kf)%ny)
+      xtz=zero
+      do i=0,mg(kf)%nx
+        do j=0,mg(kf)%ny
+          xtz=xtz+mg(kf)%v(j,i)*mg(kf)%w(j,i)
+        end do
+      end do
+      write(6,'(" c2f_bilinear_ad (a*aT), kc,kf,xtz,yty=",2i3,2e22.15,e10.3)') &
+                     kc,kf,xtz,yty,abs(two*(xtz-yty)/(abs(xtz)+abs(yty)))
+                     if(abs(xtz)+abs(yty) /= zero) errmax=max(abs(two*(xtz-yty)/(abs(xtz)+abs(yty))),errmax)
+    end do
+          write(6,'(" max error for c2f_bilinear_ad=",e10.3)') errmax
+
+!              c2f_bicubic
+
+    errmax=zero
+    do kf=1,mgrid-1
+      kc=kf+1
+      call random_number(mg(kc)%v)
+      mg(kc)%w=mg(kc)%v
+      call c2f_bicubic(mg(kc)%v,mg(kf)%f,mg(kc)%nx,mg(kc)%ny,mg(kf)%nx,mg(kf)%ny,mg(kf)%bicubic_mask)
+      yty=zero
+      do i=0,mg(kf)%nx
+        do j=0,mg(kf)%ny
+          yty=yty+mg(kf)%f(j,i)**2
+        end do
+      end do
+      call c2f_bicubic_ad(mg(kc)%v,mg(kf)%f,mg(kc)%nx,mg(kc)%ny,mg(kf)%nx,mg(kf)%ny,mg(kf)%bicubic_mask)
+      xtz=zero
+      do i=0,mg(kc)%nx
+        do j=0,mg(kc)%ny
+          xtz=xtz+mg(kc)%v(j,i)*mg(kc)%w(j,i)
+        end do
+      end do
+      write(6,'(" c2f_bicubic_ad (aT*a), kc,kf,xtz,yty=",2i3,2e22.15,e10.3)') &
+                     kc,kf,xtz,yty,abs(two*(xtz-yty)/(abs(xtz)+abs(yty)))
+                     if(abs(xtz)+abs(yty) /= zero) errmax=max(abs(two*(xtz-yty)/(abs(xtz)+abs(yty))),errmax)
+    end do
+
+    do kf=1,mgrid-1
+      kc=kf+1
+      call random_number(mg(kf)%v)
+      mg(kf)%w=mg(kf)%v
+      call c2f_bicubic_ad(mg(kc)%f,mg(kf)%v,mg(kc)%nx,mg(kc)%ny,mg(kf)%nx,mg(kf)%ny,mg(kf)%bicubic_mask)
+      yty=zero
+      do i=0,mg(kc)%nx
+        do j=0,mg(kc)%ny
+          yty=yty+mg(kc)%f(j,i)**2
+        end do
+      end do
+      call c2f_bicubic(mg(kc)%f,mg(kf)%v,mg(kc)%nx,mg(kc)%ny,mg(kf)%nx,mg(kf)%ny,mg(kf)%bicubic_mask)
+      xtz=zero
+      do i=0,mg(kf)%nx
+        do j=0,mg(kf)%ny
+          xtz=xtz+mg(kf)%v(j,i)*mg(kf)%w(j,i)
+        end do
+      end do
+      write(6,'(" c2f_bicubic_ad (a*aT), kc,kf,xtz,yty=",2i3,2e22.15,e10.3)') &
+                     kc,kf,xtz,yty,abs(two*(xtz-yty)/(abs(xtz)+abs(yty)))
+                     if(abs(xtz)+abs(yty) /= zero) errmax=max(abs(two*(xtz-yty)/(abs(xtz)+abs(yty))),errmax)
+    end do
+          write(6,'(" max error for c2f_bicubic_ad=",e10.3)') errmax
+
+!              eval_bdys
+
+    errmax=zero
+    do kf=1,mgrid
+      call random_number(mg(kf)%v)
+      mg(kf)%w=mg(kf)%v
+      call eval_bdys(mg(kf)%v,mg(kf),mg(kf)%nx,mg(kf)%ny)
+      yty=zero
+      do i=0,mg(kf)%nx
+        do j=0,mg(kf)%ny
+          yty=yty+mg(kf)%v(j,i)**2
+        end do
+      end do
+      call eval_bdys_ad(mg(kf)%v,mg(kf),mg(kf)%nx,mg(kf)%ny)
+      xtz=zero
+      do i=0,mg(kf)%nx
+        do j=0,mg(kf)%ny
+          xtz=xtz+mg(kf)%v(j,i)*mg(kf)%w(j,i)
+        end do
+      end do
+      write(6,'(" eval_bdys_ad (aT*a), k,xtz,yty=",i3,2e22.15,e10.3)') &
+                     kf,xtz,yty,abs(two*(xtz-yty)/(abs(xtz)+abs(yty)))
+                     if(abs(xtz)+abs(yty) /= zero) errmax=max(abs(two*(xtz-yty)/(abs(xtz)+abs(yty))),errmax)
+    end do
+
+    do kf=1,mgrid
+      call random_number(mg(kf)%v)
+      mg(kf)%w=mg(kf)%v
+      call eval_bdys_ad(mg(kf)%v,mg(kf),mg(kf)%nx,mg(kf)%ny)
+      yty=zero
+      do i=0,mg(kf)%nx
+        do j=0,mg(kf)%ny
+          yty=yty+mg(kf)%v(j,i)**2
+        end do
+      end do
+      call eval_bdys(mg(kf)%v,mg(kf),mg(kf)%nx,mg(kf)%ny)
+      xtz=zero
+      do i=0,mg(kf)%nx
+        do j=0,mg(kf)%ny
+          xtz=xtz+mg(kf)%v(j,i)*mg(kf)%w(j,i)
+        end do
+      end do
+      write(6,'(" eval_bdys_ad (a*aT), k,xtz,yty=",i3,2e22.15,e10.3)') &
+                     kf,xtz,yty,abs(two*(xtz-yty)/(abs(xtz)+abs(yty)))
+                     if(abs(xtz)+abs(yty) /= zero) errmax=max(abs(two*(xtz-yty)/(abs(xtz)+abs(yty))),errmax)
+    end do
+          write(6,'(" max error for eval_bdys_ad=",e10.3)') errmax
+
+!              f2c_full_weight
+
+    errmax=zero
+    do kf=1,mgrid-1
+      kc=kf+1
+      call random_number(mg(kf)%v)
+      mg(kf)%w=mg(kf)%v
+      call f2c_full_weight(mg(kf)%v,mg(kc)%f,mg(kf)%nx,mg(kf)%ny,mg(kc)%nx,mg(kc)%ny)
+      yty=zero
+      do i=0,mg(kc)%nx
+        do j=0,mg(kc)%ny
+          yty=yty+mg(kc)%f(j,i)**2
+        end do
+      end do
+      call f2c_full_weight_ad(mg(kf)%v,mg(kc)%f,mg(kf)%nx,mg(kf)%ny,mg(kc)%nx,mg(kc)%ny)
+      xtz=zero
+      do i=0,mg(kf)%nx
+        do j=0,mg(kf)%ny
+          xtz=xtz+mg(kf)%v(j,i)*mg(kf)%w(j,i)
+        end do
+      end do
+      write(6,'(" f2c_full_weight_ad (aT*a), kc,kf,xtz,yty=",2i3,2e22.15,e10.3)') &
+                     kc,kf,xtz,yty,abs(two*(xtz-yty)/(abs(xtz)+abs(yty)))
+                     if(abs(xtz)+abs(yty) /= zero) errmax=max(abs(two*(xtz-yty)/(abs(xtz)+abs(yty))),errmax)
+    end do
+
+    do kf=1,mgrid-1
+      kc=kf+1
+      call random_number(mg(kc)%v)
+      mg(kc)%w=mg(kc)%v
+      call f2c_full_weight_ad(mg(kf)%f,mg(kc)%v,mg(kf)%nx,mg(kf)%ny,mg(kc)%nx,mg(kc)%ny)
+      yty=zero
+      do i=0,mg(kf)%nx
+        do j=0,mg(kf)%ny
+          yty=yty+mg(kf)%f(j,i)**2
+        end do
+      end do
+      call f2c_full_weight(mg(kf)%f,mg(kc)%v,mg(kf)%nx,mg(kf)%ny,mg(kc)%nx,mg(kc)%ny)
+      xtz=zero
+      do i=0,mg(kc)%nx
+        do j=0,mg(kc)%ny
+          xtz=xtz+mg(kc)%v(j,i)*mg(kc)%w(j,i)
+        end do
+      end do
+      write(6,'(" f2c_full_weight_ad (a*aT), kc,kf,xtz,yty=",2i3,2e22.15,e10.3)') &
+                     kc,kf,xtz,yty,abs(two*(xtz-yty)/(abs(xtz)+abs(yty)))
+                     if(abs(xtz)+abs(yty) /= zero) errmax=max(abs(two*(xtz-yty)/(abs(xtz)+abs(yty))),errmax)
+    end do
+          write(6,'(" max error for f2c_full_weight_ad=",e10.3)') errmax
+
+!              forward_op
+
+    errmax=zero
+    do ihem=0,1
+      helmholtz_factor=ihem
+      do kf=1,mgrid
+        call random_number(mg(kf)%v)
+        mg(kf)%w=mg(kf)%v
+        call forward_op(mg(kf)%v,mg(kf)%f,mg(kf)%nx,mg(kf)%ny,kf,helmholtz_factor)
+        yty=zero
+        do i=0,mg(kf)%nx
+          do j=0,mg(kf)%ny
+            yty=yty+mg(kf)%f(j,i)**2
+          end do
+        end do
+        call forward_op_ad(mg(kf)%v,mg(kf)%f,mg(kf)%nx,mg(kf)%ny,kf,helmholtz_factor)
+        xtz=zero
+        do i=0,mg(kf)%nx
+          do j=0,mg(kf)%ny
+            xtz=xtz+mg(kf)%v(j,i)*mg(kf)%w(j,i)
+          end do
+        end do
+        write(6,'(" forward_op_ad (aT*a), h,k,xtz,yty=",i2,i3,2e22.15,e10.3)') &
+                       ihem,kf,xtz,yty,abs(two*(xtz-yty)/(abs(xtz)+abs(yty)))
+                     if(abs(xtz)+abs(yty) /= zero) errmax=max(abs(two*(xtz-yty)/(abs(xtz)+abs(yty))),errmax)
+      end do
+
+      do kf=1,mgrid
+        call random_number(mg(kf)%f)
+        mg(kf)%w=mg(kf)%f
+        call forward_op_ad(mg(kf)%v,mg(kf)%f,mg(kf)%nx,mg(kf)%ny,kf,helmholtz_factor)
+        yty=zero
+        do i=0,mg(kf)%nx
+          do j=0,mg(kf)%ny
+            yty=yty+mg(kf)%v(j,i)**2
+          end do
+        end do
+        call forward_op(mg(kf)%v,mg(kf)%f,mg(kf)%nx,mg(kf)%ny,kf,helmholtz_factor)
+        xtz=zero
+        do i=0,mg(kf)%nx
+          do j=0,mg(kf)%ny
+            xtz=xtz+mg(kf)%f(j,i)*mg(kf)%w(j,i)
+          end do
+        end do
+        write(6,'(" forward_op_ad (a*aT), h,k,xtz,yty=",i2,i3,2e22.15,e10.3)') &
+                       ihem,kf,xtz,yty,abs(two*(xtz-yty)/(abs(xtz)+abs(yty)))
+                     if(abs(xtz)+abs(yty) /= zero) errmax=max(abs(two*(xtz-yty)/(abs(xtz)+abs(yty))),errmax)
+      end do
+    end do
+          write(6,'(" max error for forward_op_ad=",e10.3)') errmax
+
+!              inverse_luop_x
+
+    errmax=zero
+    do ii=1,1
+    do jj=1,2
+    do ihem=0,1
+      helmholtz_factor=ihem
+      do kf=1,mgrid
+        call random_number(mg(kf)%v)
+        mg(kf)%w=mg(kf)%v
+        mg(kf)%f=zero
+        if(ihem == 0) then
+          call inverse_luop_x(mg(kf)%v,mg(kf)%f,mg(kf)%dbarx,mg(kf)%ubarx,mg(kf)%obarx, &
+                               mg(kf)%nx,mg(kf)%ny,jj,ii)
+        else
+          call inverse_luop_x(mg(kf)%v,mg(kf)%f,mg(kf)%dbarxh,mg(kf)%ubarxh,mg(kf)%obarxh, &
+                               mg(kf)%nx,mg(kf)%ny,jj,ii)
+        end if
+        yty=zero
+        do i=0,mg(kf)%nx
+          do j=0,mg(kf)%ny
+            yty=yty+mg(kf)%f(j,i)**2
+          end do
+        end do
+        mg(kf)%v=zero
+        if(ihem == 0) then
+          call inverse_luop_x_ad(mg(kf)%v,mg(kf)%f,mg(kf)%dbarx,mg(kf)%ubarx,mg(kf)%obarx, &
+                               mg(kf)%nx,mg(kf)%ny,jj,ii)
+        else
+          call inverse_luop_x_ad(mg(kf)%v,mg(kf)%f,mg(kf)%dbarxh,mg(kf)%ubarxh,mg(kf)%obarxh, &
+                               mg(kf)%nx,mg(kf)%ny,jj,ii)
+        end if
+        xtz=zero
+        do i=0,mg(kf)%nx
+          do j=0,mg(kf)%ny
+            xtz=xtz+mg(kf)%v(j,i)*mg(kf)%w(j,i)
+          end do
+        end do
+        write(6,'(" inverse_luop_x_ad (aT*a), jj,ii,h,k,xtz,yty=",3i2,i3,2e22.15,e10.3)') &
+                       jj,ii,ihem,kf,xtz,yty,abs(two*(xtz-yty)/(abs(xtz)+abs(yty)))
+                     if(abs(xtz)+abs(yty) /= zero) errmax=max(abs(two*(xtz-yty)/(abs(xtz)+abs(yty))),errmax)
+      end do
+
+      do kf=1,mgrid
+        call random_number(mg(kf)%f)
+        mg(kf)%w=mg(kf)%f
+        mg(kf)%v=zero
+        if(ihem == 0) then
+          call inverse_luop_x_ad(mg(kf)%v,mg(kf)%f,mg(kf)%dbarx,mg(kf)%ubarx,mg(kf)%obarx, &
+                               mg(kf)%nx,mg(kf)%ny,jj,ii)
+        else
+          call inverse_luop_x_ad(mg(kf)%v,mg(kf)%f,mg(kf)%dbarxh,mg(kf)%ubarxh,mg(kf)%obarxh, &
+                               mg(kf)%nx,mg(kf)%ny,jj,ii)
+        end if
+        yty=zero
+        do i=0,mg(kf)%nx
+          do j=0,mg(kf)%ny
+            yty=yty+mg(kf)%v(j,i)**2
+          end do
+        end do
+        mg(kf)%f=zero
+        if(ihem == 0) then
+          call inverse_luop_x(mg(kf)%v,mg(kf)%f,mg(kf)%dbarx,mg(kf)%ubarx,mg(kf)%obarx, &
+                               mg(kf)%nx,mg(kf)%ny,jj,ii)
+        else
+          call inverse_luop_x(mg(kf)%v,mg(kf)%f,mg(kf)%dbarxh,mg(kf)%ubarxh,mg(kf)%obarxh, &
+                               mg(kf)%nx,mg(kf)%ny,jj,ii)
+        end if
+        xtz=zero
+        do i=0,mg(kf)%nx
+          do j=0,mg(kf)%ny
+            xtz=xtz+mg(kf)%f(j,i)*mg(kf)%w(j,i)
+          end do
+        end do
+        write(6,'(" inverse_luop_x_ad (a*aT), jj,ii,h,k,xtz,yty=",3i2,i3,2e22.15,e10.3)') &
+                       jj,ii,ihem,kf,xtz,yty,abs(two*(xtz-yty)/(abs(xtz)+abs(yty)))
+                     if(abs(xtz)+abs(yty) /= zero) errmax=max(abs(two*(xtz-yty)/(abs(xtz)+abs(yty))),errmax)
+      end do
+    end do
+    end do
+    end do
+          write(6,'(" max error for inverse_luop_x_ad=",e10.3)') errmax
+
+!              inverse_luop_y
+
+    errmax=zero
+    do ii=1,2
+    do jj=1,1
+    do ihem=0,1
+      helmholtz_factor=ihem
+      do kf=1,mgrid
+        call random_number(mg(kf)%v)
+        mg(kf)%w=mg(kf)%v
+        mg(kf)%f=zero
+        if(ihem == 0) then
+          call inverse_luop_y(mg(kf)%v,mg(kf)%f,mg(kf)%dbary,mg(kf)%ubary,mg(kf)%obary, &
+                               mg(kf)%nx,mg(kf)%ny,ii,jj)
+        else
+          call inverse_luop_y(mg(kf)%v,mg(kf)%f,mg(kf)%dbaryh,mg(kf)%ubaryh,mg(kf)%obaryh, &
+                               mg(kf)%nx,mg(kf)%ny,ii,jj)
+        end if
+        yty=zero
+        do i=0,mg(kf)%nx
+          do j=0,mg(kf)%ny
+            yty=yty+mg(kf)%f(j,i)**2
+          end do
+        end do
+        mg(kf)%v=zero
+        if(ihem == 0) then
+          call inverse_luop_y_ad(mg(kf)%v,mg(kf)%f,mg(kf)%dbary,mg(kf)%ubary,mg(kf)%obary, &
+                               mg(kf)%nx,mg(kf)%ny,ii,jj)
+        else
+          call inverse_luop_y_ad(mg(kf)%v,mg(kf)%f,mg(kf)%dbaryh,mg(kf)%ubaryh,mg(kf)%obaryh, &
+                               mg(kf)%nx,mg(kf)%ny,ii,jj)
+        end if
+        xtz=zero
+        do i=0,mg(kf)%nx
+          do j=0,mg(kf)%ny
+            xtz=xtz+mg(kf)%v(j,i)*mg(kf)%w(j,i)
+          end do
+        end do
+        write(6,'(" inverse_luop_y_ad (aT*a), ii,jj,h,k,xtz,yty=",3i2,i3,2e22.15,e10.3)') &
+                       ii,jj,ihem,kf,xtz,yty,abs(two*(xtz-yty)/(abs(xtz)+abs(yty)))
+                     if(abs(xtz)+abs(yty) /= zero) errmax=max(abs(two*(xtz-yty)/(abs(xtz)+abs(yty))),errmax)
+      end do
+
+      do kf=1,mgrid
+        call random_number(mg(kf)%f)
+        mg(kf)%w=mg(kf)%f
+        mg(kf)%v=zero
+        if(ihem == 0) then
+          call inverse_luop_y_ad(mg(kf)%v,mg(kf)%f,mg(kf)%dbary,mg(kf)%ubary,mg(kf)%obary, &
+                               mg(kf)%nx,mg(kf)%ny,ii,jj)
+        else
+          call inverse_luop_y_ad(mg(kf)%v,mg(kf)%f,mg(kf)%dbaryh,mg(kf)%ubaryh,mg(kf)%obaryh, &
+                               mg(kf)%nx,mg(kf)%ny,ii,jj)
+        end if
+        yty=zero
+        do i=0,mg(kf)%nx
+          do j=0,mg(kf)%ny
+            yty=yty+mg(kf)%v(j,i)**2
+          end do
+        end do
+        mg(kf)%f=zero
+        if(ihem == 0) then
+          call inverse_luop_y(mg(kf)%v,mg(kf)%f,mg(kf)%dbary,mg(kf)%ubary,mg(kf)%obary, &
+                               mg(kf)%nx,mg(kf)%ny,ii,jj)
+        else
+          call inverse_luop_y(mg(kf)%v,mg(kf)%f,mg(kf)%dbaryh,mg(kf)%ubaryh,mg(kf)%obaryh, &
+                               mg(kf)%nx,mg(kf)%ny,ii,jj)
+        end if
+        xtz=zero
+        do i=0,mg(kf)%nx
+          do j=0,mg(kf)%ny
+            xtz=xtz+mg(kf)%f(j,i)*mg(kf)%w(j,i)
+          end do
+        end do
+        write(6,'(" inverse_luop_y_ad (a*aT), ii,jj,h,k,xtz,yty=",3i2,i3,2e22.15,e10.3)') &
+                       ii,jj,ihem,kf,xtz,yty,abs(two*(xtz-yty)/(abs(xtz)+abs(yty)))
+                     if(abs(xtz)+abs(yty) /= zero) errmax=max(abs(two*(xtz-yty)/(abs(xtz)+abs(yty))),errmax)
+      end do
+    end do
+    end do
+    end do
+          write(6,'(" max error for inverse_luop_y_ad=",e10.3)') errmax
+
+!              relax_ad
+
+    errmax=zero
+    do ihem=0,1
+      do kf=1,mgrid
+        call random_number(mg(kf)%v)
+        call random_number(mg(kf)%f)
+        mg(kf)%w=mg(kf)%v
+        mg(kf)%y=mg(kf)%f
+        if(ihem == 1) then
+          call relax(mg(kf)%v,mg(kf)%f, &
+                      mg(kf)%dbarxh,mg(kf)%ubarxh,mg(kf)%obarxh, &
+                      mg(kf)%dbaryh,mg(kf)%ubaryh,mg(kf)%obaryh, &
+                      mg(kf)%h0p,mg(kf)%h0m,mg(kf)%hp0,mg(kf)%hm0, &
+                      mg(kf)%nx,mg(kf)%ny,mg(kf)%b_over_a_east_neg,mg(kf)%b_over_a_north_neg)
+        else
+          call relax(mg(kf)%v,mg(kf)%f, &
+                      mg(kf)%dbarx,mg(kf)%ubarx,mg(kf)%obarx, &
+                      mg(kf)%dbary,mg(kf)%ubary,mg(kf)%obary, &
+                      mg(kf)%h0p,mg(kf)%h0m,mg(kf)%hp0,mg(kf)%hm0, &
+                      mg(kf)%nx,mg(kf)%ny,mg(kf)%b_over_a_east_neg,mg(kf)%b_over_a_north_neg)
+        end if
+        yty=zero
+        do i=0,mg(kf)%nx
+          do j=0,mg(kf)%ny
+            yty=yty+mg(kf)%f(j,i)**2+mg(kf)%v(j,i)**2
+          end do
+        end do
+        if(ihem == 1) then
+          call relax_ad(mg(kf)%v,mg(kf)%f, &
+                      mg(kf)%dbarxh,mg(kf)%ubarxh,mg(kf)%obarxh, &
+                      mg(kf)%dbaryh,mg(kf)%ubaryh,mg(kf)%obaryh, &
+                      mg(kf)%h0p,mg(kf)%h0m,mg(kf)%hp0,mg(kf)%hm0, &
+                      mg(kf)%nx,mg(kf)%ny,mg(kf)%b_over_a_east_neg,mg(kf)%b_over_a_north_neg)
+        else
+          call relax_ad(mg(kf)%v,mg(kf)%f, &
+                      mg(kf)%dbarx,mg(kf)%ubarx,mg(kf)%obarx, &
+                      mg(kf)%dbary,mg(kf)%ubary,mg(kf)%obary, &
+                      mg(kf)%h0p,mg(kf)%h0m,mg(kf)%hp0,mg(kf)%hm0, &
+                      mg(kf)%nx,mg(kf)%ny,mg(kf)%b_over_a_east_neg,mg(kf)%b_over_a_north_neg)
+        end if
+        xtz=zero
+        do i=0,mg(kf)%nx
+          do j=0,mg(kf)%ny
+            xtz=xtz+mg(kf)%v(j,i)*mg(kf)%w(j,i)+mg(kf)%f(j,i)*mg(kf)%y(j,i)
+          end do
+        end do
+        write(6,'(" relax_ad (aT*a), h,k,xtz,yty=",i2,i3,2e22.15,e10.3)') &
+                       ihem,kf,xtz,yty,abs(two*(xtz-yty)/(abs(xtz)+abs(yty)))
+                     if(abs(xtz)+abs(yty) /= zero) errmax=max(abs(two*(xtz-yty)/(abs(xtz)+abs(yty))),errmax)
+      end do
+
+      do kf=1,mgrid
+        call random_number(mg(kf)%v)
+        call random_number(mg(kf)%f)
+        mg(kf)%w=mg(kf)%v
+        mg(kf)%y=mg(kf)%f
+        if(ihem == 1) then
+          call relax_ad(mg(kf)%v,mg(kf)%f, &
+                      mg(kf)%dbarxh,mg(kf)%ubarxh,mg(kf)%obarxh, &
+                      mg(kf)%dbaryh,mg(kf)%ubaryh,mg(kf)%obaryh, &
+                      mg(kf)%h0p,mg(kf)%h0m,mg(kf)%hp0,mg(kf)%hm0, &
+                      mg(kf)%nx,mg(kf)%ny,mg(kf)%b_over_a_east_neg,mg(kf)%b_over_a_north_neg)
+        else
+          call relax_ad(mg(kf)%v,mg(kf)%f, &
+                      mg(kf)%dbarx,mg(kf)%ubarx,mg(kf)%obarx, &
+                      mg(kf)%dbary,mg(kf)%ubary,mg(kf)%obary, &
+                      mg(kf)%h0p,mg(kf)%h0m,mg(kf)%hp0,mg(kf)%hm0, &
+                      mg(kf)%nx,mg(kf)%ny,mg(kf)%b_over_a_east_neg,mg(kf)%b_over_a_north_neg)
+        end if
+        yty=zero
+        do i=0,mg(kf)%nx
+          do j=0,mg(kf)%ny
+            yty=yty+mg(kf)%f(j,i)**2+mg(kf)%v(j,i)**2
+          end do
+        end do
+        if(ihem == 1) then
+          call relax(mg(kf)%v,mg(kf)%f, &
+                      mg(kf)%dbarxh,mg(kf)%ubarxh,mg(kf)%obarxh, &
+                      mg(kf)%dbaryh,mg(kf)%ubaryh,mg(kf)%obaryh, &
+                      mg(kf)%h0p,mg(kf)%h0m,mg(kf)%hp0,mg(kf)%hm0, &
+                      mg(kf)%nx,mg(kf)%ny,mg(kf)%b_over_a_east_neg,mg(kf)%b_over_a_north_neg)
+        else
+          call relax(mg(kf)%v,mg(kf)%f, &
+                      mg(kf)%dbarx,mg(kf)%ubarx,mg(kf)%obarx, &
+                      mg(kf)%dbary,mg(kf)%ubary,mg(kf)%obary, &
+                      mg(kf)%h0p,mg(kf)%h0m,mg(kf)%hp0,mg(kf)%hm0, &
+                      mg(kf)%nx,mg(kf)%ny,mg(kf)%b_over_a_east_neg,mg(kf)%b_over_a_north_neg)
+        end if
+        xtz=zero
+        do i=0,mg(kf)%nx
+          do j=0,mg(kf)%ny
+            xtz=xtz+mg(kf)%v(j,i)*mg(kf)%w(j,i)+mg(kf)%f(j,i)*mg(kf)%y(j,i)
+          end do
+        end do
+        write(6,'(" relax_ad (a*aT), h,k,xtz,yty=",i2,i3,2e22.15,e10.3)') &
+                       ihem,kf,xtz,yty,abs(two*(xtz-yty)/(abs(xtz)+abs(yty)))
+                     if(abs(xtz)+abs(yty) /= zero) errmax=max(abs(two*(xtz-yty)/(abs(xtz)+abs(yty))),errmax)
+      end do
+
+    end do
+          write(6,'(" max error for relax_ad=",e10.3)') errmax
+
+!              vcycle_ad
+   
+    errmax=zero
+    do ivar=1,2
+    do ihem=0,1
+     helmholtz=ihem == 1
+     do nrelax1=1,1
+     do nrelax2=1,1
+     do nrelax_solve=1,1
+     do mgrid2=2,mgrid
+   ! do mgrid2=2,2
+      kf=1
+      mg(kf)%y=zero ; mg(kf)%z=zero
+      if(ivar == 1) call random_number(mg(kf)%y)
+      if(ivar == 2) call random_number(mg(kf)%z)
+      mg(kf)%yy=mg(kf)%y
+      mg(kf)%zz=mg(kf)%z
+      call vcycle(mg(kf)%y,mg(kf)%z,mg(kf)%nx,mg(kf)%ny,mgrid2,nrelax1,nrelax2,nrelax_solve,helmholtz)
+      yty=zero
+      do i=0,mg(kf)%nx
+        do j=0,mg(kf)%ny
+          yty=yty+mg(kf)%y(j,i)**2+mg(kf)%z(j,i)**2
+        end do
+      end do
+      call vcycle_ad(mg(kf)%y,mg(kf)%z,mg(kf)%nx,mg(kf)%ny,mgrid2,nrelax1,nrelax2,nrelax_solve,helmholtz)
+      xtz=zero
+      do i=0,mg(kf)%nx
+        do j=0,mg(kf)%ny
+          xtz=xtz+mg(kf)%y(j,i)*mg(kf)%yy(j,i)+mg(kf)%z(j,i)*mg(kf)%zz(j,i)
+        end do
+      end do
+        write(6,'(" vcycle_ad (aT*a), vhn12sm2,xz,yy=",6i2,2e22.15,e10.3)') &
+               ivar,ihem,nrelax1,nrelax2,nrelax_solve,mgrid2,xtz,yty,abs(two*(xtz-yty)/(abs(xtz)+abs(yty)))
+                     if(abs(xtz)+abs(yty) /= zero) errmax=max(abs(two*(xtz-yty)/(abs(xtz)+abs(yty))),errmax)
+   
+      mg(kf)%y=zero ; mg(kf)%z=zero
+      if(ivar == 1) call random_number(mg(kf)%y)
+      if(ivar == 2) call random_number(mg(kf)%z)
+      mg(kf)%yy=mg(kf)%y
+      mg(kf)%zz=mg(kf)%z
+      call vcycle_ad(mg(kf)%y,mg(kf)%z,mg(kf)%nx,mg(kf)%ny,mgrid2,nrelax1,nrelax2,nrelax_solve,helmholtz)
+      yty=zero
+      do i=0,mg(kf)%nx
+        do j=0,mg(kf)%ny
+          yty=yty+mg(kf)%y(j,i)**2+mg(kf)%z(j,i)**2
+        end do
+      end do
+      call vcycle(mg(kf)%y,mg(kf)%z,mg(kf)%nx,mg(kf)%ny,mgrid2,nrelax1,nrelax2,nrelax_solve,helmholtz)
+      xtz=zero
+      do i=0,mg(kf)%nx
+        do j=0,mg(kf)%ny
+          xtz=xtz+mg(kf)%y(j,i)*mg(kf)%yy(j,i)+mg(kf)%z(j,i)*mg(kf)%zz(j,i)
+        end do
+      end do
+        write(6,'(" vcycle_ad (a*aT), vhn12sm2,xz,yy=",6i2,2e22.15,e10.3)') &
+               ivar,ihem,nrelax1,nrelax2,nrelax_solve,mgrid2,xtz,yty,abs(two*(xtz-yty)/(abs(xtz)+abs(yty)))
+                     if(abs(xtz)+abs(yty) /= zero) errmax=max(abs(two*(xtz-yty)/(abs(xtz)+abs(yty))),errmax)
+     end do
+     end do
+     end do
+     end do
+    end do
+    end do
+    write(6,'(" max error for vcycle_ad=",e10.3)') errmax
+
+!              fmg_ad
+   
+    errmax=zero
+    do ivar=1,2
+    do ihem=0,1
+     helmholtz=ihem == 1
+     do nrelax1=1,1
+     do nrelax2=1,1
+     do nrelax_solve=25,25
+      kf=1
+      mg(kf)%y=zero ; mg(kf)%z=zero
+      if(ivar == 1) call random_number(mg(kf)%y)
+      if(ivar == 2) call random_number(mg(kf)%z)
+      mg(kf)%yy=mg(kf)%y
+      mg(kf)%zz=mg(kf)%z
+      call fmg(mg(kf)%y,mg(kf)%z,helmholtz,nrelax1,nrelax2,nrelax_solve,mg(kf)%nx,mg(kf)%ny)
+      yty=zero
+      do i=0,mg(kf)%nx
+        do j=0,mg(kf)%ny
+          yty=yty+mg(kf)%y(j,i)**2+mg(kf)%z(j,i)**2
+        end do
+      end do
+      call fmg_ad(mg(kf)%y,mg(kf)%z,helmholtz,nrelax1,nrelax2,nrelax_solve,mg(kf)%nx,mg(kf)%ny)
+      xtz=zero
+      do i=0,mg(kf)%nx
+        do j=0,mg(kf)%ny
+          xtz=xtz+mg(kf)%y(j,i)*mg(kf)%yy(j,i)+mg(kf)%z(j,i)*mg(kf)%zz(j,i)
+        end do
+      end do
+        write(6,'(" fmg_ad (aT*a), vhn12s,xz,yy=",5i2,2e22.15,e10.3)') &
+               ivar,ihem,nrelax1,nrelax2,nrelax_solve,xtz,yty,abs(two*(xtz-yty)/(abs(xtz)+abs(yty)))
+                     if(abs(xtz)+abs(yty) /= zero) errmax=max(abs(two*(xtz-yty)/(abs(xtz)+abs(yty))),errmax)
+   
+      mg(kf)%y=zero ; mg(kf)%z=zero
+      if(ivar == 1) call random_number(mg(kf)%y)
+      if(ivar == 2) call random_number(mg(kf)%z)
+      mg(kf)%yy=mg(kf)%y
+      mg(kf)%zz=mg(kf)%z
+      call fmg_ad(mg(kf)%y,mg(kf)%z,helmholtz,nrelax1,nrelax2,nrelax_solve,mg(kf)%nx,mg(kf)%ny)
+      yty=zero
+      do i=0,mg(kf)%nx
+        do j=0,mg(kf)%ny
+          yty=yty+mg(kf)%y(j,i)**2+mg(kf)%z(j,i)**2
+        end do
+      end do
+      call fmg(mg(kf)%y,mg(kf)%z,helmholtz,nrelax1,nrelax2,nrelax_solve,mg(kf)%nx,mg(kf)%ny)
+      xtz=zero
+      do i=0,mg(kf)%nx
+        do j=0,mg(kf)%ny
+          xtz=xtz+mg(kf)%y(j,i)*mg(kf)%yy(j,i)+mg(kf)%z(j,i)*mg(kf)%zz(j,i)
+        end do
+      end do
+        write(6,'(" fmg_ad (a*aT), vhn12s,xz,yy=",5i2,2e22.15,e10.3)') &
+               ivar,ihem,nrelax1,nrelax2,nrelax_solve,xtz,yty,abs(two*(xtz-yty)/(abs(xtz)+abs(yty)))
+                     if(abs(xtz)+abs(yty) /= zero) errmax=max(abs(two*(xtz-yty)/(abs(xtz)+abs(yty))),errmax)
+     end do
+     end do
+     end do
+    end do
+    end do
+          write(6,'(" max error for fmg_ad=",e10.3)') errmax
+
+  end subroutine test_adjoint
+
+end module helmholtz_fmg_mod
+
+subroutine fmg_initialize(mype)
+
+  use m_kinds, only: r_kind,i_kind,r_single
+  use constants, only: zero,half,one
+  use gridmod, only: region_lat,region_dx,region_dy,nlon,nlat
+  use helmholtz_fmg_mod, only: generate_grids,init_mgvars
+  use mod_vtrans, only: nvmodes_keep,depths
+  implicit none
+
+  integer(i_kind),intent(in):: mype
+
+  integer(i_kind) mode_number
+  real(r_kind) phi0
+
+!                 for this version, make parallel by vertical modes, so only have nvmodes_keep copies
+!                     this is most simpleminded approach--later modify to take advantage of all processors
+!                     available.
+
+   if(mype+1 >  2*nvmodes_keep) return
+
+   mode_number=mod(mype,nvmodes_keep)+1
+   phi0=depths(mode_number)
+   write(6,*)' in fmg_initialize, mype,mode_number,phi0=',mype,mode_number,phi0
+
+   call generate_grids(nlon,nlat)
+   call init_mgvars(region_dx,region_dy,region_lat,phi0)
+
+end subroutine fmg_initialize
+
+subroutine fmg_initialize_e(mype)
+
+  use m_kinds, only: r_kind,i_kind,r_single
+  use constants, only: zero,half,one
+  use gridmod, only: region_lat,region_dx,region_dy,nlon,nlat,txy2ll
+  use helmholtz_fmg_mod, only: generate_grids,init_mgvars
+  use mod_vtrans, only: nvmodes_keep,depths
+  use zrnmi_mod, only: zrnmi_initialize
+  implicit none
+
+  integer(i_kind),intent(in):: mype
+
+  integer(i_kind) mode_number
+  real(r_kind) phi0
+  real(r_kind) region_lat_e(0:nlat+1,0:nlon+1)
+  real(r_kind) region_dx_e(0:nlat+1,0:nlon+1),region_dy_e(0:nlat+1,0:nlon+1)
+  integer(i_kind) i,j
+  real(r_kind) rx,ry,rlon
+
+!                 for this version, make parallel by vertical modes, so only have nvmodes_keep copies
+!                     this is most simpleminded approach--later modify to take advantage of all processors
+!                     available.
+
+   call zrnmi_initialize(mype)
+
+   if(mype+1 >  2*nvmodes_keep) return
+
+   mode_number=mod(mype,nvmodes_keep)+1
+   phi0=depths(mode_number)
+   write(6,*)' in fmg_initialize_e, mype,mode_number,phi0=',mype,mode_number,phi0
+
+   do j=1,nlon
+     do i=1,nlat
+       region_lat_e(i,j)=region_lat(i,j)
+       region_dx_e(i,j)=region_dx(i,j)
+       region_dy_e(i,j)=region_dy(i,j)
+     end do
+   end do
+
+   do j=1,nlon
+     rx=j
+     ry=0
+     call txy2ll(rx,ry,rlon,region_lat_e(0,j))
+     region_dx_e(0,j)=region_dx_e(1,j)
+     region_dy_e(0,j)=region_dy_e(1,j)
+     ry=nlat+1
+     call txy2ll(rx,ry,rlon,region_lat_e(nlat+1,j))
+     region_dx_e(nlat+1,j)=region_dx_e(nlat,j)
+     region_dy_e(nlat+1,j)=region_dy_e(nlat,j)
+   end do
+   do i=0,nlat+1
+     ry=i
+     rx=0
+     call txy2ll(rx,ry,rlon,region_lat_e(i,0))
+     region_dx_e(i,0)=region_dx_e(i,1)
+     region_dy_e(i,0)=region_dy_e(i,1)
+     rx=nlon+1
+     call txy2ll(rx,ry,rlon,region_lat_e(i,nlon+1))
+     region_dx_e(i,nlon+1)=region_dx_e(i,nlon)
+     region_dy_e(i,nlon+1)=region_dy_e(i,nlon)
+   end do
+              if(mype == 0) call outgrad1(region_lat_e,'region_lat_e',nlon+2,nlat+2)
+              if(mype == 0) call outgrad1(region_dx_e,'region_dx_e',nlon+2,nlat+2)
+              if(mype == 0) call outgrad1(region_dy_e,'region_dy_e',nlon+2,nlat+2)
+   
+
+   call generate_grids(nlon+2,nlat+2)
+   call init_mgvars(region_dx_e,region_dy_e,region_lat_e,phi0)
+
+end subroutine fmg_initialize_e
+
+subroutine fmg_strong_bal_correction(u_t,v_t,t_t,ps_t,psi,chi,t,ps,bal_diagnostic,fullfield,update,mype)
+
+  use m_kinds, only: r_kind,i_kind
+  use constants, only: zero,two,omega
+  use gridmod, only: lat2,lon2,nsig,nlat,nlon,region_lat
+  use mod_vtrans, only: vtrans,vtrans_inv,nvmodes_keep,depths
+  use m_mpimod, only: gsi_mpi_comm_world,ierror,mpi_sum,mpi_rtype
+  use zrnmi_mod, only: zrnmi_filter_uvm2
+  use jfunc,only: jiter
+  use hybrid_ensemble_parameters, only: uv_hyb_ens
+  implicit none
+
+  integer(i_kind),intent(in)::mype
+  logical,intent(in)::bal_diagnostic,update,fullfield
+  real(r_kind),dimension(lat2,lon2,nsig),intent(in)::u_t,v_t,t_t
+  real(r_kind),dimension(lat2,lon2),intent(in)::ps_t
+  real(r_kind),dimension(lat2,lon2,nsig),intent(inout)::psi,chi,t
+  real(r_kind),dimension(lat2,lon2),intent(inout)::ps
+
+  real(r_kind),dimension(lat2,lon2,nvmodes_keep)::utilde,vtilde,mtilde
+  real(r_kind),dimension(lat2,lon2,nvmodes_keep)::delpsitilde,delchitilde,delmtilde,dummytilde
+  real(r_kind),dimension(nlat,nlon)::u0t,v0t,m0t,div0t,vor0t,rhs,mtg,delm,divtg,vortg,mtg_x,mtg_y
+  real(r_kind),dimension(nlat,nlon)::delvor,deldiv,delpsi,delchi,delf1,delf2
+  integer(i_kind) mode_number_a,mode_number_b
+  real(r_kind) bal_a (nvmodes_keep),bal_b (nvmodes_keep)
+  real(r_kind) bal_a0(nvmodes_keep),bal_b0(nvmodes_keep)
+  real(r_kind) bal(nvmodes_keep)
+  character(1) bourke_mcgregor_scheme
+
+  integer(i_kind) i,j
+
+  if(uv_hyb_ens) then
+     write(0,*)' STOP IN fmg_strong_bal_correction--NOT ABLE TO ACCEPT uv_hyb_ens=.true. YET'
+     call stop2(998)
+  end if
+
+ !bourke_mcgregor_scheme='A'
+  bourke_mcgregor_scheme='B'
+
+  mode_number_a=0 ; mode_number_b=0
+  if(mype+1 <= 2*nvmodes_keep) then
+    if(mype+1 <= nvmodes_keep) then
+      mode_number_a=mype+1
+    else
+      mode_number_b=mype+1-nvmodes_keep
+    end if
+  end if
+ !write(6,*)' in fmg_strong_bal_correction, mode_number_a,mode_number_b=',mode_number_a,mode_number_b
+          !      if(mype >  -10) then
+          !        call mpi_finalize(i)
+          !        stop
+          !      end if
+
+!      vertical mode transform
+
+    utilde=zero ; vtilde=zero ; mtilde=zero                !!! redundant--remove eventually!!!!
+    call vtrans(u_t,v_t,t_t,ps_t,utilde,vtilde,mtilde)
+
+!    filter low frequency scales out of tendencies
+    call zrnmi_filter_uvm2(utilde,vtilde,mtilde,mype)
+
+!     layout for new rtlnmc forward code:
+
+!1.  u0t,v0t,m0t input on subdomains  --  output will be delchi, delpsi, delm-->delt,delps
+
+!2.  set up slab areas  A:         0     <= mype <= nvmodes_keep-1
+!                       B:  nvmodes_keep <= mype <= 2*nvmodes_keep-1
+
+!        require npe >= 2*nvmodes_keep
+
+!3.  subdomains to slabs:  u0t,v0t,m0t --> A and B
+
+    u0t=zero ; v0t=zero ; m0t=zero             !  may be redundant--consider removing!!
+    call special_for_llfmg_sub2grid3(utilde,vtilde,mtilde,utilde,vtilde,mtilde,u0t,v0t,m0t,mype)
+
+!4.  compute div0t on A from u0t,v0t and vort0t on B from u0t,v0t
+
+    if(mode_number_a /= 0) then
+      call get_div_reg(u0t,v0t,div0t)
+    end if
+    if(mode_number_b /= 0) then
+      call get_vor_reg(u0t,v0t,vor0t)
+    end if
+
+!5.  solve HOP*delm = div0t                    on A
+!          HOP*mtg  = delsqr*m0t-f*vor0t  on B
+
+    if(mode_number_a /= 0) then
+      call fmg_wrapper_e(delm,div0t,.true.,nlon,nlat)
+    end if
+    if(mode_number_b /= 0) then
+      call get_delsqr_reg(m0t,rhs)
+      do j=1,nlon
+        do i=1,nlat
+          rhs(i,j)=rhs(i,j)-two*omega*sin(region_lat(i,j))*vor0t(i,j)
+        end do
+      end do
+      call fmg_wrapper_e(mtg,rhs,.true.,nlon,nlat)
+    end if
+
+!6.  diagnostic BAL computation:
+
+!        BAL = integral( mtg_x**2 + mtg_y**2 + phi0*(vortg**2+divtg**2) )
+
+!       bal_a = integral( phi0*divtg**2 )
+
+!       bal_b = integral( mtg_x**2 + mtg_y**2 + phi0*vortg**2 )
+
+!       BAL = bal_a + bal_b
+
+    if(bal_diagnostic) then
+
+      bal_a=zero ; bal_b=zero
+      if(mode_number_a /= 0) then
+        divtg=div0t
+        bal_a=zero
+        do j=1,nlon
+          do i=1,nlat
+            bal_a(mode_number_a)=bal_a(mode_number_a)+depths(mode_number_a)*divtg(i,j)**2
+          end do
+        end do
+      end if
+      if(mode_number_b /= 0) then
+!                                  vortg=f*mtg/phi0    ; compute grad(mtg)
+        do j=1,nlon
+          do i=1,nlat
+            vortg(i,j)=two*omega*sin(region_lat(i,j))*mtg(i,j)/depths(mode_number_b)
+          end do
+        end do
+        call delx_reg(mtg,mtg_x,.false.)
+        call dely_reg(mtg,mtg_y,.false.)
+        bal_b=zero
+        do j=1,nlon
+          do i=1,nlat
+            bal_b(mode_number_b)=bal_b(mode_number_b)+depths(mode_number_b)*vortg(i,j)**2 &
+                                  +mtg_x(i,j)**2+mtg_y(i,j)**2
+          end do
+        end do
+      end if
+      call mpi_allreduce(bal_a,bal_a0,nvmodes_keep,mpi_rtype,mpi_sum,gsi_mpi_comm_world,ierror)
+      call mpi_allreduce(bal_b,bal_b0,nvmodes_keep,mpi_rtype,mpi_sum,gsi_mpi_comm_world,ierror)
+      bal=bal_a0+bal_b0
+      if(mype == 0) then
+        if(fullfield) then
+          write(6,*)'FMG_STRONG_BAL:   FULL FIELD BALANCE DIAGNOSTICS --  '
+        else
+           write(6,*) 'FMG_STRONG_BAL:   INCREMENTAL BALANCE DIAGNOSTICS --  '
+        end if
+        do i=1,nvmodes_keep
+          write(6,'(" jiter,mode,bal_a,b,bal=",2i3,3e20.9)')jiter,i,bal_a0(i),bal_b0(i),bal(i)
+        end do
+      end if
+    end if
+
+
+!7.  delvor = f*delm/phi0 --> solve delsqr(delpsi) = delvor    on A
+!    deldiv = mtg/phi0    --> solve delsqr(delchi) = deldiv    on B     (for bourke_mcgregor_scheme = B )
+!    deldiv = m0t/phi0                                                  (for bourke_mcgregor_scheme = A )
+
+    if(mode_number_a /= 0) then
+      do j=1,nlon
+        do i=1,nlat
+          delvor(i,j)=two*omega*sin(region_lat(i,j))*delm(i,j)/depths(mode_number_a)
+        end do
+      end do
+      call fmg_wrapper_e(delpsi,delvor,.false.,nlon,nlat)
+    end if
+    if(mode_number_b /= 0) then
+      if(bourke_mcgregor_scheme == 'A') then
+       !write(6,*)' using bourke_mcgregor_scheme A, so deldiv = m0t/phi0'
+        do j=1,nlon
+          do i=1,nlat
+            deldiv(i,j)=m0t(i,j)/depths(mode_number_b)
+          end do
+        end do
+      elseif(bourke_mcgregor_scheme == 'B') then
+       !write(6,*)' using bourke_mcgregor_scheme B, so deldiv = mtg/phi0'
+        do j=1,nlon
+          do i=1,nlat
+            deldiv(i,j)=mtg(i,j)/depths(mode_number_b)
+          end do
+        end do
+      end if
+      call fmg_wrapper_e(delchi,deldiv,.false.,nlon,nlat)
+    end if
+
+
+!8.  delpsi,delm    A slab --> subdomains
+!    delchi,dummy   B slab --> subdomains
+
+!    if update_uv, u_psi,v_psi  A slab --> subdomains
+!    if update_uv, u_chi,v_chi  B slab --> subdomains
+
+    delf1=zero ; delf2=zero
+    if(mode_number_a /= 0) then
+      do j=1,nlon
+        do i=1,nlat
+          delf1(i,j)= delpsi(i,j)
+          delf2 (i,j)=delm(i,j)
+        end do
+      end do
+    end if
+    if(mode_number_b /= 0) then
+      do j=1,nlon
+        do i=1,nlat
+          delf1(i,j)= delchi(i,j)
+          delf2 (i,j)=delchi(i,j)
+        end do
+      end do
+    end if
+    call special_for_llfmg_grid2sub2(delf1,delf2,delpsitilde,delmtilde,delchitilde,dummytilde,mype)
+    if(update) call vtrans_inv(delpsitilde,delchitilde,delmtilde,psi,chi,t,ps)
+
+end subroutine fmg_strong_bal_correction
+
+subroutine fmg_strong_bal_correction_ad(u_t,v_t,t_t,ps_t,psi,chi,t,ps,update,mype)
+
+  use m_kinds, only: r_kind,i_kind
+  use constants, only: zero,two,omega
+  use gridmod, only: lat2,lon2,nsig,nlat,nlon,region_lat
+  use mod_vtrans, only: vtrans_ad,vtrans_inv_ad,nvmodes_keep,depths
+! use helmholtz_fmg_mod, only: mg
+  use m_mpimod, only: gsi_mpi_comm_world,mpi_sum,mpi_rtype
+  use zrnmi_mod, only: zrnmi_filter_uvm2_ad
+  use hybrid_ensemble_parameters, only: uv_hyb_ens
+  implicit none
+
+  integer(i_kind),intent(in)::mype
+  logical,intent(in)::update
+  real(r_kind),dimension(lat2,lon2,nsig),intent(inout)::u_t,v_t,t_t
+  real(r_kind),dimension(lat2,lon2),intent(inout)::ps_t
+  real(r_kind),dimension(lat2,lon2,nsig),intent(in)::psi,chi,t
+  real(r_kind),dimension(lat2,lon2),intent(in)::ps
+
+  real(r_kind),dimension(lat2,lon2,nvmodes_keep)::utilde,vtilde,mtilde,utdum,vtdum,mtdum
+  real(r_kind),dimension(lat2,lon2,nvmodes_keep)::delpsitilde,delchitilde,delmtilde,dummytilde
+  real(r_kind),dimension(nlat,nlon)::u0t,v0t,m0t,div0t,vor0t,rhs,mtg,delm
+  real(r_kind),dimension(nlat,nlon)::delvor,deldiv,delpsi,delchi,delf1,delf2
+  real(r_kind),dimension(lat2,lon2,nsig)::dpsi,dchi,dt
+  real(r_kind),dimension(lat2,lon2)::dps
+  integer(i_kind) i,j,mode_number_a,mode_number_b
+  character(1) bourke_mcgregor_scheme
+
+  if(uv_hyb_ens) then
+    write(0,*)' STOP IN fmg_strong_bal_correction--NOT ABLE TO ACCEPT uv_hyb_ens=.true. YET'
+    call stop2(998)
+  end if
+
+ !bourke_mcgregor_scheme='A'
+  bourke_mcgregor_scheme='B'
+
+  mode_number_a=0 ; mode_number_b=0
+  if(mype+1 <= 2*nvmodes_keep) then
+    if(mype+1 <= nvmodes_keep) then
+      mode_number_a=mype+1
+    else
+      mode_number_b=mype+1-nvmodes_keep
+    end if
+  end if
+ !write(6,*)' in fmg_strong_bal_correction_ad, mode_number_a,mode_number_b=',mode_number_a,mode_number_b
+
+  dpsi=zero ; dchi=zero ; dt=zero ; dps=zero
+  if(update) then
+    dpsi=psi ; dchi=chi
+    dt=t ; dps=ps
+  end if
+  delpsitilde=zero ; delchitilde=zero ; delmtilde=zero
+  call vtrans_inv_ad(delpsitilde,delchitilde,delmtilde,dpsi,dchi,dt,dps)
+
+!8.  delpsi,delm    A slab --> subdomains
+!    delchi,dummy   B slab --> subdomains
+
+!    if update_uv, u_psi,v_psi  A slab --> subdomains
+!    if update_uv, u_chi,v_chi  B slab --> subdomains
+
+  call special_for_llfmg_sub2grid2(delpsitilde,delmtilde,delchitilde,dummytilde,delf1,delf2,mype)
+
+    delpsi=zero ; delchi=zero ; delm=zero
+    if(mode_number_a /= 0) then
+      do j=1,nlon
+        do i=1,nlat
+          delpsi(i,j)=delf1(i,j)
+          delm(i,j)=delf2(i,j)
+        end do
+      end do
+    end if
+    if(mode_number_b /= 0) then
+      do j=1,nlon
+        do i=1,nlat
+          delchi(i,j)=delf1(i,j)
+        end do
+      end do
+    end if
+
+!7.  delvor = f*delm/phi0 --> solve delsqr(delpsi) = delvor    on A
+!    deldiv = mtg/phi0    --> solve delsqr(delchi) = deldiv    on B     (for bourke_mcgregor_scheme = B )
+!    deldiv = m0t/phi0                                                  (for bourke_mcgregor_scheme = A )
+
+    if(mode_number_a /= 0) then
+      delvor=zero
+      call fmg_wrapper_e_ad(delpsi,delvor,.false.,nlon,nlat)
+      do j=1,nlon
+        do i=1,nlat
+          delm(i,j)=delm(i,j)+two*omega*sin(region_lat(i,j))*delvor(i,j)/depths(mode_number_a)
+        end do
+      end do
+    end if
+    if(mode_number_b /= 0) then
+      deldiv=zero
+      call fmg_wrapper_e_ad(delchi,deldiv,.false.,nlon,nlat)
+      m0t=zero ; mtg=zero
+      if(bourke_mcgregor_scheme == 'A') then
+       !write(6,*)' using bourke_mcgregor_scheme A, so deldiv = m0t/phi0'
+        do j=1,nlon
+          do i=1,nlat
+            m0t(i,j)=deldiv(i,j)/depths(mode_number_b)
+          end do
+        end do
+      elseif(bourke_mcgregor_scheme == 'B') then
+       !write(6,*)' using bourke_mcgregor_scheme B, so deldiv = mtg/phi0'
+        do j=1,nlon
+          do i=1,nlat
+            mtg(i,j)=deldiv(i,j)/depths(mode_number_b)
+          end do
+        end do
+      end if
+    end if
+
+!5.  solve HOP*delm = div0t                    on A
+!          HOP*mtg  = delsqr*m0t-f*vor0t  on B
+
+    if(mode_number_a /= 0) then
+      div0t=zero
+      call fmg_wrapper_e_ad(delm,div0t,.true.,nlon,nlat)
+    end if
+    if(mode_number_b /= 0) then
+      rhs=zero
+      call fmg_wrapper_e_ad(mtg,rhs,.true.,nlon,nlat)
+      do j=1,nlon
+        do i=1,nlat
+          vor0t(i,j)= -two*omega*sin(region_lat(i,j))*rhs(i,j)
+        end do
+      end do
+      call tget_delsqr_reg(rhs,m0t)
+    end if
+
+!4.  compute div0t on A from u0t,v0t and vort0t on B from u0t,v0t
+
+    if(mode_number_a /= 0) then
+      call get_div_reg_ad(u0t,v0t,div0t)
+    end if
+    if(mode_number_b /= 0) then
+      call get_vor_reg_ad(u0t,v0t,vor0t)
+    end if
+
+!3.  subdomains to slabs:  u0t,v0t,m0t --> A and B
+
+    utilde=zero ; vtilde=zero ; mtilde=zero
+    call special_for_llfmg_grid2sub3(u0t,v0t,m0t,utilde,vtdum,mtdum,utdum,vtilde,mtilde,mype)
+    utilde=utilde+utdum ; vtilde=vtilde+vtdum
+
+!      adjoint of filter low frequency scales out of tendencies
+    call zrnmi_filter_uvm2_ad(utilde,vtilde,mtilde,mype)
+
+!      adjoint of vertical mode transform
+
+    call vtrans_ad(u_t,v_t,t_t,ps_t,utilde,vtilde,mtilde)
+
+end subroutine fmg_strong_bal_correction_ad
+
+subroutine fmg_strong_bal_correction_ad_test(u_t,v_t,t_t,ps_t,psi,chi,t,ps,mype)
+
+!<><><><<><><><>test of fmg_strong_bal_correction_ad><>><<><><<<<<<<<<<<<<<<<>>>>>>>>>>>>>
+
+           use constants, only: zero,two
+           use m_mpimod, only: mpi_rtype,mpi_sum,gsi_mpi_comm_world,ierror
+  use m_kinds, only: r_kind,i_kind
+  use gridmod, only: lat2,lon2,nsig
+           implicit none
+
+  integer(i_kind),intent(in)::mype
+  real(r_kind),dimension(lat2,lon2,nsig),intent(inout)::u_t,v_t,t_t
+  real(r_kind),dimension(lat2,lon2),intent(inout)::ps_t
+  real(r_kind),dimension(lat2,lon2,nsig),intent(inout)::psi,chi,t
+  real(r_kind),dimension(lat2,lon2),intent(inout)::ps
+           real(r_kind),dimension(lat2,lon2,nsig)::uu_t,vv_t,tt_t
+           real(r_kind),dimension(lat2,lon2)::pps_t
+           real(r_kind),dimension(lat2,lon2,nsig)::psi2,chi2,t2
+           real(r_kind),dimension(lat2,lon2)::ps2
+           integer(i_kind) ivar,i,j,k
+           real(r_kind) yty,yty0,xtz,xtz0,errmax
+
+     errmax=zero
+     do ivar=0,4
+      if(ivar >  0) then
+       u_t=zero ; v_t=zero ; t_t=zero ; ps_t=zero
+       if(ivar == 1) call random_number(u_t)
+       if(ivar == 2) call random_number(v_t)
+       if(ivar == 3) call random_number(t_t)
+       if(ivar == 4) call random_number(ps_t)
+      end if
+       uu_t=u_t ; vv_t=v_t ; tt_t=t_t ; pps_t=ps_t
+       psi=zero ; chi=zero ; t=zero ; ps=zero
+       call fmg_strong_bal_correction(u_t,v_t,t_t,ps_t,psi,chi,t,ps,.false.,.false.,.true.,mype)
+       yty=zero
+       do k=1,nsig
+         do i=2,lon2-1
+           do j=2,lat2-1
+             yty=yty+psi(j,i,k)**2+chi(j,i,k)**2+t(j,i,k)**2
+           end do
+         end do
+       end do
+       do i=2,lon2-1
+         do j=2,lat2-1
+           yty=yty+ps(j,i)**2
+         end do
+       end do
+       call mpi_allreduce(yty,yty0,1,mpi_rtype,mpi_sum,gsi_mpi_comm_world,ierror)
+       u_t=zero ; v_t=zero ; t_t=zero ; ps_t=zero
+       call fmg_strong_bal_correction_ad(u_t,v_t,t_t,ps_t,psi,chi,t,ps,.true.,mype)
+       xtz=zero
+       do k=1,nsig
+         do i=2,lon2-1
+           do j=2,lat2-1
+             xtz=xtz+uu_t(j,i,k)*u_t(j,i,k)+vv_t(j,i,k)*v_t(j,i,k)+tt_t(j,i,k)*t_t(j,i,k)
+           end do
+         end do
+       end do
+       do i=2,lon2-1
+         do j=2,lat2-1
+           xtz=xtz+pps_t(j,i)*ps_t(j,i)
+         end do
+       end do
+       call mpi_allreduce(xtz,xtz0,1,mpi_rtype,mpi_sum,gsi_mpi_comm_world,ierror)
+         if(mype == 0) &
+         write(6,'(" fmg_strong_bal_correction_ad (aT*a), ivar,xx,yy=",i2,2e22.15,e10.3)') &
+                ivar,xtz0,yty0,abs(two*(xtz0-yty0)/(abs(xtz0)+abs(yty0)))
+               if(abs(xtz0)+abs(yty0) /= zero) errmax=max(abs(two*(xtz0-yty0)/(abs(xtz0)+abs(yty0))),errmax)
+ 
+       if(ivar == 0) cycle
+       psi=zero ; chi=zero ; t=zero ; ps=zero
+       if(ivar == 1) call random_number(psi)
+       if(ivar == 2) call random_number(chi)
+       if(ivar == 3) call random_number(t)
+       if(ivar == 4) call random_number(ps)
+       psi2=psi ; chi2=chi ; t2=t ; ps2=ps
+       u_t=zero ; v_t=zero ; t_t=zero ; ps_t=zero
+       call fmg_strong_bal_correction_ad(u_t,v_t,t_t,ps_t,psi,chi,t,ps,.true.,mype)
+       yty=zero
+       do k=1,nsig
+         do i=2,lon2-1
+           do j=2,lat2-1
+             yty=yty+u_t(j,i,k)*u_t(j,i,k)+v_t(j,i,k)*v_t(j,i,k)+t_t(j,i,k)*t_t(j,i,k)
+           end do
+         end do
+       end do
+       do i=2,lon2-1
+         do j=2,lat2-1
+           yty=yty+ps_t(j,i)*ps_t(j,i)
+         end do
+       end do
+       call mpi_allreduce(yty,yty0,1,mpi_rtype,mpi_sum,gsi_mpi_comm_world,ierror)
+       psi=zero ; chi=zero ; t=zero ; ps=zero
+       call fmg_strong_bal_correction(u_t,v_t,t_t,ps_t,psi,chi,t,ps,.false.,.false.,.true.,mype)
+       xtz=zero
+       do k=1,nsig
+         do i=2,lon2-1
+           do j=2,lat2-1
+             xtz=xtz+psi2(j,i,k)*psi(j,i,k)+chi2(j,i,k)*chi(j,i,k)+t2(j,i,k)*t(j,i,k)
+           end do
+         end do
+       end do
+       do i=2,lon2-1
+         do j=2,lat2-1
+           xtz=xtz+ps2(j,i)*ps(j,i)
+         end do
+       end do
+       call mpi_allreduce(xtz,xtz0,1,mpi_rtype,mpi_sum,gsi_mpi_comm_world,ierror)
+         if(mype == 0) &
+         write(6,'(" fmg_strong_bal_correction_ad (a*aT), ivar,xx,yy=",i2,2e22.15,e10.3)') &
+                ivar,xtz0,yty0,abs(two*(xtz0-yty0)/(abs(xtz0)+abs(yty0)))
+               if(abs(xtz0)+abs(yty0) /= zero) errmax=max(abs(two*(xtz0-yty0)/(abs(xtz0)+abs(yty0))),errmax)
+ 
+     end do
+     if(mype == 0) write(6,'(" max error for fmg_strong_bal_correction_ad=",e10.3)') errmax
+        if(mype >  -1000) then
+              call mpi_finalize(ierror)
+              stop
+        end if
+ 
+ !<><><><<><><><><<<<<<<<<<<<<<<<<<<<<<>>>>>>>>>>>>
+
+end subroutine fmg_strong_bal_correction_ad_test
+
+subroutine zrnmi_filter_uvm_ad_test(mype)
+
+!<><><><<><><><>test of zrnmi_filter_uvm_ad_test><>><<><><<<<<<<<<<<<<<<<>>>>>>>>>>>>>
+
+           use constants, only: zero,two
+           use m_mpimod, only: mpi_rtype,mpi_sum,gsi_mpi_comm_world,ierror
+  use m_kinds, only: r_kind,i_kind
+  use gridmod, only: lat2,lon2
+  use mod_vtrans, only: nvmodes_keep
+  use zrnmi_mod, only: zrnmi_filter_uvm2,zrnmi_filter_uvm2_ad
+           implicit none
+
+  integer(i_kind),intent(in)::mype
+  real(r_kind),dimension(lat2,lon2,nvmodes_keep)::u1,u2,v1,v2,m1,m2
+           integer(i_kind) ivar,i,j,k
+           real(r_kind) yty,yty0,xtz,xtz0,errmax
+
+     errmax=zero
+     do ivar=1,3
+       u1=zero ; v1=zero ; m1=zero
+       if(ivar == 1) call random_number(u1)
+       if(ivar == 2) call random_number(v1)
+       if(ivar == 3) call random_number(m1)
+       u2=u1 ; v2=v1 ; m2=m1
+       call zrnmi_filter_uvm2(u1,v1,m1,mype)
+       yty=zero
+       do k=1,nvmodes_keep
+         do i=2,lon2-1
+           do j=2,lat2-1
+             yty=yty+u1(j,i,k)**2+v1(j,i,k)**2+m1(j,i,k)**2
+           end do
+         end do
+       end do
+       call mpi_allreduce(yty,yty0,1,mpi_rtype,mpi_sum,gsi_mpi_comm_world,ierror)
+       call zrnmi_filter_uvm2_ad(u1,v1,m1,mype)
+       xtz=zero
+       do k=1,nvmodes_keep
+         do i=2,lon2-1
+           do j=2,lat2-1
+             xtz=xtz+u1(j,i,k)*u2(j,i,k)+v1(j,i,k)*v2(j,i,k)+m1(j,i,k)*m2(j,i,k)
+           end do
+         end do
+       end do
+       call mpi_allreduce(xtz,xtz0,1,mpi_rtype,mpi_sum,gsi_mpi_comm_world,ierror)
+         if(mype == 0) &
+         write(6,'(" zrnmi_filter_uvm2_ad (aT*a), ivar,xx,yy=",i2,2e22.15,e10.3)') &
+                ivar,xtz0,yty0,abs(two*(xtz0-yty0)/(abs(xtz0)+abs(yty0)))
+               if(abs(xtz0)+abs(yty0) /= zero) errmax=max(abs(two*(xtz0-yty0)/(abs(xtz0)+abs(yty0))),errmax)
+ 
+       u1=zero ; v1=zero ; m1=zero
+       if(ivar == 1) call random_number(u1)
+       if(ivar == 2) call random_number(v1)
+       if(ivar == 3) call random_number(m1)
+       u2=u1 ; v2=v1 ; m2=m1
+       call zrnmi_filter_uvm2_ad(u1,v1,m1,mype)
+       yty=zero
+       do k=1,nvmodes_keep
+         do i=2,lon2-1
+           do j=2,lat2-1
+             yty=yty+u1(j,i,k)**2+v1(j,i,k)**2+m1(j,i,k)**2
+           end do
+         end do
+       end do
+       call mpi_allreduce(yty,yty0,1,mpi_rtype,mpi_sum,gsi_mpi_comm_world,ierror)
+       call zrnmi_filter_uvm2(u1,v1,m1,mype)
+       xtz=zero
+       do k=1,nvmodes_keep
+         do i=2,lon2-1
+           do j=2,lat2-1
+             xtz=xtz+u1(j,i,k)*u2(j,i,k)+v1(j,i,k)*v2(j,i,k)+m1(j,i,k)*m2(j,i,k)
+           end do
+         end do
+       end do
+       call mpi_allreduce(xtz,xtz0,1,mpi_rtype,mpi_sum,gsi_mpi_comm_world,ierror)
+         if(mype == 0) &
+         write(6,'(" zrnmi_filter_uvm2_ad (a*aT), ivar,xx,yy=",i2,2e22.15,e10.3)') &
+                ivar,xtz0,yty0,abs(two*(xtz0-yty0)/(abs(xtz0)+abs(yty0)))
+               if(abs(xtz0)+abs(yty0) /= zero) errmax=max(abs(two*(xtz0-yty0)/(abs(xtz0)+abs(yty0))),errmax)
+
+     end do
+     if(mype == 0) write(6,'(" max error for zrnmi_filter_uvm2_ad=",e10.3)') errmax
+        if(mype >  -1000) then
+              call mpi_finalize(ierror)
+              stop
+        end if
+ 
+ !<><><><<><><><><<<<<<<<<<<<<<<<<<<<<<>>>>>>>>>>>>
+
+end subroutine zrnmi_filter_uvm_ad_test
+
+subroutine fmg_wrapper(v,f,helmholtz,nlon,nlat)
+
+  use m_kinds, only: r_kind,i_kind
+  use helmholtz_fmg_mod,only: fmg
+  implicit none
+
+  integer(i_kind),intent(in):: nlon,nlat
+  real(r_kind),intent(in)::    f(0:nlat-1,0:nlon-1)
+  real(r_kind),intent(out)::   v(0:nlat-1,0:nlon-1)
+  logical,intent(in)::         helmholtz
+
+  call fmg(v,f,helmholtz,1,1,60,nlon-1,nlat-1)
+
+end subroutine fmg_wrapper
+
+subroutine fmg_wrapper_e(v,f,helmholtz,nlon,nlat)
+
+  use m_kinds, only: r_kind,i_kind
+  use constants, only: zero
+  use helmholtz_fmg_mod,only: fmg
+  implicit none
+
+  integer(i_kind),intent(in):: nlon,nlat
+  real(r_kind),intent(in)::    f(nlat,nlon)
+  real(r_kind),intent(out)::   v(nlat,nlon)
+  logical,intent(in)::         helmholtz
+
+  real(r_kind),dimension(0:nlat+1,0:nlon+1)::fe,ve
+  integer(i_kind) i,j
+
+  fe=zero
+  do j=1,nlon
+    do i=1,nlat
+      fe(i,j)=f(i,j)
+    end do
+  end do
+  call fmg(ve,fe,helmholtz,1,1,60,nlon+1,nlat+1)
+  do j=1,nlon
+    do i=1,nlat
+      v(i,j)=ve(i,j)
+    end do
+  end do
+
+end subroutine fmg_wrapper_e
+
+subroutine fmg_wrapper_e_ad(v,f,helmholtz,nlon,nlat)
+
+  use m_kinds, only: r_kind,i_kind
+  use constants, only: zero
+  use helmholtz_fmg_mod,only: fmg_ad
+  implicit none
+
+  integer(i_kind),intent(in):: nlon,nlat
+  real(r_kind),intent(inout)::    f(nlat,nlon)
+  real(r_kind),intent(in)::   v(nlat,nlon)
+  logical,intent(in)::         helmholtz
+
+  real(r_kind),dimension(0:nlat+1,0:nlon+1)::fe,ve
+  integer(i_kind) i,j
+
+  ve=zero
+  do j=1,nlon
+    do i=1,nlat
+      ve(i,j)=v(i,j)
+      fe(i,j)=f(i,j)
+    end do
+  end do
+  call fmg_ad(ve,fe,helmholtz,1,1,60,nlon+1,nlat+1)
+  do j=1,nlon
+    do i=1,nlat
+      f(i,j)=fe(i,j)
+    end do
+  end do
+
+end subroutine fmg_wrapper_e_ad
+
+subroutine get_delsqr_reg(work1,work2)
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    get_delsqr_reg compute laplacian  
+!   prgmmr: parrish          org: np23               date:  2006-02-13
+!
+! abstract:  compute laplacian
+!
+! program history log:
+!   2006-02-13  parrish
+!
+!   input argument list:
+!     work1  - array to be differentiated
+!
+!   output argument list:
+!     work2  - array containing laplacian
+!
+! attributes:
+!   language: f90
+!   machine:  ibm rs/6000 sp
+!$$$
+
+  use m_kinds, only: r_kind,i_kind
+  use gridmod, only: nlat,nlon
+  implicit none
+  
+  integer(i_kind) i,j
+  real(r_kind),dimension(nlat,nlon):: work1,work2
+  real(r_kind),dimension(nlat,nlon):: grid1,grid2,grid3,grid4
+
+  call delx_reg(work1,grid1,(.false.))
+  call delx_reg(grid1,grid2,(.true.))
+  call dely_reg(work1,grid3,(.false.))
+  call dely_reg(grid3,grid4,(.true.))
+
+  do j=1,nlon
+    do i=1,nlat
+      work2(i,j)=grid2(i,j)+grid4(i,j)
+    end do
+  end do
+  
+  return
+end subroutine get_delsqr_reg
+
+subroutine tget_delsqr_reg(work2,work1)
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    tget_delsqr_reg             adjoint of get_delsqr_reg
+!   prgmmr: parrish          org: np23               date:  2006-02-13
+!
+! abstract:  adjoint of get_delsqr_reg
+!
+! program history log:
+!   2006-02-13  parrish
+!
+!   input argument list:
+!     work2  - array containing delsqr variable
+!     work1  - previous contents to be accumulated to
+!
+!   output argument list:
+!     work1  - array containing accumulation of adjoint delsqr
+!
+! attributes:
+!   language: f90
+!   machine:  ibm rs/6000 sp
+!$$$
+  use m_kinds, only: r_kind,i_kind
+  use gridmod, only: nlat,nlon
+  use constants, only: zero
+  implicit none
+
+  integer(i_kind) i,j
+  real(r_kind),dimension(nlat,nlon):: work1,work2
+  real(r_kind),dimension(nlat,nlon):: grid1,grid2,grid3,grid4
+
+  do j=1,nlon
+    do i=1,nlat
+      grid2(i,j)=zero
+      grid4(i,j)=zero
+      grid1(i,j)=zero
+      grid3(i,j)=zero
+    end do
+  end do
+  do j=1,nlon
+    do i=1,nlat
+      grid2(i,j)=grid2(i,j)+work2(i,j)
+      grid4(i,j)=grid4(i,j)+work2(i,j)
+    end do
+  end do
+  call tdely_reg(grid4,grid3,(.true.))
+  call tdely_reg(grid3,work1,(.false.))
+  call tdelx_reg(grid2,grid1,(.true.))
+  call tdelx_reg(grid1,work1,(.false.))
+  
+  return
+end subroutine tget_delsqr_reg
+
+subroutine outgrad1(f,label,nx,ny)
+
+         character(*) label
+         integer(4) nx,ny
+         real(8) f(ny,nx)
+
+         character(80) dsdes,dsdat
+         character(80) datdes(1000)
+         character(1) blank
+         integer np,ioutcor,ioutdat,ntime
+         integer i,j,k,next,last,koutmax
+         real(4) out(nx,ny)
+         real(4) undef,rlonmap0,rlatmap0,dlonmap,dlatmap
+         real(4) startp,pinc
+         data blank/' '/
+         data undef/-9.99e33/
+
+
+         np=1
+         ioutcor=10
+         ioutdat=11
+
+         write(dsdes,'(a,".des")')trim(label)
+         write(dsdat,'(a,".dat")')trim(label)
+         open(unit=ioutcor,file=dsdes,form='formatted')
+         open(unit=ioutdat,file=dsdat,form='unformatted')
+         ntime=1
+         rlonmap0=1.
+         dlonmap=1.
+         rlatmap0=1.
+         dlatmap=1.
+         startp=1.
+         pinc=1.
+         koutmax=1
+         do i=1,1000
+          write(datdes(i),'(80a1)')(blank,k=1,80)
+         end do
+         write(datdes(1),'("DSET ",a)')trim(dsdat)
+         write(datdes(2),'("options big_endian sequential")')
+         write(datdes(3),'("TITLE ",a)')trim(label)
+         write(datdes(4),'("UNDEF ",e11.2)')undef
+         write(datdes(5),'("XDEF ",i5," LINEAR ",f7.2,f7.2)')nx,rlonmap0,dlonmap
+         write(datdes(6),'("YDEF ",i5," LINEAR ",f7.2,f7.2)')ny,rlatmap0,dlatmap
+         next=7
+         write(datdes(next),'("ZDEF ",i5," LINEAR ",f7.2,f7.2)')np,startp,pinc
+         next=next+1
+         write(datdes(next),'("TDEF ",i5," LINEAR 0Z23may1992 24hr")')koutmax
+         next=next+1
+         write(datdes(next),'("VARS 1")')
+         next=next+1
+         write(datdes(next),'("f   ",i5," 99 f   ")')np
+         next=next+1
+         write(datdes(next),'("ENDVARS")')
+         last=next
+         write(ioutcor,'(a80)')(datdes(i),i=1,last)
+         close(ioutcor)
+
+         do i=1,nx
+           do j=1,ny
+             out(i,j)=f(j,i)
+           end do
+         end do
+         write(ioutdat)((out(i,j),i=1,nx),j=1,ny)
+         close(ioutdat)
+
+return
+end subroutine outgrad1
+
+subroutine special_for_llfmg_sub2grid3(a1,a2,a3,b1,b2,b3,f1,f2,f3,mype)
+
+  use m_kinds, only: i_kind,r_kind
+  use m_mpimod, only: npe
+  use gridmod, only: lat1,lon1,lat2,lon2,nlat,nlon,itotsub,iglobal
+  use general_commvars_mod, only: ltosi,ltosj
+  use mod_vtrans, only: nvmodes_keep
+  implicit none
+
+  integer(i_kind),intent(in):: mype
+  real(r_kind),dimension(lat2,lon2,nvmodes_keep),intent(in)::a1,a2,a3,b1,b2,b3
+  real(r_kind),dimension(nlat,nlon),intent(out):: f1,f2,f3
+
+  real(r_kind) all_loc(lat1,lon1,3,2*nvmodes_keep),tempa(itotsub,3)
+  integer(i_kind) i,ip1,j,jp1,k,ka,kb
+  integer(i_kind) kbegin(0:npe-1),kend(0:npe-1),numlevs(0:npe-1)
+
+  do k=1,nvmodes_keep
+    ka=k
+    kb=ka+nvmodes_keep
+    do i=1,lon1
+      ip1=i+1
+      do j=1,lat1
+        jp1=j+1
+        all_loc(j,i,1,ka)=a1(jp1,ip1,k)
+        all_loc(j,i,2,ka)=a2(jp1,ip1,k)
+        all_loc(j,i,3,ka)=a3(jp1,ip1,k)
+        all_loc(j,i,1,kb)=b1(jp1,ip1,k)
+        all_loc(j,i,2,kb)=b2(jp1,ip1,k)
+        all_loc(j,i,3,kb)=b3(jp1,ip1,k)
+      end do
+    end do
+  end do
+
+  do k=0,2*nvmodes_keep-1
+    numlevs(k)=3
+  end do
+  do k=2*nvmodes_keep,npe-1
+    numlevs(k)=0
+  end do
+  kbegin(0)=1
+  do k=1,npe-1
+    kbegin(k)=kbegin(k-1)+numlevs(k-1)
+  end do
+  do k=0,npe-1
+    kend(k)=kbegin(k)+numlevs(k)-1
+  end do
+
+  call generic_sub2grid8(all_loc,tempa,kbegin(mype),kend(mype),kbegin,kend,mype,6*nvmodes_keep)
+  do k=1,kend(mype)-kbegin(mype)+1
+    if(k == 1) then
+      do i=1,iglobal
+        f1(ltosi(i),ltosj(i))=tempa(i,k)
+      end do
+    elseif(k == 2) then
+      do i=1,iglobal
+        f2(ltosi(i),ltosj(i))=tempa(i,k)
+      end do
+    elseif(k == 3) then
+      do i=1,iglobal
+        f3(ltosi(i),ltosj(i))=tempa(i,k)
+      end do
+    end if
+  end do
+
+end subroutine special_for_llfmg_sub2grid3
+
+subroutine special_for_llfmg_sub2grid2(a1,a2,b1,b2,f1,f2,mype)
+
+  use m_kinds, only: i_kind,r_kind
+  use m_mpimod, only: npe
+  use gridmod, only: lat1,lon1,lat2,lon2,nlat,nlon,itotsub,iglobal
+  use general_commvars_mod, only: ltosi,ltosj
+  use mod_vtrans, only: nvmodes_keep
+  implicit none
+
+  integer(i_kind),intent(in):: mype
+  real(r_kind),dimension(lat2,lon2,nvmodes_keep),intent(in)::a1,a2,b1,b2
+  real(r_kind),dimension(nlat,nlon),intent(out):: f1,f2
+
+  real(r_kind) all_loc(lat1,lon1,2,2*nvmodes_keep),tempa(itotsub,2)
+  integer(i_kind) i,ip1,j,jp1,k,ka,kb
+  integer(i_kind) kbegin(0:npe-1),kend(0:npe-1),numlevs(0:npe-1)
+
+  do k=1,nvmodes_keep
+    ka=k
+    kb=ka+nvmodes_keep
+    do i=1,lon1
+      ip1=i+1
+      do j=1,lat1
+        jp1=j+1
+        all_loc(j,i,1,ka)=a1(jp1,ip1,k)
+        all_loc(j,i,2,ka)=a2(jp1,ip1,k)
+        all_loc(j,i,1,kb)=b1(jp1,ip1,k)
+        all_loc(j,i,2,kb)=b2(jp1,ip1,k)
+      end do
+    end do
+  end do
+
+  do k=0,2*nvmodes_keep-1
+    numlevs(k)=2
+  end do
+  do k=2*nvmodes_keep,npe-1
+    numlevs(k)=0
+  end do
+  kbegin(0)=1
+  do k=1,npe-1
+    kbegin(k)=kbegin(k-1)+numlevs(k-1)
+  end do
+  do k=0,npe-1
+    kend(k)=kbegin(k)+numlevs(k)-1
+  end do
+
+  call generic_sub2grid8(all_loc,tempa,kbegin(mype),kend(mype),kbegin,kend,mype,4*nvmodes_keep)
+  do k=1,kend(mype)-kbegin(mype)+1
+    if(k == 1) then
+      do i=1,iglobal
+        f1(ltosi(i),ltosj(i))=tempa(i,k)
+      end do
+    elseif(k == 2) then
+      do i=1,iglobal
+        f2(ltosi(i),ltosj(i))=tempa(i,k)
+      end do
+    end if
+  end do
+
+end subroutine special_for_llfmg_sub2grid2
+
+subroutine special_for_llfmg_grid2sub2(f1,f2,a1,a2,b1,b2,mype)
+
+  use m_kinds, only: i_kind,r_kind
+  use m_mpimod, only: npe
+  use gridmod, only: lat2,lon2,nlat,nlon,itotsub
+  use general_commvars_mod, only: ltosi_s,ltosj_s
+  use mod_vtrans, only: nvmodes_keep
+  implicit none
+
+  integer(i_kind),intent(in):: mype
+  real(r_kind),dimension(nlat,nlon),intent(in):: f1,f2
+  real(r_kind),dimension(lat2,lon2,nvmodes_keep),intent(out)::a1,a2,b1,b2
+
+  real(r_kind) all_loc(lat2,lon2,2,2*nvmodes_keep),tempa(itotsub,2)
+  integer(i_kind) i,j,k,ka,kb
+  integer(i_kind) kbegin(0:npe-1),kend(0:npe-1),numlevs(0:npe-1)
+
+  do k=0,2*nvmodes_keep-1
+    numlevs(k)=2
+  end do
+  do k=2*nvmodes_keep,npe-1
+    numlevs(k)=0
+  end do
+  kbegin(0)=1
+  do k=1,npe-1
+    kbegin(k)=kbegin(k-1)+numlevs(k-1)
+  end do
+  do k=0,npe-1
+    kend(k)=kbegin(k)+numlevs(k)-1
+  end do
+
+  do k=1,kend(mype)-kbegin(mype)+1
+    if(k == 1) then
+      do i=1,itotsub
+        tempa(i,k)=f1(ltosi_s(i),ltosj_s(i))
+      end do
+    elseif(k == 2) then
+      do i=1,itotsub
+        tempa(i,k)=f2(ltosi_s(i),ltosj_s(i))
+      end do
+    end if
+  end do
+
+  call generic_grid2sub8(tempa,all_loc,kbegin(mype),kend(mype),kbegin,kend,mype,4*nvmodes_keep)
+
+  do k=1,nvmodes_keep
+    ka=k
+    kb=ka+nvmodes_keep
+    do i=1,lon2
+      do j=1,lat2
+        a1(j,i,k)=all_loc(j,i,1,ka)
+        a2(j,i,k)=all_loc(j,i,2,ka)
+        b1(j,i,k)=all_loc(j,i,1,kb)
+        b2(j,i,k)=all_loc(j,i,2,kb)
+      end do
+    end do
+  end do
+
+end subroutine special_for_llfmg_grid2sub2
+
+subroutine special_for_llfmg_grid2sub3(f1,f2,f3,a1,a2,a3,b1,b2,b3,mype)
+
+  use m_kinds, only: i_kind,r_kind
+  use m_mpimod, only: npe
+  use gridmod, only: lat2,lon2,nlat,nlon,itotsub
+  use general_commvars_mod, only: ltosi_s,ltosj_s
+  use mod_vtrans, only: nvmodes_keep
+  implicit none
+
+  integer(i_kind),intent(in):: mype
+  real(r_kind),dimension(nlat,nlon),intent(in):: f1,f2,f3
+  real(r_kind),dimension(lat2,lon2,nvmodes_keep),intent(out)::a1,a2,a3,b1,b2,b3
+
+  real(r_kind) all_loc(lat2,lon2,3,2*nvmodes_keep),tempa(itotsub,3)
+  integer(i_kind) i,j,k,ka,kb
+  integer(i_kind) kbegin(0:npe-1),kend(0:npe-1),numlevs(0:npe-1)
+
+  do k=0,2*nvmodes_keep-1
+    numlevs(k)=3
+  end do
+  do k=2*nvmodes_keep,npe-1
+    numlevs(k)=0
+  end do
+  kbegin(0)=1
+  do k=1,npe-1
+    kbegin(k)=kbegin(k-1)+numlevs(k-1)
+  end do
+  do k=0,npe-1
+    kend(k)=kbegin(k)+numlevs(k)-1
+  end do
+
+  do k=1,kend(mype)-kbegin(mype)+1
+    if(k == 1) then
+      do i=1,itotsub
+        tempa(i,k)=f1(ltosi_s(i),ltosj_s(i))
+      end do
+    elseif(k == 2) then
+      do i=1,itotsub
+        tempa(i,k)=f2(ltosi_s(i),ltosj_s(i))
+      end do
+    elseif(k == 3) then
+      do i=1,itotsub
+        tempa(i,k)=f3(ltosi_s(i),ltosj_s(i))
+      end do
+    end if
+  end do
+
+  call generic_grid2sub8(tempa,all_loc,kbegin(mype),kend(mype),kbegin,kend,mype,6*nvmodes_keep)
+
+  do k=1,nvmodes_keep
+    ka=k
+    kb=ka+nvmodes_keep
+    do i=1,lon2
+      do j=1,lat2
+        a1(j,i,k)=all_loc(j,i,1,ka)
+        a2(j,i,k)=all_loc(j,i,2,ka)
+        a3(j,i,k)=all_loc(j,i,3,ka)
+        b1(j,i,k)=all_loc(j,i,1,kb)
+        b2(j,i,k)=all_loc(j,i,2,kb)
+        b3(j,i,k)=all_loc(j,i,3,kb)
+      end do
+    end do
+  end do
+
+end subroutine special_for_llfmg_grid2sub3
+
+subroutine generic_sub2grid8(all_loc,tempa,kbegin_loc,kend_loc,kbegin,kend,mype,num_fields)
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    generic_sub2grid   converts from subdomains to full horizontal grid
+!   prgmmr: parrish          org: np22                date: 2004-11-29
+!
+! abstract: variation on subroutine sub2grid, with more general distribution of variables
+!              along the k index.
+!
+! program history log:
+!   2004-02-03  kleist, new mpi strategy
+!   2004-05-06  derber
+!   2004-07-15  treadon - handle periodic subdomains
+!   2004-07-28  treadon - add only on use declarations; add intent in/out
+!   2004-10-26  kleist - u,v removed; periodicity accounted for only in
+!               sub2grid routine if necessary
+!   2004-11-29  parrish - adapt sub2grid for related use with mpi io.
+!
+!   input argument list:
+!     all_loc  - input grid values in vertical subdomain mode
+!     kbegin_loc - starting k index for tempa on local processor
+!     kend_loc   - ending k index for tempa on local processor
+!     kbegin     - starting k indices for tempa for all processors
+!     kend       - ending k indices for tempa for all processors
+!     mype       - local processor number
+!     num_fields - total range of k index (1 <= k <= num_fields)
+!
+!   output argument list:
+!     tempa    - output grid values in horizontal slab mode.
+!
+! attributes:
+!   language: f90
+!   machine:  ibm RS/6000 SP
+!
+!$$$
+
+  use m_mpimod, only: ierror,gsi_mpi_comm_world,mpi_rtype,npe
+  use gridmod, only: ijn,itotsub,lat1,lon1
+  use m_kinds, only: r_kind,i_kind
+  use constants, only: zero
+  implicit none
+
+  integer(i_kind) kbegin_loc,kend_loc,mype,num_fields
+  integer(i_kind) kbegin(0:npe),kend(0:npe-1)
+  real(r_kind) tempa(itotsub,kbegin_loc:max(kbegin_loc,kend_loc))
+  real(r_kind) all_loc(lat1*lon1*num_fields)
+
+  integer(i_kind) k
+  integer(i_kind) sendcounts(0:npe-1),sdispls(0:npe),recvcounts(0:npe-1),rdispls(0:npe)
+
+! first get alltoallv indices
+
+  sdispls(0)=0
+  do k=0,npe-1
+   sendcounts(k)=ijn(k+1)*(kend_loc-kbegin_loc+1)
+   sdispls(k+1)=sdispls(k)+sendcounts(k)
+  end do
+  rdispls(0)=0
+  do k=0,npe-1
+   recvcounts(k)=ijn(mype+1)*(kend(k)-kbegin(k)+1)
+   rdispls(k+1)=rdispls(k)+recvcounts(k)
+  end do
+
+  call mpi_alltoallv(all_loc,recvcounts,rdispls,mpi_rtype, &
+                tempa,sendcounts,sdispls,mpi_rtype,gsi_mpi_comm_world,ierror)
+
+  if(kbegin_loc <= kend_loc) then
+    call reorder_s8(tempa,kend_loc-kbegin_loc+1)
+  else
+    tempa=zero
+  end if
+
+end subroutine generic_sub2grid8
+
+  subroutine reorder_s8(work,k_in)
+
+! !USES:
+
+    use m_mpimod, only: npe
+    use m_kinds, only: r_kind,i_kind
+    use constants, only: zero
+    use gridmod, only: ijn,itotsub
+    implicit none
+
+! !INPUT PARAMETERS:
+
+   integer(i_kind), intent(in) ::  k_in    ! number of levs in work array
+
+! !INPUT/OUTPUT PARAMETERS:
+
+    real(r_kind),dimension(itotsub*k_in),intent(inout):: work ! array to reorder
+
+! !OUTPUT PARAMETERS:
+
+! !DESCRIPTION: adapt reorder to work with single precision
+!
+! !REVISION HISTORY:
+!
+!   2004-01-25  kleist
+!   2004-05-14  kleist, documentation
+!   2004-07-15  todling, protex-complaint prologue
+!   2004-11-29  adapt reorder to work with single precision
+!
+! !REMAKRS:
+!
+!   language: f90
+!   machine:  ibm rs/6000 sp; sgi origin 2000; compaq/hp
+!
+! !AUTHOR:
+!    kleist           org: np20                date: 2004-01-25
+!
+!EOP
+!-------------------------------------------------------------------------
+
+    integer(i_kind) iloc,iskip,i,k,n
+    real(r_kind),dimension(itotsub,k_in):: temp
+
+! Zero out temp array
+    do k=1,k_in
+       do i=1,itotsub
+          temp(i,k)=zero
+       end do
+    end do
+
+! Load temp array in desired order
+    do k=1,k_in
+      iskip=0
+      iloc=0
+      do n=1,npe
+        if (n/=1) then
+          iskip=iskip+ijn(n-1)*k_in
+        end if
+        do i=1,ijn(n)
+          iloc=iloc+1
+          temp(iloc,k)=work(i + iskip + &
+                   (k-1)*ijn(n))
+        end do
+      end do
+    end do
+
+! Load the temp array back into work
+    iloc=0
+    do k=1,k_in
+      do i=1,itotsub
+        iloc=iloc+1
+        work(iloc)=temp(i,k)
+      end do
+    end do
+
+    return
+  end subroutine reorder_s8
+
+subroutine generic_grid2sub8(tempa,all_loc,kbegin_loc,kend_loc,kbegin,kend,mype,num_fields)
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    generic_grid2sub   converts from full horizontal grid to subdomains
+!   prgmmr: parrish          org: np22                date: 2004-11-29
+!
+! abstract: variation on subroutine grid2sub, with more general distribution of variables
+!              along the k index.
+!
+! program history log:
+!   2004-02-03  kleist, new mpi strategy
+!   2004-05-06  derber
+!   2004-07-15  treadon - handle periodic subdomains
+!   2004-07-28  treadon - add only on use declarations; add intent in/out
+!   2004-10-26  kleist - u,v removed; periodicity accounted for only in
+!               sub2grid routine if necessary
+!   2004-11-29  parrish - adapt grid2sub for related use with mpi io.
+!
+!   input argument list:
+!     tempa    - input grid values in horizontal slab mode.
+!     kbegin_loc - starting k index for tempa on local processor
+!     kend_loc   - ending k index for tempa on local processor
+!     kbegin     - starting k indices for tempa for all processors
+!     kend       - ending k indices for tempa for all processors
+!     mype       - local processor number
+!     num_fields - total range of k index (1 <= k <= num_fields)
+!
+!   output argument list:
+!     all_loc  - output grid values in vertical subdomain mode
+!
+! attributes:
+!   language: f90
+!   machine:  ibm RS/6000 SP
+!
+!$$$
+
+  use m_mpimod, only: ierror,gsi_mpi_comm_world,mpi_rtype,npe
+  use gridmod, only: ijn_s,itotsub,lat2,lon2
+  use m_kinds, only: r_kind,i_kind
+  use constants, only: zero
+  implicit none
+  
+  integer(i_kind) kbegin_loc,kend_loc,mype,num_fields
+  integer(i_kind) kbegin(0:npe),kend(0:npe-1)
+  real(r_kind) tempa(itotsub,kbegin_loc:max(kbegin_loc,kend_loc))
+  real(r_kind) all_loc(lat2*lon2*num_fields)
+  
+  integer(i_kind) k
+  integer(i_kind) sendcounts(0:npe-1),sdispls(0:npe),recvcounts(0:npe-1),rdispls(0:npe)
+
+! first get alltoallv indices
+  
+  sdispls(0)=0
+  do k=0,npe-1
+     sendcounts(k)=ijn_s(k+1)*(kend_loc-kbegin_loc+1) 
+     sdispls(k+1)=sdispls(k)+sendcounts(k)
+  end do
+  rdispls(0)=0
+  do k=0,npe-1
+     recvcounts(k)=ijn_s(mype+1)*(kend(k)-kbegin(k)+1)
+     rdispls(k+1)=rdispls(k)+recvcounts(k)
+  end do
+  
+! then call reorder2
+
+  if(kbegin_loc <= kend_loc) then
+    call reorder2_s8(tempa,kend_loc-kbegin_loc+1)
+  else
+    tempa=zero
+  end if
+
+! then alltoallv and i think we are done??
+
+  call mpi_alltoallv(tempa,sendcounts,sdispls,mpi_rtype, &
+       all_loc,recvcounts,rdispls,mpi_rtype,gsi_mpi_comm_world,ierror)
+
+end subroutine generic_grid2sub8
+
+subroutine reorder2_s8(work,k_in)
+
+! !USES:
+
+  use constants, only: zero
+  use m_mpimod, only: npe
+  use gridmod, only: ijn_s,itotsub
+  use m_kinds, only: r_kind,i_kind
+  implicit none
+  
+
+! !INPUT PARAMETERS:
+
+  integer(i_kind), intent(in) ::  k_in    ! number of levs in work array
+
+! !INPUT/OUTPUT PARAMETERS:
+
+  real(r_kind),dimension(itotsub,k_in),intent(inout):: work
+
+! !OUTPUT PARAMETERS:
+
+! !DESCRIPTION: adapt reorder2 to single precision
+!
+! !REVISION HISTORY:
+!
+!   2004-01-25  kleist
+!   2004-05-14  kleist, documentation
+!   2004-07-15  todling, protex-complaint prologue
+!   2004-11-29  parrish, adapt reorder2 to single precision
+!
+! !REMARKS:
+!   language: f90
+!   machine:  ibm rs/6000 sp; sgi origin 2000; compaq/hp
+!
+! !AUTHOR:
+!    kleist           org: np20                date: 2004-01-25
+!
+!EOP
+!-------------------------------------------------------------------------
+
+  integer(i_kind) iloc,iskip,i,k,n
+  real(r_kind),dimension(itotsub*k_in):: temp
+
+! Zero out temp array
+  do k=1,itotsub*k_in
+     temp(k)=zero
+  end do
+  
+! Load temp array in order of subdomains
+  iloc=0
+  iskip=0
+  do n=1,npe
+     if (n/=1) then
+        iskip=iskip+ijn_s(n-1)
+     end if
+     
+     do k=1,k_in
+        do i=1,ijn_s(n)
+           iloc=iloc+1
+           temp(iloc)=work(iskip+i,k)
+        end do
+     end do
+  end do
+
+! Now load the tmp array back into work
+  iloc=0
+  do k=1,k_in
+     do i=1,itotsub
+        iloc=iloc+1
+        work(i,k)=temp(iloc)
+     end do
+  end do
+  
+  return
+end subroutine reorder2_s8
+
+subroutine get_div_reg(u,v,div)
+
+  use m_kinds, only: r_kind,i_kind
+  use gridmod, only: nlat,nlon
+  implicit none
+
+  real(r_kind),dimension(nlat,nlon),intent(in):: u,v
+  real(r_kind),dimension(nlat,nlon),intent(out)::div
+
+  integer(i_kind) i,j
+  real(r_kind),dimension(nlat,nlon)::ux,vy
+
+  call delx_reg(u,ux,.true.)
+  call dely_reg(v,vy,.true.)
+
+  do j=1,nlon
+    do i=1,nlat
+      div(i,j)=ux(i,j)+vy(i,j)
+    end do
+  end do
+
+end subroutine get_div_reg
+
+subroutine get_div_reg_ad(u,v,div)
+
+  use m_kinds, only: r_kind,i_kind
+  use gridmod, only: nlat,nlon
+  use constants, only: zero
+  implicit none
+
+  real(r_kind),dimension(nlat,nlon),intent(out):: u,v
+  real(r_kind),dimension(nlat,nlon),intent(in)::div
+
+  integer(i_kind) i,j
+  real(r_kind),dimension(nlat,nlon)::ux,vy
+
+  do j=1,nlon
+    do i=1,nlat
+      ux(i,j)=div(i,j)
+      vy(i,j)=div(i,j)
+    end do
+  end do
+
+  u=zero ; v=zero
+  call tdelx_reg(ux,u,.true.)
+  call tdely_reg(vy,v,.true.)
+
+end subroutine get_div_reg_ad
+
+subroutine get_vor_reg(u,v,vor)
+
+  use m_kinds, only: r_kind,i_kind
+  use gridmod, only: nlat,nlon
+  implicit none
+
+  real(r_kind),dimension(nlat,nlon),intent(in):: u,v
+  real(r_kind),dimension(nlat,nlon),intent(out)::vor
+
+  integer(i_kind) i,j
+  real(r_kind),dimension(nlat,nlon)::uy,vx
+
+  call delx_reg(v,vx,.true.)
+  call dely_reg(u,uy,.true.)
+
+  do j=1,nlon
+    do i=1,nlat
+      vor(i,j)=vx(i,j)-uy(i,j)
+    end do
+  end do
+
+end subroutine get_vor_reg
+
+subroutine get_vor_reg_ad(u,v,vor)
+
+  use m_kinds, only: r_kind,i_kind
+  use gridmod, only: nlat,nlon
+  use constants, only: zero
+  implicit none
+
+  real(r_kind),dimension(nlat,nlon),intent(out):: u,v
+  real(r_kind),dimension(nlat,nlon),intent(in)::vor
+
+  integer(i_kind) i,j
+  real(r_kind),dimension(nlat,nlon)::uy,vx
+
+
+  do j=1,nlon
+    do i=1,nlat
+      vx(i,j)=vor(i,j)
+      uy(i,j)=-vor(i,j)
+    end do
+  end do
+  u=zero ; v=zero
+  call tdelx_reg(vx,v,.true.)
+  call tdely_reg(uy,u,.true.)
+
+end subroutine get_vor_reg_ad

--- a/src/gsibec/gsi/strong_bal_correction.f90
+++ b/src/gsibec/gsi/strong_bal_correction.f90
@@ -1,0 +1,198 @@
+subroutine strong_bal_correction(u_t,v_t,t_t,ps_t,mype,psi,chi,t,ps,bal_diagnostic,fullfield,update,uvflag)
+
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    strong_bal_correction  strong balance correction
+!   prgmmr: parrish          org: np23                date: 2007-02-15
+!
+! abstract: given input perturbation tendencies of u,v,t,ps from TLM,
+!           and input perturbation u,v,t,ps, compute balance adjustment to u,v,t,ps
+!           which zeroes out input gravity component of perturbation tendencies.
+!           also output, for later use, input tendencies projected onto gravity modes.
+!           this is higher level routine, which calls more specific routines, based
+!           on the value of parameters regional and reg_tlnmc_type, passed through module mod_strong
+!
+!           If .not. regional then call global application
+!           If regional, then
+!               reg_tlnmc_type = 1 for 1st version of regional application
+!                              = 2 for 2nd version of regional application
+!           
+!
+! program history log:
+!   2007-02-15  parrish
+!   2008-08-10  derber - update to output correction to psi and chi for global
+!   2012-02-08  kleist - add uvflag to argument list
+!   2013-07-02  parrish - changes to eliminate tlnmc_type for global tlnmc and
+!                          add new variable reg_tlnmc_type for two versions of
+!                          regional tlnmc.
+!
+!   input argument list:
+!     u_t      - input perturbation u tendency (subdomains)
+!     v_t      - input perturbation v tendency (subdomains)
+!     t_t      - input perturbation T tendency (subdomains)
+!     ps_t     - input perturbation surface pressure tendency (subdomains)
+!     mype     - current processor
+!     psi
+!     chi
+!     t        - input perturbation T (subdomains)
+!     ps       - input perturbation surface pressure (subdomains)
+!     bal_diagnostic - if true, then compute BAL diagnostic, a measure of amplitude
+!                      of balanced gravity mode tendencies
+!     fullfield - if true, the BAL diagnostics are full field, if false, they are 
+!                 incremental.
+!     update   - if false, then do not update u,v,t,ps with balance increment
+!
+!   output argument list:
+!     u_t      - output perturbation u tendency (subdomains)
+!     v_t      - output perturbation v tendency (subdomains)
+!     t_t      - output perturbation T tendency (subdomains)
+!     ps_t     - output perturbation surface pressure tendency (subdomains)
+!     psi
+!     chi
+!     t        - output balanced perturbation T (subdomains)
+!     ps       - output balanced perturbation surface pressure (subdomains)
+!
+! attributes:
+!   language: f90
+!   machine:  ibm RS/6000 SP
+!
+!$$$
+
+  use m_kinds, only: r_kind,i_kind
+  use mod_strong, only: reg_tlnmc_type
+  use zrnmi_mod, only: zrnmi_strong_bal_correction
+  use strong_fast_global_mod, only: strong_bal_correction_fast_global
+  use gridmod, only: lat2,lon2,nsig,regional
+  implicit none
+
+  integer(i_kind)                       ,intent(in   ) :: mype
+  logical                               ,intent(in   ) :: bal_diagnostic,update,fullfield,uvflag
+  real(r_kind),dimension(lat2,lon2,nsig),intent(inout) :: u_t,v_t,t_t
+  real(r_kind),dimension(lat2,lon2)     ,intent(inout) :: ps_t
+  real(r_kind),dimension(lat2,lon2,nsig),intent(inout) :: psi,chi,t
+  real(r_kind),dimension(lat2,lon2)     ,intent(inout) :: ps
+
+  if(.not.regional) then
+
+!    global option:
+
+     call strong_bal_correction_fast_global(u_t,v_t,t_t,ps_t,mype,psi,chi,t,ps,bal_diagnostic,fullfield,update,uvflag)
+
+  else
+
+     if(reg_tlnmc_type==1) then
+
+!       regional option 1:
+
+        call zrnmi_strong_bal_correction(u_t,v_t,t_t,ps_t,psi,chi,t,ps,bal_diagnostic,fullfield,update,mype)
+
+     elseif(reg_tlnmc_type==2) then
+
+!       regional option 2:
+
+        !call fmg_strong_bal_correction_ad_test(u_t,v_t,t_t,ps_t,psi,chi,t,ps,mype)
+        !call zrnmi_filter_uvm_ad_test(mype)
+
+        call fmg_strong_bal_correction(u_t,v_t,t_t,ps_t,psi,chi,t,ps,bal_diagnostic,fullfield,update,mype)
+
+     end if
+
+  end if
+
+end subroutine strong_bal_correction
+
+subroutine strong_bal_correction_ad(u_t,v_t,t_t,ps_t,mype,psi,chi,t,ps,uvflag)
+
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    strong_bal_correction_ad  adjoint strong balance correction
+!   prgmmr: parrish          org: np23                date: 2007-02-15
+!
+! abstract: given input perturbation tendencies of u,v,t,ps from TLM,
+!           and input perturbation u,v,t,ps, compute balance adjustment to u,v,t,ps
+!           which zeroes out input gravity component of perturbation tendencies.
+!           also output, for later use, input tendencies projected onto gravity modes.
+!           this is higher level routine, which calls more specific routines, based
+!           on the value of parameters regional and reg_tlnmc_type, passed through module mod_strong
+!
+!           If .not. regional then call global application
+!           If regional, then
+!               reg_tlnmc_type = 1 for 1st version of regional application
+!                              = 2 for 2nd version of regional application
+!           
+!
+! program history log:
+!   2007-02-15  parrish
+!   2008-08-10  derber - update to output correction to psi and chi for global
+!   2012-02-08  kleist - add uvflag to argument list
+!
+!   input argument list:
+!     u_t      - input perturbation u tendency (subdomains)
+!     v_t      - input perturbation v tendency (subdomains)
+!     t_t      - input perturbation T tendency (subdomains)
+!     ps_t     - input perturbation surface pressure tendency (subdomains)
+!     mype     - current processor
+!     psi
+!     chi
+!     t        - input perturbation T (subdomains)
+!     ps       - input perturbation surface pressure (subdomains)
+!
+!   output argument list:
+!     u_t      - output adjusted perturbation u_t (subdomains)
+!     v_t      - output adjusted perturbation v_t (subdomains)
+!     t_t      - output adjusted perturbation T_t (subdomains)
+!     ps_t     - output adjusted perturbation ps_t (subdomains)
+!     psi
+!     chi
+!     t        - output perturbation T (subdomains)
+!     ps       - output perturbation surface pressure (subdomains)
+!
+! attributes:
+!   language: f90
+!   machine:  ibm RS/6000 SP
+!
+!$$$
+
+  use m_kinds, only: r_kind,i_kind
+  use mod_strong, only: reg_tlnmc_type
+  use zrnmi_mod, only: zrnmi_strong_bal_correction_ad
+  use strong_fast_global_mod, only: strong_bal_correction_fast_global_ad
+  use gridmod, only: lat2,lon2,nsig,regional
+  implicit none
+
+  integer(i_kind)                       ,intent(in   ) :: mype
+  real(r_kind),dimension(lat2,lon2,nsig),intent(inout) :: u_t,v_t,t_t
+  real(r_kind),dimension(lat2,lon2)     ,intent(inout) :: ps_t
+  real(r_kind),dimension(lat2,lon2,nsig),intent(inout) :: psi,chi,t
+  real(r_kind),dimension(lat2,lon2)     ,intent(inout) :: ps
+  logical,intent(in):: uvflag
+
+  logical update
+
+  if(.not.regional) then
+
+!    global option:
+
+     call strong_bal_correction_fast_global_ad(u_t,v_t,t_t,ps_t,mype,psi,chi,t,ps,uvflag)
+
+  else
+
+     if(reg_tlnmc_type==1) then
+
+!       regional option 1:
+
+        update=.true.
+        call zrnmi_strong_bal_correction_ad(u_t,v_t,t_t,ps_t,psi,chi,t,ps,update,mype)
+
+     elseif(reg_tlnmc_type==2) then
+
+!       regional option 2:
+
+        update=.true.
+        call fmg_strong_bal_correction_ad(u_t,v_t,t_t,ps_t,psi,chi,t,ps,update,mype)
+     end if
+
+  end if
+
+end subroutine strong_bal_correction_ad
+

--- a/src/gsibec/gsi/strong_baldiag_inc.f90
+++ b/src/gsibec/gsi/strong_baldiag_inc.f90
@@ -1,0 +1,180 @@
+subroutine strong_baldiag_inc(sval,nsval)
+
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    strong_baldiag_inc    get balance diagnostics
+!   prgmmr: parrish          org: np23                date: 2006-08-12
+!
+! abstract: get balance diagnostic statistics of increment
+!
+! program history log:
+!   2006-08-12  parrish
+!   2007-04-16  kleist   - modified to be used for diagnostics only
+!   2007-07-26 cucurull  - call getprs; add xhat3dp and remove ps in calctends_tl argument list
+!   2007-08-08  derber - only calculate dynamics time derivatives
+!   2008-04-09  safford  - rm unused vars and uses
+!   2009-01-17  todling  - per early changes from Tremolet (revisited)
+!   2010-05-13  todling  - udpate to use gsi_bundle
+!                          BUG FIX: was missing deallocate_state call
+!   2011-06-07  guo      - fixed the dimension of argument sval and added nsval
+!   2011-07-03  todling  - avoid explicit reference to internal bundle arrays
+!   2011-11-01  eliu     - add handling for ql and qi increments 
+!   2012-02-08  kleist   - add uvflag=.true. to call to strong_bal_correction
+!   2012-03-11  tong     - modified to take into account the case when cw is not
+!                          a control variable or not included in met_guess
+!   2013-10-19  todling  - guess in metguess now
+!   2013-10-28  todling  - rename p3d to prse
+!   2014-06-05  eliu     - add condition to get pointer for cw tendency  
+!
+!   input argument list:
+!     sval    - current solution in state space
+!
+!   output argument list:
+!     sval
+!
+! attributes:
+!   language: f90
+!   machine:  ibm RS/6000 SP
+!
+!$$$
+  use m_kinds, only: i_kind,r_kind
+  use m_mpimod, only: mype
+  use mod_vtrans,only: nvmodes_keep
+  use state_vectors, only: allocate_state
+  use state_vectors, only: deallocate_state
+  use gsi_bundlemod, only: gsi_bundle
+  use gsi_bundlemod, only: gsi_bundlegetpointer
+  use gsi_bundlemod, only: assignment(=)
+  use gsi_metguess_mod,  only: gsi_metguess_get
+  use constants, only: zero
+  implicit none
+
+! Declare passed variables
+  type(gsi_bundle),intent(inout) :: sval(nsval)
+  integer(i_kind) ,intent(in   ) :: nsval
+
+! Declare local variables
+  character(len=*),parameter::myname='strong_baldiag_inc' 
+  integer(i_kind) ii,ier,iqi,iql,icw,istatus   
+  integer(i_kind) is_u,is_v,is_t,is_q,is_qi,is_ql,is_cw,is_oz,is_p,is_prse
+  real(r_kind),pointer,dimension(:,:,:) :: dhat_dt_u  =>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: dhat_dt_v  =>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: dhat_dt_t  =>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: dhat_dt_q  =>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: dhat_dt_oz =>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: dhat_dt_cw =>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: dhat_dt_ql =>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: dhat_dt_qi =>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: dhat_dt_prse=>NULL()
+!
+  real(r_kind),pointer,dimension(:,:,:) :: p_u  =>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: p_v  =>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: p_q  =>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: p_t  =>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: p_cw =>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: p_ql =>NULL()
+  real(r_kind),pointer,dimension(:,:,:) :: p_qi =>NULL()
+  real(r_kind),pointer,dimension(:,:  ) :: p_ps =>NULL()
+  real(r_kind),allocatable,dimension(:,:,:) :: cw_hold
+  logical fullfield
+  type(gsi_bundle) dhat_dt
+  logical lcld
+
+!************************************************************************************  
+! Initialize variable
+
+! Get relevant pointers; return if not found
+  ier=0;icw=0;iql=0;iqi=0
+  call gsi_bundlegetpointer(sval(1),'u',   is_u,   istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(sval(1),'v',   is_v,   istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(sval(1),'tv',  is_t,   istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(sval(1),'q',   is_q,   istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(sval(1),'oz',  is_oz,  istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(sval(1),'cw',  is_cw,  istatus);icw=istatus+icw           
+  call gsi_bundlegetpointer(sval(1),'ql',  is_ql,  istatus);iql=istatus+iql           
+  call gsi_bundlegetpointer(sval(1),'qi',  is_qi,  istatus);iqi=istatus+iqi           
+  call gsi_bundlegetpointer(sval(1),'ps',  is_p,   istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(sval(1),'prse',is_prse,istatus);ier=istatus+ier
+  if(ier/=0)then
+    write(6,*) myname, 'trouble getting sval pointers, ier= ', ier 
+    call stop2(999)
+  endif
+
+  call allocate_state(dhat_dt) 
+  dhat_dt=zero
+  ier=0;icw=0;iql=0;iqi=0
+  call gsi_bundlegetpointer(dhat_dt,'u',  dhat_dt_u,   istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(dhat_dt,'v',  dhat_dt_v,   istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(dhat_dt,'tv', dhat_dt_t,   istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(dhat_dt,'q',  dhat_dt_q,   istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(dhat_dt,'oz', dhat_dt_oz,  istatus);ier=istatus+ier
+  call gsi_bundlegetpointer(dhat_dt,'cw', dhat_dt_cw, istatus);icw=istatus+icw
+  call gsi_bundlegetpointer(dhat_dt,'ql', dhat_dt_ql, istatus);iql=istatus+iql
+  call gsi_bundlegetpointer(dhat_dt,'qi', dhat_dt_qi, istatus);iqi=istatus+iqi
+  call gsi_bundlegetpointer(dhat_dt,'prse',dhat_dt_prse,istatus);ier=istatus+ier
+
+  if(ier/=0) then
+    write(6,*) myname, ': trouble getting temporary tendency pointers, ier= ', ier           
+    call stop2(999)
+  endif
+
+!     compute derivatives
+! Determine how many vertical levels each mpi task will
+! handle in computing horizontal derivatives
+
+  lcld = (icw==0 .or. (iql+iqi)==0)
+
+  do ii=1,nsval
+!    if(mype==0) write(6,'(1x,a,i0,a)') 'strong_baldiag_inc: sval(',ii,')'
+
+     call gsi_bundlegetpointer(sval(ii),'u',   p_u,  istatus)
+     call gsi_bundlegetpointer(sval(ii),'v',   p_v,  istatus)
+     call gsi_bundlegetpointer(sval(ii),'tv',  p_t,  istatus)
+     call gsi_bundlegetpointer(sval(ii),'q',   p_q,  istatus) 
+!_RT call gsi_bundlegetpointer(sval(ii),'oz',  p_oz, istatus)
+!    call gsi_bundlegetpointer(sval(ii),'cw',  p_cw, istatus)
+     call gsi_bundlegetpointer(sval(ii),'ps',  p_ps, istatus)
+!_RT call gsi_bundlegetpointer(sval(ii),'prse',p_prse,istatus)
+
+     if (lcld) then
+        if (icw==0) then
+!_RT       call gsi_bundlegetpointer(sval(ii),'cw', p_cw, istatus)
+           call calctends_tl(sval(ii),dhat_dt,mype)
+        else
+           call gsi_bundlegetpointer(sval(ii),'qi', p_cw, istatus)
+           call gsi_bundlegetpointer(sval(ii),'ql', p_ql, istatus)
+           call gsi_bundlegetpointer(sval(ii),'qi', p_qi, istatus)
+           allocate(cw_hold(size(p_ql,1),size(p_ql,2),size(p_ql,3)))
+           cw_hold=p_cw
+           p_cw=p_ql+p_qi
+           call calctends_tl(sval(ii),dhat_dt,mype)
+           p_cw=cw_hold
+           deallocate(cw_hold)
+!          call calctends_tl( &
+!            p_u,p_v ,p_t,  &
+!            p_q,p_oz,(p_ql+p_qi), &
+!            mype, nnnn1o,          &
+!            dhat_dt_u,dhat_dt_v ,dhat_dt_t,dhat_dt_prse, &
+!            dhat_dt_q,dhat_dt_oz,dhat_dt_ql,p_prse)    ! eliu: for now, just use
+                                                       ! dhat_dt_ql to hold time tendency terms for cw
+                                                       ! since it is
+                                                       ! calculated but
+                                                       ! not used 
+             !RTodling: Emily we need to talk about ... dhat_dt_ql not used anyway!
+        end if
+     else
+        call calctends_tl(sval(ii),dhat_dt,mype) 
+     end if
+
+     if(nvmodes_keep>0) then
+        fullfield=.false.
+        call strong_bal_correction(dhat_dt_u,dhat_dt_v,dhat_dt_t,dhat_dt_prse,&
+                                   mype,p_u,p_v,&
+                                        p_t,p_ps,&   
+                                   .true.,fullfield,.false.,.true.)
+     end if
+  enddo
+  call deallocate_state(dhat_dt)   
+
+  return
+end subroutine strong_baldiag_inc

--- a/src/gsibec/gsi/strong_fast_global_mod.f90
+++ b/src/gsibec/gsi/strong_fast_global_mod.f90
@@ -1,0 +1,2959 @@
+module strong_fast_global_mod
+!$$$   module documentation block
+!                .      .    .                                       .
+! module:    strong_fast_global_mod
+!
+! abstract: contains all routines for fast strong balance constraint
+!
+
+! program history log:
+!   2008-04-04  safford - add moddule doc block and missing subroutine doc blocks
+!   2012-02-08  kleist  - add uvflag in place of uv_hyb_ens
+!   2012-11-23  parrish - Replace calls to spanaly_ns and spsynth_ns with inline code.
+!                          Remove subroutines spanaly_ns and spsynth_ns.
+!   2013-07-02  parrish - change name of init_strongvars_2 to init_strongvars.
+!
+! subroutines included:
+!    init_strongvars          --
+!    strong_bal_correction_fast_global
+!    strong_bal_correction_fast_global_ad -- adjoint of strong_bal_correction
+!    gather_rmstends0         -- get bal diagnostics
+!    gather_rmstends          -- get bal diagnostics
+!    inmi_coupler_sd2ew0      --
+!    inmi_coupler_sd2ew1      --
+!    inmi_coupler_sd2ew       --
+!    inmi_coupler_ew2sd1      --
+!    inmi_coupler_ew2sd       --
+!    inmi_ew_trans            --
+!    inmi_ew_invtrans_ad      --
+!    inmi_ew_invtrans         --
+!    inmi_ew_trans_ad         --
+!    inmi_coupler_ew2ns0      --
+!    inmi_coupler_ew2ns1      --
+!    inmi_coupler_ew2ns       --
+!    inmi_coupler_ns2ew       --
+!    inmi_nsuvm2zdm           --
+!    spdz2uv_ns               -- compute winds from div and vort for 1 zonal wave number
+!    spuv2dz_ns               -- compute div,vort from winds for one zonal wave number
+!
+! variable definitions:
+!
+! attributes:
+!   language:  f90
+!   machine:   ibm rs/6000 sp
+!$$$ end documentation block
+
+  use m_kinds, only: i_kind,r_kind
+  use gridmod, only: nlat,nlon,lat2,lon2,nsig,sp_a,jstart,istart
+  use gridmod, only: ilat1,jlon1
+  use constants, only: zero,one,two,rearth
+  use m_mpimod, only: ierror,gsi_mpi_comm_world,mpi_integer4,mpi_rtype,mpi_sum,npe
+  use mod_vtrans, only: speeds,nvmodes_keep,vtrans,vtrans_inv,vtrans_ad,vtrans_inv_ad
+  implicit none
+
+! set default to private
+  private
+! set subroutines to public
+  public :: init_strongvars
+  public :: strong_bal_correction_fast_global
+  public :: strong_bal_correction_fast_global_ad
+  public :: gather_rmstends0
+  public :: gather_rmstends
+  public :: inmi_coupler_sd2ew0
+  public :: inmi_coupler_sd2ew1
+  public :: inmi_coupler_sd2ew
+  public :: inmi_coupler_ew2sd1
+  public :: inmi_coupler_ew2sd
+  public :: inmi_ew_trans
+  public :: inmi_ew_invtrans_ad
+  public :: inmi_ew_invtrans
+  public :: inmi_ew_trans_ad
+  public :: inmi_coupler_ew2ns0
+  public :: inmi_coupler_ew2ns1
+  public :: inmi_coupler_ew2ns
+  public :: inmi_coupler_ns2ew
+  public :: inmi_nsuvm2zdm
+  public :: spdz2uv_ns
+  public :: spuv2dz_ns
+
+  integer(i_kind),allocatable:: mode_list(:,:)
+                                                   !  mode_list(1,j) = lat index for ew strip j
+                                                   !  mode_list(2,j) = vert mode number for ew strip j
+                                                   !  mode_list(3,j) = pe of this lat/vert mode strip 
+  integer(i_kind),allocatable:: mmode_list(:,:)
+                                                   !  mmode_list(1,j) = m1 (zonal wave number 1) for ns strip
+                                                   !  mmode_list(2,j) = m2 (zonal wave number 2) for ns strip
+                                                   !  mmode_list(3,j) = vert mode number 1 for ns strip j
+                                                   !  mmode_list(4,j) = vert mode number 2 for ns strip j
+                                                   !  mmode_list(5,j) = pe for ns strip j
+  integer(i_kind) nlatm_0,nlatm_1,m_0,m_1
+  integer(i_kind) mthis
+  integer(i_kind) nallsend_ew2sd,nallrecv_ew2sd
+  integer(i_kind) nallsend,nallrecv
+  integer(i_kind) nallsend_sd2ew,nallrecv_sd2ew
+  integer(i_kind),allocatable,dimension(:)::mthis0,ndisp,indexglob
+  integer(i_kind),allocatable,dimension(:)::nsend_sd2ew,nrecv_sd2ew
+  integer(i_kind),allocatable,dimension(:)::ndsend_sd2ew,ndrecv_sd2ew
+  integer(i_kind),allocatable,dimension(:)::nsend_ew2sd,nrecv_ew2sd
+  integer(i_kind),allocatable,dimension(:)::ndsend_ew2sd,ndrecv_ew2sd
+  integer(i_kind),allocatable,dimension(:)::nsend,nrecv,ndsend,ndrecv
+  integer(i_kind),allocatable,dimension(:,:)::info_send_sd2ew,info_recv_sd2ew
+  integer(i_kind),allocatable,dimension(:,:)::info_send_ew2sd,info_recv_ew2sd
+  integer(i_kind),allocatable,dimension(:,:)::info_send,info_recv
+
+contains
+
+subroutine init_strongvars(mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    init_strongvars
+!
+!   prgrmmr: parrish
+!
+! abstract: initialize strong fast global initialization
+!
+! program history log:
+!   2008-04-04  safford -- add subprogram doc block
+!   2010-03-31  treadon - replace specmod jcap with sp_a structure
+!
+!   input argument list:
+!     mype     - mpi task id
+!
+!   output argument list:
+!
+! attributes:
+!   language:  f90
+!   machine:   ibm rs/6000 sp
+!
+!$$$
+
+  implicit none
+
+  integer(i_kind),intent(in   ) :: mype
+
+  allocate(mode_list(3,nlat*nvmodes_keep),mmode_list(5,(sp_a%jcap+1)*nvmodes_keep))
+  call inmi_coupler_sd2ew0(mype)
+  call inmi_coupler_ew2ns0(mype)
+  call gather_rmstends0
+  call inmi_coupler_sd2ew1(mype)
+  call inmi_coupler_ew2ns1(mype)
+  call inmi_coupler_ew2sd1(mype)
+
+  return
+end subroutine init_strongvars
+
+
+subroutine strong_bal_correction_fast_global(u_t,v_t,t_t,ps_t,mype,psi,chi,t,ps, &
+                                              bal_diagnostic,fullfield,update,uvflag)
+
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    strong_bal_correction  strong balance correction
+!   prgmmr: parrish          org: np23                date: 2006-07-15
+!
+! abstract: given input perturbation tendencies of u,v,t,ps from tlm on gaussian grid,
+!           and input perturbation u,v,t,ps, compute balance adjustment to u,v,t,ps
+!           which zeroes out input gravity component of perturbation tendencies.
+!           also output, for later use, input tendencies projected onto gravity modes.
+!
+! program history log:
+!   2006-07-15  parrish
+!   2007-04-16  kleist  - modified for full field or incremental diagnostics
+!   2008-10-08  parrish/derber - modify to output streamfunction and vel. pot. and not update time derivatives
+!   2009-11-27  parrish - add uvflag.  if uvflag=true, then
+!                          input/output variables psi=u, chi=v.
+!   2010-03-31  treadon - replace specmod jcap with sp_a structure
+!   2012-02-08  kleist  - add uvflag in place of uv_hyb_ens
+!   2013-10-26  todling - prevent division by zero when rms's are zero
+!
+!   input argument list:
+!     u_t      - input perturbation u tendency on gaussian grid (subdomains)
+!     v_t      - input perturbation v tendency on gaussian grid (subdomains)
+!     t_t      - input perturbation t tendency on gaussian grid (subdomains)
+!     ps_t     - input perturbation surface pressure tendency on gaussian grid (subdomains)
+!     mype     - current processor
+!     psi      - input perturbation psi on gaussian grid (subdomains)
+!     chi      - input perturbation chi on gaussian grid (subdomains)
+!     t        - input perturbation t on gaussian grid (subdomains)
+!     ps       - input perturbation surface pressure on gaussian grid (subdomains)
+!     bal_diagnostic - if true, then compute bal diagnostic, a measure of amplitude
+!                      of balanced gravity mode tendencies
+!     fullfield - if true, full field diagnostics
+!                 if false, incremental 
+!     update   - if false, then do not update u,v,t,ps with balance increment
+!
+!   output argument list:
+!     psi      - output balanced perturbation u on gaussian grid (subdomains)
+!     chi      - output balanced perturbation v on gaussian grid (subdomains)
+!     t        - output balanced perturbation t on gaussian grid (subdomains)
+!     ps       - output balanced perturbation surface pressure on gaussian grid (subdomains)
+!
+! attributes:
+!   language: f90
+!   machine:  ibm rs/6000 sp
+!
+!$$$
+
+  use mod_strong, only: dinmi,gproj,gproj_diag,gproj_diag_update
+  use constants, only: tiny_r_kind
+  implicit none
+
+  integer(i_kind)                       ,intent(in   ) :: mype
+  logical                               ,intent(in   ) :: bal_diagnostic,update,fullfield,uvflag
+  real(r_kind),dimension(lat2,lon2,nsig),intent(in   ) :: u_t,v_t,t_t
+  real(r_kind),dimension(lat2,lon2)     ,intent(in   ) :: ps_t
+  real(r_kind),dimension(lat2,lon2,nsig),intent(inout) :: psi,chi,t
+  real(r_kind),dimension(lat2,lon2)     ,intent(inout) :: ps
+
+  real(r_kind),dimension(nvmodes_keep)::rmstend_uf,rmstend_g_uf
+  real(r_kind),dimension(nvmodes_keep)::rmstend_f,rmstend_g_f
+
+  real(r_kind),dimension(lat2,lon2,nvmodes_keep)::utilde_t,vtilde_t,mtilde_t
+  real(r_kind),dimension(lat2,lon2,nvmodes_keep)::delutilde,delvtilde,delmtilde
+  real(r_kind),dimension(2,0:sp_a%jcap)::divhat,vorthat,mhat,deldivhat,delvorthat,delmhat
+  real(r_kind),allocatable,dimension(:,:)::rmstend_loc_uf,rmstend_g_loc_uf
+  real(r_kind),allocatable,dimension(:,:)::rmstend_loc_f,rmstend_g_loc_f
+  real(r_kind),allocatable,dimension(:,:,:,:)::uvm_ew
+  real(r_kind),allocatable,dimension(:,:,:,:,:)::uvm_ewtrans,uvm_ns,zdm_hat
+  real(r_kind) rmstend_all_uf,rmstend_all_g_uf,rmstend_all_f,rmstend_all_g_f
+  real(r_kind) del2inv,rn,gspeed
+  real(r_kind) diff1,diffi
+
+  integer(i_kind) i,ipair,kk,mode,n,mmax,m
+
+  if(.not. (update .or. bal_diagnostic))return
+
+  mmax=sp_a%jcap
+
+!   1.  u,v,t,ps   -->    utilde,vtilde,mtilde  (vertical mode transform)
+!       (subdomains)         (subdomains)
+
+  call vtrans(u_t,v_t,t_t,ps_t,utilde_t,vtilde_t,mtilde_t)
+
+  allocate(uvm_ew(nlon,2,3,nlatm_0:nlatm_1),uvm_ewtrans(2,0:sp_a%jcap,2,3,nlatm_0:nlatm_1))
+  allocate(uvm_ns(3,2,nlat,2,m_0:m_1),zdm_hat(3,2,nlat,2,m_0:m_1))
+  call inmi_coupler_sd2ew(utilde_t,vtilde_t,mtilde_t,utilde_t,vtilde_t,mtilde_t, &
+                          uvm_ew,mype)
+  call inmi_ew_trans(uvm_ew,uvm_ewtrans)
+  call inmi_coupler_ew2ns(uvm_ewtrans,uvm_ns)
+  call inmi_nsuvm2zdm(uvm_ns,zdm_hat)
+  if(bal_diagnostic)then
+    allocate(rmstend_loc_f(2,m_0:m_1))
+    allocate(rmstend_g_loc_f(2,m_0:m_1))
+    rmstend_loc_f=zero
+    rmstend_g_loc_f=zero
+    allocate(rmstend_loc_uf(2,m_0:m_1))
+    allocate(rmstend_g_loc_uf(2,m_0:m_1))
+    rmstend_g_loc_uf=zero
+    rmstend_loc_uf=zero
+  end if
+  if(update)then
+!$omp parallel do  schedule(dynamic,1) private(kk,ipair,m,mode,gspeed,i,n) &
+!$omp private(vorthat,divhat,delvorthat,deldivhat,delmhat,mhat,rn,del2inv)
+    do kk=m_0,m_1
+       do ipair=1,2
+          m=mmode_list(ipair,kk)
+          mode=mmode_list(ipair+2,kk)
+          gspeed=speeds(abs(mode))
+          i=0
+          do n=m,sp_a%jcap
+             i=i+1
+             vorthat(1,n)=zdm_hat(1,1,i,ipair,kk)
+             vorthat(2,n)=zdm_hat(1,2,i,ipair,kk)
+             divhat( 1,n)=zdm_hat(2,1,i,ipair,kk)
+             divhat( 2,n)=zdm_hat(2,2,i,ipair,kk)
+             mhat(   1,n)=zdm_hat(3,1,i,ipair,kk)
+             mhat(   2,n)=zdm_hat(3,2,i,ipair,kk)
+          end do
+
+!   4.  divhat,vorthat,mhat --> deldivhat,delvorthat,delmhat   (inmi correction)
+!          (slabs)                        (slabs)
+
+          if(mode >  0) then
+!               here, delvorthat, etc contain field corrections necessary to zero out gravity component
+!                                         of tendencies
+             call dinmi(vorthat(1,m),divhat(1,m),mhat(1,m),delvorthat(1,m),deldivhat(1,m),delmhat(1,m),&
+                      m,mmax,gspeed)
+          else
+!               here, delvorthat, etc contain gravity component of tendencies
+             if(bal_diagnostic) then   ! bal_diagnostic and update
+                call gproj_diag_update(vorthat(1,m),divhat(1,m),mhat(1,m),delvorthat(1,m),deldivhat(1,m),delmhat(1,m), &
+                          rmstend_loc_uf(ipair,kk),rmstend_g_loc_uf(ipair,kk),rmstend_loc_f(ipair,kk), &
+                          rmstend_g_loc_f(ipair,kk),m,mmax,gspeed)
+             else              !  update only
+                call gproj(vorthat(1,m),divhat(1,m),mhat(1,m),delvorthat(1,m),deldivhat(1,m),delmhat(1,m), &
+                          m,mmax,gspeed)
+             end if
+          end if
+
+          if(.not. uvflag)then
+             do n=m,sp_a%jcap
+                if(n >  0) then
+                   rn=real(n,r_kind)
+                   del2inv=-rearth**2/(rn*(rn+one))
+                else
+                   del2inv=zero
+                end if
+                delvorthat(1,n)=delvorthat(1,n)*del2inv
+                delvorthat(2,n)=delvorthat(2,n)*del2inv
+                deldivhat(1,n)=deldivhat(1,n)*del2inv
+                deldivhat(2,n)=deldivhat(2,n)*del2inv
+             end do
+          end if
+             
+          i=0
+          do n=m,sp_a%jcap
+             i=i+1
+             zdm_hat(1,1,i,ipair,kk)=delvorthat(1,n)
+             zdm_hat(1,2,i,ipair,kk)=delvorthat(2,n)
+             zdm_hat(2,1,i,ipair,kk)=deldivhat(1,n)
+             zdm_hat(2,2,i,ipair,kk)=deldivhat(2,n)
+             zdm_hat(3,1,i,ipair,kk)=delmhat(1,n)
+             zdm_hat(3,2,i,ipair,kk)=delmhat(2,n)
+          end do
+        end do
+     end do
+!   7.  delutilde,delvtilde,delmtilde  -->  psi,chi,t,ps   (vertical mode inverse transform)
+!       (subdomains)                      (subdomains)
+
+!  update u,v,t,ps
+
+     if(uvflag) then
+        call inmi_nszdm2uvm(uvm_ns,zdm_hat)
+     else
+        call inmi_nspcm_hat2pcm(uvm_ns,zdm_hat)
+     end if
+     call inmi_coupler_ns2ew(uvm_ewtrans,uvm_ns)
+     call inmi_ew_invtrans(uvm_ew,uvm_ewtrans)
+     call inmi_coupler_ew2sd(delutilde,delvtilde,delmtilde,utilde_t,vtilde_t,mtilde_t,uvm_ew,mype)
+     call vtrans_inv(delutilde,delvtilde,delmtilde,psi,chi,t,ps)
+!    u_t_g=zero;v_t_g=zero;t_t_g=zero;ps_t_g=zero
+!    call vtrans_inv(utilde_t,vtilde_t,mtilde_t,u_t_g,v_t_g,t_t_g,ps_t_g)
+  else            ! bal_diagnostic only no update
+!$omp parallel do  schedule(dynamic,1) private(kk,ipair,m,mode,gspeed,i,n) &
+!$omp private(vorthat,divhat,mhat)
+     do kk=m_0,m_1
+        do ipair=1,2
+           mode=mmode_list(ipair+2,kk)
+           if(mode > 0)cycle
+           m=mmode_list(ipair,kk)
+           gspeed=speeds(abs(mode))
+           i=0
+           do n=m,sp_a%jcap
+              i=i+1
+              vorthat(1,n)=zdm_hat(1,1,i,ipair,kk)
+              vorthat(2,n)=zdm_hat(1,2,i,ipair,kk)
+              divhat( 1,n)=zdm_hat(2,1,i,ipair,kk)
+              divhat( 2,n)=zdm_hat(2,2,i,ipair,kk)
+              mhat(   1,n)=zdm_hat(3,1,i,ipair,kk)
+              mhat(   2,n)=zdm_hat(3,2,i,ipair,kk)
+           end do
+
+           call gproj_diag(vorthat(1,m),divhat(1,m),mhat(1,m), &
+                     rmstend_loc_uf(ipair,kk),rmstend_g_loc_uf(ipair,kk),rmstend_loc_f(ipair,kk), &
+                     rmstend_g_loc_f(ipair,kk),m,mmax,gspeed)
+        end do
+     end do
+  end if
+
+  deallocate(uvm_ew,uvm_ewtrans,uvm_ns,zdm_hat)
+
+
+  if(bal_diagnostic) then
+     call gather_rmstends(rmstend_loc_uf,  rmstend_uf)
+     call gather_rmstends(rmstend_g_loc_uf,rmstend_g_uf)
+     call gather_rmstends(rmstend_loc_f,   rmstend_f)
+     call gather_rmstends(rmstend_g_loc_f, rmstend_g_f)
+     if(mype == 0) then
+        rmstend_all_uf=zero
+        rmstend_all_g_uf=zero
+
+        if (fullfield) then
+           write(6,*) 'strong_fast_global:   full field balance diagnostics --  '
+        else
+           write(6,*) 'strong_fast_global:   incremental balance diagnostics --  '
+        end if
+
+        do i=1,nvmodes_keep
+           rmstend_all_uf=rmstend_all_uf+rmstend_uf(i)
+           rmstend_all_g_uf=rmstend_all_g_uf+rmstend_g_uf(i)
+           diffi = rmstend_uf(i)-rmstend_g_uf(i) 
+           diff1 = rmstend_uf(1)-rmstend_g_uf(1)
+           if(abs(diffi)<tiny_r_kind.or.abs(diff1)<tiny_r_kind) then
+             write(6,'(" mode,rmstend_uf,rmstend_g_uf,rat = ",i5,2e28.18)') &
+                              i,rmstend_uf(i),rmstend_g_uf(i)
+           else
+             write(6,'(" mode,rmstend_uf,rmstend_g_uf,rat = ",i5,2e28.18,2f24.18)') &
+                              i,rmstend_uf(i),rmstend_g_uf(i),&
+                              rmstend_g_uf(i)/diffi, &
+                              rmstend_g_uf(i)/diff1
+           endif
+        end do
+        rmstend_all_f=zero
+        rmstend_all_g_f=zero
+        do i=1,nvmodes_keep
+           rmstend_all_f=rmstend_all_f+rmstend_f(i)
+           rmstend_all_g_f=rmstend_all_g_f+rmstend_g_f(i)
+           diffi = rmstend_f(i)-rmstend_g_f(i)
+           diff1 = rmstend_f(1)-rmstend_g_f(1)
+           if(abs(diffi)<tiny_r_kind.or.abs(diff1)<tiny_r_kind) then
+             write(6,'(" mode,rmstend_f,rmstend_g_f = ",i5,2e28.18)') &
+                              i,rmstend_f(i),rmstend_g_f(i)
+           else
+             write(6,'(" mode,rmstend_f,rmstend_g_f,rat = ",i5,2e28.18,2f24.18)') &
+                              i,rmstend_f(i),rmstend_g_f(i),&
+                              rmstend_g_f(i)/diffi, &
+                              rmstend_g_f(i)/diff1
+           endif
+        end do
+        diffi = rmstend_all_uf-rmstend_all_g_uf
+        diff1 = rmstend_all_f-rmstend_all_g_f
+        if(abs(diffi)<tiny_r_kind.or.abs(diff1)<tiny_r_kind) then
+          write(6,'(" rmstend_all_uf,g_uf,rat = ",2e28.18)') rmstend_all_uf,rmstend_all_g_uf
+          write(6,'(" rmstend_all_f,g_f,rat = ",2e28.18)') rmstend_all_f,rmstend_all_g_f
+        else
+          write(6,'(" rmstend_all_uf,g_uf,rat = ",2e28.18,f24.18)') rmstend_all_uf,rmstend_all_g_uf, &
+                                                   diffi
+          write(6,'(" rmstend_all_f,g_f,rat = ",2e28.18,f24.18)') rmstend_all_f,rmstend_all_g_f, &
+                                                   diff1
+        endif
+     end if
+     deallocate(rmstend_loc_uf,rmstend_g_loc_uf)
+     deallocate(rmstend_loc_f,rmstend_g_loc_f)
+  end if
+  return
+
+end subroutine strong_bal_correction_fast_global
+
+subroutine strong_bal_correction_fast_global_ad(u_t,v_t,t_t,ps_t,mype,psi,chi,t,ps,uvflag)
+
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    strong_bal_correction_ad adjoint of strong_bal_correction
+!   prgmmr: parrish          org: np23                date: 2006-07-15
+!
+! abstract: adjoint of strong_bal_correction
+!
+! program history log:
+!   2006-07-15  parrish
+!   2008-10-08  parrish/derber - modify to output streamfunction and vel. pot. and not update time derivatives
+!   2009-11-27  parrish - add uvflag.  if present and true, then
+!                          input/output variables psi=u, chi=v.
+!   2010-03-31  treadon - replace specmod jcap with sp_a structure
+!   2012-02-08  kleist  - add uvflag in place of uv_hyb_ens
+!
+!   input argument list:
+!     u_t      - input perturbation u tendency on gaussian grid (subdomains)
+!     v_t      - input perturbation v tendency on gaussian grid (subdomains)
+!     t_t      - input perturbation t tendency on gaussian grid (subdomains)
+!     ps_t     - input perturbation surface pressure tendency on gaussian grid (subdomains)
+!     mype     - current processor
+!     psi      - input perturbation psi on gaussian grid (subdomains)
+!     chi      - input perturbation chi on gaussian grid (subdomains)
+!     t        - input perturbation t on gaussian grid (subdomains)
+!     ps       - input perturbation surface pressure on gaussian grid (subdomains)
+!
+!   output argument list:
+!     u_t      - output perturbation u tendency on gaussian grid (subdomains)
+!     v_t      - output perturbation v tendency on gaussian grid (subdomains)
+!     t_t      - output perturbation t tendency on gaussian grid (subdomains)
+!     ps_t     - output perturbation surface pressure tendency on gaussian grid (subdomains)
+!
+! attributes:
+!   language: f90
+!   machine:  ibm rs/6000 sp
+!
+!$$$
+
+  use mod_strong, only: dinmi_ad,gproj_ad
+  implicit none
+
+  integer(i_kind)                       ,intent(in   ) :: mype
+  real(r_kind),dimension(lat2,lon2,nsig),intent(inout) :: u_t,v_t,t_t
+  real(r_kind),dimension(lat2,lon2)     ,intent(inout) :: ps_t
+  real(r_kind),dimension(lat2,lon2,nsig),intent(in   ) :: psi,chi,t
+  real(r_kind),dimension(lat2,lon2)     ,intent(in   ) :: ps
+  logical, intent(in)                                  :: uvflag
+
+  real(r_kind),dimension(lat2,lon2,nvmodes_keep)::utilde_t,vtilde_t,mtilde_t
+  real(r_kind),dimension(lat2,lon2,nvmodes_keep)::delutilde,delvtilde,delmtilde
+  real(r_kind),dimension(2,0:sp_a%jcap)::divhat,vorthat,mhat,deldivhat,delvorthat,delmhat
+  real(r_kind),allocatable,dimension(:,:,:,:)::uvm_ew
+  real(r_kind),allocatable,dimension(:,:,:,:,:)::uvm_ewtrans,uvm_ns,zdm_hat
+  real(r_kind) del2inv,rn,gspeed
+
+  integer(i_kind) i,ipair,kk,mode,n,m,mmax
+
+  mmax=sp_a%jcap
+
+!  adjoint of update u,v,t,ps
+
+!   7.  adjoint of delutilde,delvtilde,delmtilde  -->  psi,chi,t,ps  (vert mode inverse transform)
+!       (subdomains)                      (subdomains)
+
+  delutilde=zero ; delvtilde=zero ; delmtilde=zero
+  call vtrans_inv_ad(delutilde,delvtilde,delmtilde,psi,chi,t,ps)
+
+  allocate(uvm_ew(nlon,2,3,nlatm_0:nlatm_1),uvm_ewtrans(2,0:sp_a%jcap,2,3,nlatm_0:nlatm_1))
+  allocate(uvm_ns(3,2,nlat,2,m_0:m_1),zdm_hat(3,2,nlat,2,m_0:m_1))
+  utilde_t=zero ; vtilde_t=zero ; mtilde_t=zero
+  call inmi_coupler_sd2ew(delutilde,delvtilde,delmtilde,utilde_t,vtilde_t,mtilde_t,uvm_ew,mype)
+  call inmi_ew_invtrans_ad(uvm_ew,uvm_ewtrans)
+  call inmi_coupler_ew2ns(uvm_ewtrans,uvm_ns)
+  if(uvflag) then
+     call inmi_nszdm2uvm_ad(uvm_ns,zdm_hat)
+  else
+     call inmi_nspcm_hat2pcm_ad(uvm_ns,zdm_hat)
+  end if
+!$omp parallel do  schedule(dynamic,1) private(kk,ipair,m,mode,gspeed,i,n) &
+!$omp private(vorthat,divhat,delvorthat,deldivhat,delmhat,mhat,rn,del2inv)
+  do kk=m_0,m_1
+     do ipair=1,2
+        m=mmode_list(ipair,kk)
+        mode=mmode_list(ipair+2,kk)
+        gspeed=speeds(abs(mode))
+        do n=m,sp_a%jcap
+           vorthat(1,n)=zero
+           vorthat(2,n)=zero
+           divhat( 1,n)=zero
+           divhat( 2,n)=zero
+           mhat(   1,n)=zero
+           mhat(   2,n)=zero
+        end do
+        i=0
+        do n=m,sp_a%jcap
+           i=i+1
+           delvorthat(1,n)=zdm_hat(1,1,i,ipair,kk)
+           delvorthat(2,n)=zdm_hat(1,2,i,ipair,kk)
+           deldivhat(1,n)=zdm_hat(2,1,i,ipair,kk)
+           deldivhat(2,n)=zdm_hat(2,2,i,ipair,kk)
+           delmhat(1,n)=zdm_hat(3,1,i,ipair,kk)
+           delmhat(2,n)=zdm_hat(3,2,i,ipair,kk)
+        end do
+        if(.not. uvflag) then
+           do n=m,sp_a%jcap
+              if(n >  0) then
+                 rn=real(n,r_kind) 
+                 del2inv=-rearth**2/(rn*(rn+one))
+              else
+                 del2inv=zero
+              end if
+              delvorthat(1,n)=delvorthat(1,n)*del2inv
+              delvorthat(2,n)=delvorthat(2,n)*del2inv
+              deldivhat(1,n)=deldivhat(1,n)*del2inv
+              deldivhat(2,n)=deldivhat(2,n)*del2inv
+           end do
+        end if
+        if(mode >  0) then
+           call dinmi_ad(vorthat(1,m),divhat(1,m),mhat(1,m),&
+                       delvorthat(1,m)   ,   deldivhat(1,m),   delmhat(1,m),m,mmax,gspeed)
+        else
+           call gproj_ad(vorthat(1,m),divhat(1,m),mhat(1,m),delvorthat(1,m),deldivhat(1,m), &
+                 delmhat(1,m),m,mmax,gspeed)
+        end if
+
+        i=0
+        do n=m,sp_a%jcap
+           i=i+1
+           zdm_hat(1,1,i,ipair,kk)=vorthat(1,n)
+           zdm_hat(1,2,i,ipair,kk)=vorthat(2,n)
+           zdm_hat(2,1,i,ipair,kk)=divhat(1,n)
+           zdm_hat(2,2,i,ipair,kk)=divhat(2,n)
+           zdm_hat(3,1,i,ipair,kk)=mhat(1,n)
+           zdm_hat(3,2,i,ipair,kk)=mhat(2,n)
+        end do
+
+     end do
+  end do
+
+  call inmi_nsuvm2zdm_ad(uvm_ns,zdm_hat)
+  call inmi_coupler_ns2ew(uvm_ewtrans,uvm_ns)
+  call inmi_ew_trans_ad(uvm_ew,uvm_ewtrans)
+  call inmi_coupler_ew2sd(utilde_t,vtilde_t,mtilde_t,delutilde,delvtilde,delmtilde,uvm_ew,mype)
+
+  utilde_t=utilde_t+delutilde
+  vtilde_t=vtilde_t+delvtilde
+  mtilde_t=mtilde_t+delmtilde
+!
+!    1.  adjoint of u,v,t,ps   -->    utilde,vtilde,mtilde  (vertical mode transform)
+!                      (subdomains)         (subdomains)
+
+  call vtrans_ad(u_t,v_t,t_t,ps_t,utilde_t,vtilde_t,mtilde_t)
+  deallocate(uvm_ew,uvm_ewtrans,uvm_ns,zdm_hat)
+
+end subroutine strong_bal_correction_fast_global_ad
+
+subroutine gather_rmstends0
+
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    gather_rmstends0  get bal diagnostics
+!   prgmmr: parrish          org: np23                date: 2006-08-03
+!
+! abstract: compute bal diagnostics which give amplitude of 
+!           gravity projection of energy norm of tendencies
+!
+! program history log:
+!   2006-08-03  parrish
+!   2008-04-04  safford  - rm unused uses
+!   2010-03-31  treadon - replace specmod jcap with sp_a structure
+!
+!   input argument list:
+!
+!   output argument list:
+!     rmstend  -  all vertical modes of rmstend assembled across all processors
+!
+! attributes:
+!   language: f90
+!   machine:  ibm rs/6000 sp
+!
+!$$$
+
+  implicit none
+
+  integer(i_kind),dimension(m_0:m_1):: indexloc
+  integer(i_kind) i
+  
+  allocate(mthis0(npe),ndisp(npe+1),indexglob((sp_a%jcap+1)*nvmodes_keep))
+  do i=m_0,m_1
+     indexloc(i)=i
+  end do
+  mthis=m_1-m_0+1
+  call mpi_allgather(mthis,1,mpi_integer4,mthis0,1,mpi_integer4,gsi_mpi_comm_world,ierror)
+  ndisp(1)=0
+  do i=2,npe+1
+     ndisp(i)=ndisp(i-1)+mthis0(i-1)
+  end do
+  call mpi_allgatherv(indexloc,mthis,mpi_integer4, &
+                      indexglob,mthis0,ndisp,mpi_integer4,gsi_mpi_comm_world,ierror)
+
+end subroutine gather_rmstends0
+
+subroutine gather_rmstends(rmstend_loc,rmstend)
+
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    gather_rmstends  get bal diagnostics
+!   prgmmr: parrish          org: np23                date: 2006-08-03
+!
+! abstract: compute bal diagnostics which give amplitude of 
+!           gravity projection of energy norm of tendencies
+!
+! program history log:
+!   2006-08-03  parrish
+!   2008-04-04  safford  - rm unused uses
+!
+!   input argument list:
+!     rmstend_loc - previously computed energy norms of vertical modes
+!                   as distributed on local processors
+!
+!   output argument list:
+!     rmstend  -  all vertical modes of rmstend assembled across all processors
+!
+! attributes:
+!   language: f90
+!   machine:  ibm rs/6000 sp
+!
+!$$$
+
+  implicit none
+
+  real(r_kind),intent(in   ) :: rmstend_loc(2,m_0:m_1)
+  real(r_kind),intent(  out) :: rmstend(nvmodes_keep)
+
+  real(r_kind),dimension(2,(sp_a%jcap+1)*nvmodes_keep)::work
+  integer(i_kind) i,ii,mode,mpi_string1
+  
+  call mpi_type_contiguous(2,mpi_rtype,mpi_string1,ierror)
+  call mpi_type_commit(mpi_string1,ierror)
+  call mpi_allgatherv(rmstend_loc,mthis,mpi_string1, &
+                     work,mthis0,ndisp,mpi_string1,gsi_mpi_comm_world,ierror)
+  call mpi_type_free(mpi_string1,ierror)
+  rmstend=zero
+  do i=1,ndisp(npe+1)
+     ii=indexglob(i)
+     mode=mmode_list(3,ii)
+     if(mode <  0) rmstend(-mode)=work(1,ii)+rmstend(-mode)
+     mode=mmode_list(4,ii)
+     if(mode <  0) rmstend(-mode)=work(2,ii)+rmstend(-mode)
+  end do
+
+end subroutine gather_rmstends
+
+subroutine inmi_coupler_sd2ew0(mype)
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    inmi_coupler_sd2ew0
+!   prgmmr:
+!
+! abstract:  create ew (lat strips) subdivision for use with inmi
+!
+! program history log:
+!   2008-04-04  safford  - add doc block
+!
+!   input argument list:
+!     mype        - current processor number
+!
+!   output argument list:
+!
+! attributes:
+!   language: f90
+!   machine:  ibm rs/6000 sp
+!
+!$$$
+
+  implicit none
+
+  integer(i_kind),intent(in   ) :: mype
+
+  integer(i_kind) i,k,kchk,kk,n,nn,nlatm_this
+
+  nlatm_this=nlat*nvmodes_keep/npe
+  if(mod(nlat*nvmodes_keep,npe)==0) then
+     kchk=npe
+  else
+     nlatm_this=nlatm_this+1
+     kchk=mod(nlat*nvmodes_keep,npe)
+  end if
+
+  nn=0
+  do k=1,nvmodes_keep
+     do i=1,nlat
+        nn=nn+1
+        mode_list(1,nn)=i
+        mode_list(2,nn)=k
+        mode_list(3,nn)=-1
+     end do
+  end do
+  
+  nlatm_0=-1
+  nlatm_1=-2
+  nn=0
+  do n=1,npe
+     if(n <= kchk) then
+        kk=nlatm_this
+     else
+        kk=nlatm_this-1
+     end if
+     if(kk >  0) then
+        if(mype+1 == n) then
+           nlatm_0=nn+1
+           nlatm_1=nn+kk
+        end if
+        do k=1,kk
+           nn=nn+1
+           mode_list(3,nn)=n
+        end do
+     end if
+  end do
+end subroutine inmi_coupler_sd2ew0
+
+subroutine inmi_coupler_sd2ew1(mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    inmi_coupler_sd2ew1
+!
+!   prgrmmr:
+!
+! abstract: use mpi_alltoallv to move u_sd,v_sd,m_sd (subdomains) to uvm_ew (lat strips)
+!
+! program history log:
+!   2008-04-04  safford -- add subprogram doc block
+!
+!   input argument list:
+!     mype     - mpi task id
+!
+!   output argument list:
+!
+! attributes:
+!   language:  f90
+!   machine:   ibm rs/6000 sp
+!
+!$$$
+
+  implicit none
+
+
+  integer(i_kind),intent(in   ) :: mype
+
+  integer(i_kind) i,ii,ii0,ilat,imode,j,mm1,nlonloc,ipe,ilatm,ilon,mpi_string1
+  real(r_kind),dimension(nlat,nvmodes_keep):: mode2_list
+
+  allocate(nsend_sd2ew(npe),nrecv_sd2ew(npe))
+  allocate(ndsend_sd2ew(npe+1),ndrecv_sd2ew(npe+1))
+  mm1=mype+1
+
+  mode2_list=0
+  do i=1,nlat*nvmodes_keep
+     ilat=mode_list(1,i)
+     imode=mode_list(2,i)
+     if(mode2_list(ilat,imode) /= 0) then
+        if(mype == 0) write(6,*)' problem in inmi_coupler_sd2ew0'
+        call mpi_finalize(i)
+        stop
+     end if
+     mode2_list(ilat,imode)=i
+  end do
+  do imode=1,nvmodes_keep
+     do ilat=1,nlat
+        if(mode2_list(ilat,imode) == 0) then
+           if(mype == 0) write(6,*)' problem in inmi_coupler_sd2ew0'
+           call mpi_finalize(i)
+           stop
+        end if
+     end do
+  end do
+
+
+
+!  obtain counts of points to send to each pe from this pe
+
+  nsend_sd2ew=0
+  nlonloc=lon2-2
+  do imode=1,nvmodes_keep
+     if(imode == 0) cycle
+     do i=2,lat2-1
+        ilat=i+istart(mm1)-2
+        j=mode2_list(ilat,imode)
+        ipe=mode_list(3,j)
+        nsend_sd2ew(ipe)=nsend_sd2ew(ipe)+nlonloc
+     end do
+  end do
+
+  ndsend_sd2ew(1)=0
+  do i=2,npe+1
+     ndsend_sd2ew(i)=ndsend_sd2ew(i-1)+nsend_sd2ew(i-1)
+  end do
+  nallsend_sd2ew=ndsend_sd2ew(npe+1)
+  allocate(info_send_sd2ew(2,nallsend_sd2ew))
+  nsend_sd2ew=0
+  do imode=1,nvmodes_keep
+     if(imode == 0) cycle
+     do i=2,lat2-1
+        ilat=i+istart(mm1)-2
+        ilatm=mode2_list(ilat,imode)
+        ipe=mode_list(3,ilatm)
+        do ii=2,lon2-1
+           ilon=ii+jstart(mm1)-2
+           nsend_sd2ew(ipe)=nsend_sd2ew(ipe)+1
+           ii0=ndsend_sd2ew(ipe)+nsend_sd2ew(ipe)
+           info_send_sd2ew(1,ii0)=ilon
+           info_send_sd2ew(2,ii0)=ilatm
+        end do
+     end do
+  end do
+
+  call mpi_alltoall(nsend_sd2ew,1,mpi_integer4,nrecv_sd2ew,1,mpi_integer4,gsi_mpi_comm_world,ierror)
+  ndrecv_sd2ew(1)=0
+  do i=2,npe+1
+     ndrecv_sd2ew(i)=ndrecv_sd2ew(i-1)+nrecv_sd2ew(i-1)
+  end do
+  nallrecv_sd2ew=ndrecv_sd2ew(npe+1)
+  allocate(info_recv_sd2ew(2,nallrecv_sd2ew))
+  call mpi_type_contiguous(2,mpi_integer4,mpi_string1,ierror)
+  call mpi_type_commit(mpi_string1,ierror)
+  call mpi_alltoallv(info_send_sd2ew,nsend_sd2ew,ndsend_sd2ew,mpi_string1, &
+                     info_recv_sd2ew,nrecv_sd2ew,ndrecv_sd2ew,mpi_string1,gsi_mpi_comm_world,ierror)
+  call mpi_type_free(mpi_string1,ierror)
+    
+end subroutine inmi_coupler_sd2ew1
+
+subroutine inmi_coupler_sd2ew(u_sd1,v_sd1,m_sd1,u_sd2,v_sd2,m_sd2,uvm_ew,mype)
+
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    init_coupler_sd2ew
+!
+!   prgrmmr:
+!
+! abstract: use mpi_alltoallv to move u_sd,v_sd,m_sd (subdomains) to uvm_ew (lat strips)
+!
+! program history log:
+!   2008-04-04  safford -- add subprogram doc block, rm unused vars
+!
+!   input argument list:
+!     mype     - mpi task id
+!     u_sd1    -
+!     v_sd1    -
+!     m_sd1    -
+!     u_sd2    -
+!     v_sd2    -
+!     m_sd2    -
+!
+!   output argument list:
+!     uvm_ew   -
+!
+! attributes:
+!   language:  f90
+!   machine:   ibm rs/6000 sp
+!
+!$$$
+
+  implicit none
+
+
+  integer(i_kind)                                 ,intent(in   ) :: mype
+  real(r_kind),dimension(lat2,lon2,nvmodes_keep)  ,intent(in   ) :: u_sd1,v_sd1,m_sd1
+  real(r_kind),dimension(lat2,lon2,nvmodes_keep)  ,intent(in   ) :: u_sd2,v_sd2,m_sd2
+  real(r_kind),dimension(nlon,2,3,nlatm_0:nlatm_1),intent(  out) :: uvm_ew
+
+  real(r_kind),allocatable,dimension(:,:,:)::sendbuf,recvbuf
+  integer(i_kind) ilat,imode,j,mm1,ilatm,ilon,mpi_string1
+
+  mm1=mype+1
+
+  allocate(sendbuf(2,3,nallsend_sd2ew))
+  do j=1,nallsend_sd2ew
+     ilon=info_send_sd2ew(1,j)-jstart(mm1)+2
+     ilatm=info_send_sd2ew(2,j)
+     ilat=mode_list(1,ilatm)-istart(mm1)+2
+     imode=mode_list(2,ilatm)
+     sendbuf(1,1,j)=u_sd1(ilat,ilon,imode)
+     sendbuf(1,2,j)=v_sd1(ilat,ilon,imode)
+     sendbuf(1,3,j)=m_sd1(ilat,ilon,imode)
+     sendbuf(2,1,j)=u_sd2(ilat,ilon,imode)
+     sendbuf(2,2,j)=v_sd2(ilat,ilon,imode)
+     sendbuf(2,3,j)=m_sd2(ilat,ilon,imode)
+  end do
+  allocate(recvbuf(2,3,nallrecv_sd2ew))
+  call mpi_type_contiguous(6,mpi_rtype,mpi_string1,ierror)
+  call mpi_type_commit(mpi_string1,ierror)
+  call mpi_alltoallv(sendbuf,nsend_sd2ew,ndsend_sd2ew,mpi_string1, &
+                     recvbuf,nrecv_sd2ew,ndrecv_sd2ew,mpi_string1,gsi_mpi_comm_world,ierror)
+  call mpi_type_free(mpi_string1,ierror)
+  deallocate(sendbuf)
+    
+  do j=1,nallrecv_sd2ew
+     ilon=info_recv_sd2ew(1,j)
+     ilatm=info_recv_sd2ew(2,j)
+     uvm_ew(ilon,1,1,ilatm)=recvbuf(1,1,j)
+     uvm_ew(ilon,1,2,ilatm)=recvbuf(1,2,j)
+     uvm_ew(ilon,1,3,ilatm)=recvbuf(1,3,j)
+     uvm_ew(ilon,2,1,ilatm)=recvbuf(2,1,j)
+     uvm_ew(ilon,2,2,ilatm)=recvbuf(2,2,j)
+     uvm_ew(ilon,2,3,ilatm)=recvbuf(2,3,j)
+  end do
+  deallocate(recvbuf)
+    
+end subroutine inmi_coupler_sd2ew
+
+subroutine inmi_coupler_ew2sd1(mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    inmi_coupler_ew2sd1
+!
+!   prgrmmr:
+!
+! abstract: use mpi_alltoallv to move uvm_ew (lat strips) to u_sd,v_sd,m_sd (subdomains)
+!
+! program history log:
+!   2008-04-04  safford -- add subprogram doc block, rm unused vars and uses
+!
+!   input argument list:
+!     mype     - mpi task id
+!
+!   output argument list:
+!
+! attributes:
+!   language:  f90
+!   machine:   ibm rs/6000 sp
+!
+!$$$
+
+  implicit none
+
+
+  integer(i_kind),intent(in   ) :: mype
+
+  integer(i_kind) i,ilat,imode,j,k,mm1,ipe,ilon,mpi_string1,nn
+
+  allocate(nsend_ew2sd(npe),nrecv_ew2sd(npe))
+  allocate(ndsend_ew2sd(npe+1),ndrecv_ew2sd(npe+1))
+  mm1=mype+1
+
+!      1.  for each pe, gather up list of points from this set of lat strips destined
+!             for subdomain of pe
+  do ipe=1,npe
+     nn=0
+     do k=nlatm_0,nlatm_1
+        ilat=mode_list(1,k)
+        imode=mode_list(2,k)
+        i=ilat-istart(ipe)+2
+        if(i <  1.or.i >  ilat1(ipe)+2) cycle
+        do j=1,jlon1(ipe)+2
+           ilon=j+jstart(ipe)-2
+           if(ilon <  1) ilon=ilon+nlon
+           if(ilon >  nlon) ilon=ilon-nlon
+           nn=nn+1
+        end do
+     end do
+     nsend_ew2sd(ipe)=nn
+  end do
+
+  ndsend_ew2sd(1)=0
+  do i=2,npe+1
+     ndsend_ew2sd(i)=ndsend_ew2sd(i-1)+nsend_ew2sd(i-1)
+  end do
+  nallsend_ew2sd=ndsend_ew2sd(npe+1)
+  allocate(info_send_ew2sd(3,nallsend_ew2sd))
+  nn=0
+  do ipe=1,npe
+     do k=nlatm_0,nlatm_1
+        ilat=mode_list(1,k)
+        imode=mode_list(2,k)
+        i=ilat-istart(ipe)+2
+        if(i <  1.or.i >  ilat1(ipe)+2) cycle
+        do j=1,jlon1(ipe)+2
+           ilon=j+jstart(ipe)-2
+           if(ilon <  1) ilon=ilon+nlon
+           if(ilon >  nlon) ilon=ilon-nlon
+           nn=nn+1
+           info_send_ew2sd(1,nn)=ilon
+           info_send_ew2sd(2,nn)=j
+           info_send_ew2sd(3,nn)=k
+        end do
+     end do
+  end do
+
+  call mpi_alltoall(nsend_ew2sd,1,mpi_integer4,nrecv_ew2sd,1,mpi_integer4,gsi_mpi_comm_world,ierror)
+  ndrecv_ew2sd(1)=0
+  do i=2,npe+1
+     ndrecv_ew2sd(i)=ndrecv_ew2sd(i-1)+nrecv_ew2sd(i-1)
+  end do
+  nallrecv_ew2sd=ndrecv_ew2sd(npe+1)
+  allocate(info_recv_ew2sd(3,nallrecv_ew2sd))
+  call mpi_type_contiguous(3,mpi_integer4,mpi_string1,ierror)
+  call mpi_type_commit(mpi_string1,ierror)
+  call mpi_alltoallv(info_send_ew2sd,nsend_ew2sd,ndsend_ew2sd,mpi_string1, &
+                     info_recv_ew2sd,nrecv_ew2sd,ndrecv_ew2sd,mpi_string1,gsi_mpi_comm_world,ierror)
+  call mpi_type_free(mpi_string1,ierror)
+
+end subroutine inmi_coupler_ew2sd1
+
+subroutine inmi_coupler_ew2sd(u_sd1,v_sd1,m_sd1,u_sd2,v_sd2,m_sd2,uvm_ew,mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    inmi_coupler_ew2sd
+!
+!   prgrmmr:
+!
+! abstract: use mpi_alltoallv to move uvm_ew (lat strips) to u_sd,v_sd,m_sd (subdomains)
+!
+! program history log:
+!   2008-04-04  safford -- add subprogram doc block, rm unused vars
+!
+!   input argument list:
+!     mype     - mpi task id
+!     uvm_ew   -
+!
+!   output argument list:
+!     u_sd1    -
+!     v_sd1    -
+!     m_sd1    -
+!     u_sd2    -
+!     v_sd2    -
+!     m_sd2    -
+!
+! attributes:
+!   language:  f90
+!   machine:   ibm rs/6000 sp
+!
+!$$$
+
+  implicit none
+
+
+  integer(i_kind)                                 ,intent(in   ) :: mype
+  real(r_kind),dimension(lat2,lon2,nvmodes_keep)  ,intent(  out) :: u_sd1,v_sd1,m_sd1
+  real(r_kind),dimension(lat2,lon2,nvmodes_keep)  ,intent(  out) :: u_sd2,v_sd2,m_sd2
+  real(r_kind),dimension(nlon,2,3,nlatm_0:nlatm_1),intent(in   ) :: uvm_ew
+
+  real(r_kind),allocatable,dimension(:,:,:)::sendbuf,recvbuf
+  integer(i_kind) ilat,imode,j,mm1,ilatm,ilon,mpi_string1,ilonloc
+
+  mm1=mype+1
+
+  allocate(sendbuf(2,3,nallsend_ew2sd))
+  do j=1,nallsend_ew2sd
+     ilon=info_send_ew2sd(1,j)
+     ilatm=info_send_ew2sd(3,j)
+     sendbuf(1,1,j)=uvm_ew(ilon,1,1,ilatm)
+     sendbuf(1,2,j)=uvm_ew(ilon,1,2,ilatm)
+     sendbuf(1,3,j)=uvm_ew(ilon,1,3,ilatm)
+     sendbuf(2,1,j)=uvm_ew(ilon,2,1,ilatm)
+     sendbuf(2,2,j)=uvm_ew(ilon,2,2,ilatm)
+     sendbuf(2,3,j)=uvm_ew(ilon,2,3,ilatm)
+  end do
+  allocate(recvbuf(2,3,nallrecv_ew2sd))
+  call mpi_type_contiguous(6,mpi_rtype,mpi_string1,ierror)
+  call mpi_type_commit(mpi_string1,ierror)
+  call mpi_alltoallv(sendbuf,nsend_ew2sd,ndsend_ew2sd,mpi_string1, &
+                     recvbuf,nrecv_ew2sd,ndrecv_ew2sd,mpi_string1,gsi_mpi_comm_world,ierror)
+  call mpi_type_free(mpi_string1,ierror)
+  deallocate(sendbuf)
+  do j=1,nallrecv_ew2sd
+     ilonloc=info_recv_ew2sd(2,j)
+     ilatm=info_recv_ew2sd(3,j)
+     ilat=mode_list(1,ilatm)-istart(mm1)+2
+     imode=mode_list(2,ilatm)
+     u_sd1(ilat,ilonloc,imode)=recvbuf(1,1,j)
+     v_sd1(ilat,ilonloc,imode)=recvbuf(1,2,j)
+     m_sd1(ilat,ilonloc,imode)=recvbuf(1,3,j)
+     u_sd2(ilat,ilonloc,imode)=recvbuf(2,1,j)
+     v_sd2(ilat,ilonloc,imode)=recvbuf(2,2,j)
+     m_sd2(ilat,ilonloc,imode)=recvbuf(2,3,j)
+!--------------check for north or south pole
+     ilat=-1
+     if(mode_list(1,ilatm) == nlat) ilat=nlat-istart(mm1)+3
+     if(mode_list(1,ilatm) == 1) ilat=2-istart(mm1)
+     if(ilat == -1) cycle
+!-----------------do repeat rows for north/south pole
+     u_sd1(ilat,ilonloc,imode)=recvbuf(1,1,j)
+     v_sd1(ilat,ilonloc,imode)=recvbuf(1,2,j)
+     m_sd1(ilat,ilonloc,imode)=recvbuf(1,3,j)
+     u_sd2(ilat,ilonloc,imode)=recvbuf(2,1,j)
+     v_sd2(ilat,ilonloc,imode)=recvbuf(2,2,j)
+     m_sd2(ilat,ilonloc,imode)=recvbuf(2,3,j)
+  end do
+  deallocate(recvbuf)
+
+end subroutine inmi_coupler_ew2sd
+
+subroutine inmi_ew_trans(uvm_ew,uvm_ewtrans)
+
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    inmi_ew_trans
+!
+!   prgrmmr:
+!
+! abstract:
+!
+! program history log:
+!   2008-04-04  safford -- add subprogram doc block, rm unused uses
+!   2010-03-31  treadon - replace specmod components with sp_a structure
+!
+!   input argument list:
+!     uvm_ew   -
+!
+!   output argument list:
+!     uvm_ewtrans -
+!
+! attributes:
+!   language:  f90
+!   machine:   ibm rs/6000 sp
+!
+!$$$
+
+  implicit none
+
+  real(r_kind),dimension(nlon,2,3,nlatm_0:nlatm_1)    ,intent(in   ) :: uvm_ew
+  real(r_kind),dimension(2,0:sp_a%jcap,2,3,nlatm_0:nlatm_1),intent(  out) :: uvm_ewtrans
+
+  integer(i_kind) i,j,k
+  real(r_kind),dimension(2,0:nlon/2,2)::halfwave
+  real(r_kind),dimension(50000+4*sp_a%imax)::tmpafft
+
+!$omp parallel do  schedule(dynamic,1) private(k,j,i,tmpafft,halfwave)
+  do k=nlatm_0,nlatm_1
+     tmpafft=sp_a%afft
+     do j=1,3
+        call spffte(nlon,1+nlon/2,nlon,2,halfwave,uvm_ew(1,1,j,k),-1,tmpafft)
+        do i=0,sp_a%jcap
+           uvm_ewtrans(1,i,1,j,k)=halfwave(1,i,1)
+           uvm_ewtrans(2,i,1,j,k)=halfwave(2,i,1)
+           uvm_ewtrans(1,i,2,j,k)=halfwave(1,i,2)
+           uvm_ewtrans(2,i,2,j,k)=halfwave(2,i,2)
+        end do
+     end do
+  end do
+
+end subroutine inmi_ew_trans
+
+subroutine inmi_ew_invtrans_ad(uvm_ew,uvm_ewtrans)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    inmi_ew_invtrans_ad
+!
+!   prgrmmr:
+!
+! abstract:
+!
+! program history log:
+!   2008-04-04  safford -- add subprogram doc block, rm unused uses
+!   2010-03-31  treadon - replace specmod components with sp_a structure
+!
+!   input argument list:
+!     uvm_ew   -
+!
+!   output argument list:
+!     uvm_ewtrans -
+!
+! attributes:
+!   language:  f90
+!   machine:   ibm rs/6000 sp
+!
+!$$$
+
+  implicit none
+
+  real(r_kind),dimension(nlon,2,3,nlatm_0:nlatm_1)    ,intent(in   ) :: uvm_ew
+  real(r_kind),dimension(2,0:sp_a%jcap,2,3,nlatm_0:nlatm_1),intent(  out) :: uvm_ewtrans
+
+  integer(i_kind) i,j,k
+  real(r_kind) fnlon,fnlon2
+  real(r_kind),dimension(2,0:nlon/2,2)::halfwave
+  real(r_kind),dimension(50000+4*sp_a%imax)::tmpafft
+
+  fnlon=real(nlon,r_kind)
+  fnlon2=two*fnlon
+
+!$omp parallel do  schedule(dynamic,1) private(k,j,i,tmpafft,halfwave)
+  do k=nlatm_0,nlatm_1
+     tmpafft=sp_a%afft
+     do j=1,3
+        call spffte(nlon,1+nlon/2,nlon,2,halfwave,uvm_ew(1,1,j,k),-1,tmpafft)
+        uvm_ewtrans(1,0,1,j,k)=halfwave(1,0,1)*fnlon
+        uvm_ewtrans(2,0,1,j,k)=halfwave(2,0,1)*fnlon
+        uvm_ewtrans(1,0,2,j,k)=halfwave(1,0,2)*fnlon
+        uvm_ewtrans(2,0,2,j,k)=halfwave(2,0,2)*fnlon
+        do i=1,sp_a%jcap
+           uvm_ewtrans(1,i,1,j,k)=halfwave(1,i,1)*fnlon2
+           uvm_ewtrans(2,i,1,j,k)=halfwave(2,i,1)*fnlon2
+           uvm_ewtrans(1,i,2,j,k)=halfwave(1,i,2)*fnlon2
+           uvm_ewtrans(2,i,2,j,k)=halfwave(2,i,2)*fnlon2
+        end do
+     end do
+  end do
+
+end subroutine inmi_ew_invtrans_ad
+
+subroutine inmi_ew_invtrans(uvm_ew,uvm_ewtrans)
+
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    inmi_ew_invtrans
+!
+!   prgrmmr:
+!
+! abstract:
+!
+! program history log:
+!   2008-04-04  safford -- add subprogram doc block, rm unused vars
+!   2010-03-31  treadon - replace specmod components with sp_a structure
+!
+!   input argument list:
+!     uvm_ewtrans -
+!
+!   output argument list:
+!     uvm_ew      -
+!
+! attributes:
+!   language:  f90
+!   machine:   ibm rs/6000 sp
+!
+!$$$
+
+  implicit none
+
+  real(r_kind),dimension(nlon,2,3,nlatm_0:nlatm_1)    ,intent(  out) :: uvm_ew
+  real(r_kind),dimension(2,0:sp_a%jcap,2,3,nlatm_0:nlatm_1),intent(in   ) :: uvm_ewtrans
+
+  integer(i_kind) i,j,k
+  real(r_kind),dimension(2,0:nlon/2,2)::halfwave
+  real(r_kind),dimension(50000+4*sp_a%imax)::tmpafft
+
+!$omp parallel do  schedule(dynamic,1) private(k,j,i,tmpafft,halfwave)
+  do k=nlatm_0,nlatm_1
+     tmpafft=sp_a%afft
+     do j=1,3
+        do i=0,sp_a%jcap
+           halfwave(1,i,1)=uvm_ewtrans(1,i,1,j,k)
+           halfwave(2,i,1)=uvm_ewtrans(2,i,1,j,k)
+           halfwave(1,i,2)=uvm_ewtrans(1,i,2,j,k)
+           halfwave(2,i,2)=uvm_ewtrans(2,i,2,j,k)
+        end do
+        do i=sp_a%jcap+1,nlon/2
+           halfwave(1,i,1)=zero
+           halfwave(2,i,1)=zero
+           halfwave(1,i,2)=zero
+           halfwave(2,i,2)=zero
+        end do
+        call spffte(nlon,1+nlon/2,nlon,2,halfwave,uvm_ew(1,1,j,k),1,tmpafft)
+     end do
+  end do
+
+end subroutine inmi_ew_invtrans
+
+subroutine inmi_ew_trans_ad(uvm_ew,uvm_ewtrans)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    inmi_ew_trans_ad
+!
+!   prgrmmr:
+!
+! abstract:
+!
+! program history log:
+!   2008-04-04  safford -- add subprogram doc block, rm unused vars
+!   2010-03-31  treadon - replace specmod components with sp_a structure
+!
+!   input argument list:
+!     uvm_ewtrans -
+!
+!   output argument list:
+!   output argument list:
+!     uvm_ew      -
+!
+! attributes:
+!   language:  f90
+!   machine:   ibm rs/6000 sp
+!
+!$$$
+
+
+  implicit none
+
+  real(r_kind),dimension(nlon,2,3,nlatm_0:nlatm_1)    ,intent(  out) :: uvm_ew
+  real(r_kind),dimension(2,0:sp_a%jcap,2,3,nlatm_0:nlatm_1),intent(in   ) :: uvm_ewtrans
+
+  integer(i_kind) i,j,k
+  real(r_kind) invnlon,invnlon2
+  real(r_kind),dimension(2,0:nlon/2,2):: halfwave
+  real(r_kind),dimension(50000+4*sp_a%imax)::tmpafft
+
+  invnlon=one/real(nlon,r_kind)
+  invnlon2=one/(two*real(nlon,r_kind))
+!$omp parallel do  schedule(dynamic,1) private(k,j,i,tmpafft,halfwave)
+  do k=nlatm_0,nlatm_1
+     tmpafft=sp_a%afft
+     do j=1,3
+        halfwave(1,0,1)=uvm_ewtrans(1,0,1,j,k)*invnlon
+        halfwave(2,0,1)=zero
+        halfwave(1,0,2)=uvm_ewtrans(1,0,2,j,k)*invnlon
+        halfwave(2,0,2)=zero
+        do i=1,sp_a%jcap
+           halfwave(1,i,1)=uvm_ewtrans(1,i,1,j,k)*invnlon2
+           halfwave(2,i,1)=uvm_ewtrans(2,i,1,j,k)*invnlon2
+           halfwave(1,i,2)=uvm_ewtrans(1,i,2,j,k)*invnlon2
+           halfwave(2,i,2)=uvm_ewtrans(2,i,2,j,k)*invnlon2
+        end do
+        do i=sp_a%jcap+1,nlon/2
+           halfwave(1,i,1)=zero
+           halfwave(2,i,1)=zero
+           halfwave(1,i,2)=zero
+           halfwave(2,i,2)=zero
+        end do
+        call spffte(nlon,1+nlon/2,nlon,2,halfwave,uvm_ew(1,1,j,k),1,tmpafft)
+     end do
+  end do
+
+end subroutine inmi_ew_trans_ad
+
+subroutine inmi_coupler_ew2ns0(mype)
+
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    inmi_coupler_ew2ns0
+!
+!   prgrmmr:
+!
+! abstract:
+!
+! program history log:
+!   2008-04-04  safford -- add subprogram doc block, rm unused uses
+!   2010-03-31  treadon - replace specmod jcap with sp_a structure
+!
+!   input argument list:
+!     mype     - mpi task id
+!
+!   output argument list:
+!
+! attributes:
+!   language:  f90
+!   machine:   ibm rs/6000 sp
+!
+!$$$
+
+  implicit none
+
+  integer(i_kind),intent(in   ) :: mype
+
+  integer(i_kind) k,kk,m,n,num_per_pe,total_groups,nn,kchk
+
+!   in laying out by zonal wave number/vertical mode, have two types of groupings:
+
+!   1.  jcap odd: 
+
+!     group zonal wave numbers in pairs as follows:
+
+!      (0,(jcap+1)/2)    then    ( m,jcap+1-m)  for m=1,(jcap-1)/2
+
+!   2.  jcap even:
+
+!     0  (+,- mode pair together),  then   (m,jcap+1-m ) for m=1,jcap/2  single modes
+
+  total_groups=(sp_a%jcap+1)*nvmodes_keep
+  num_per_pe=total_groups/npe
+  if(mod(total_groups,npe)/=0) num_per_pe=num_per_pe+1
+  if(mod(total_groups,npe)==0) then
+     kchk=npe
+  else
+     kchk=mod(total_groups,npe)
+  end if
+
+  if(mod(sp_a%jcap,2) /= 0) then
+
+!    case  jcap odd:
+   
+     nn=0
+     do k=1,nvmodes_keep
+        nn=nn+1
+        mmode_list(1,nn)=0
+        mmode_list(2,nn)=(sp_a%jcap+1)/2
+        mmode_list(3,nn)=k
+        mmode_list(4,nn)=k
+        mmode_list(5,nn)=-1
+        do m=1,(sp_a%jcap-1)/2
+           nn=nn+1
+           mmode_list(1,nn)=m
+           mmode_list(2,nn)=sp_a%jcap+1-m
+           mmode_list(3,nn)=k
+           mmode_list(4,nn)=k
+           mmode_list(5,nn)=-1
+        end do
+     end do
+     do k=1,nvmodes_keep
+        nn=nn+1
+        mmode_list(1,nn)=0
+        mmode_list(2,nn)=(sp_a%jcap+1)/2
+        mmode_list(3,nn)=-k
+        mmode_list(4,nn)=-k
+        mmode_list(5,nn)=-1
+        do m=1,(sp_a%jcap-1)/2
+           nn=nn+1
+           mmode_list(1,nn)=m
+           mmode_list(2,nn)=sp_a%jcap+1-m
+           mmode_list(3,nn)=-k
+           mmode_list(4,nn)=-k
+           mmode_list(5,nn)=-1
+        end do
+     end do
+
+  else
+
+!    case  jcap even:
+   
+     nn=0
+     do k=1,nvmodes_keep
+        nn=nn+1
+        mmode_list(1,nn)=0
+        mmode_list(2,nn)=0
+        mmode_list(3,nn)=k
+        mmode_list(4,nn)=-k
+        mmode_list(5,nn)=-1
+        do m=1,sp_a%jcap/2
+           nn=nn+1
+           mmode_list(1,nn)=m
+           mmode_list(2,nn)=sp_a%jcap+1-m
+           mmode_list(3,nn)=k
+           mmode_list(4,nn)=k
+           mmode_list(5,nn)=-1
+        end do
+     end do
+     do k=1,nvmodes_keep
+        do m=1,sp_a%jcap/2
+           nn=nn+1
+           mmode_list(1,nn)=m
+           mmode_list(2,nn)=sp_a%jcap+1-m
+           mmode_list(3,nn)=-k
+           mmode_list(4,nn)=-k
+           mmode_list(5,nn)=-1
+        end do
+     end do
+
+  end if
+
+  m_0=-1
+  m_1=-2
+  nn=0
+  do n=1,npe
+     if(n <= kchk) then
+        kk=num_per_pe
+     else
+        kk=num_per_pe-1
+     end if
+     if(kk >  0) then
+        if(mype+1 == n) then
+           m_0=nn+1
+           m_1=nn+kk
+        end if
+        do k=1,kk
+           nn=nn+1
+           mmode_list(5,nn)=n
+        end do
+     end if
+  end do
+
+end subroutine inmi_coupler_ew2ns0
+
+subroutine inmi_coupler_ew2ns1(mype)
+
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    inmi_coupler_ew2ns1
+!
+!   prgrmmr:
+!
+! abstract:
+!
+! program history log:
+!   2008-04-04  safford -- add subprogram doc block
+!   2010-03-31  treadon - replace specmod jcap with sp_a structure
+!
+!   input argument list:
+!     mype     - mpi task id
+!
+!   output argument list:
+!
+! attributes:
+!   language:  f90
+!   machine:   ibm rs/6000 sp
+!
+!$$$
+
+  implicit none
+
+  integer(i_kind),intent(in   )::mype
+
+  integer(i_kind) i,ip12,ipe,j,k,m,nn,m1,m2,ilat,imode,imode1,imode2
+  integer(i_kind) mpi_string1,ibad,ibad0,loop
+  real(r_kind),dimension(0:sp_a%jcap,-nvmodes_keep:nvmodes_keep)::mmode2_list
+
+  allocate(nsend(npe),nrecv(npe),ndsend(npe+1),ndrecv(npe+1))
+  nn=0
+                
+  mmode2_list=0
+  do j=1,(sp_a%jcap+1)*nvmodes_keep
+     m1=mmode_list(1,j)
+     m2=mmode_list(2,j)
+     imode1=mmode_list(3,j)
+     imode2=mmode_list(4,j)
+     if(imode1 == imode2) then
+        if(mmode2_list(m1,imode1) /= 0.or.mmode2_list(m2,imode1) /= 0) then
+           if(mype == 0) write(6,*)' problem in inmi_coupler_ew2ns'
+           call mpi_finalize(i)
+           stop
+        end if
+        mmode2_list(m1,imode1)=j
+        mmode2_list(m2,imode1)=j
+     end if
+     if(m1 == m2) then
+        if(mmode2_list(m1,imode1) /= 0.or.mmode2_list(m1,imode2) /= 0) then
+           if(mype == 0) write(6,*)' problem in inmi_coupler_ew2ns'
+           call mpi_finalize(i)
+           stop
+        end if
+        mmode2_list(m1,imode1)=j
+        mmode2_list(m1,imode2)=j
+     end if
+  end do
+  do imode=-nvmodes_keep,nvmodes_keep
+     if(imode == 0) cycle
+     do m=0,sp_a%jcap
+        if(mmode2_list(m,imode) == 0) then
+           if(mype == 0) write(6,*)' problem in inmi_coupler_ew2ns'
+           call mpi_finalize(i)
+           stop
+        end if
+     end do
+  end do
+
+!  obtain counts of points to send to each pe from this pe
+
+  nsend=0
+  do k=nlatm_0,nlatm_1
+     imode=mode_list(2,k)
+     do m=0,sp_a%jcap
+        j=mmode2_list(m,imode)
+        ipe=mmode_list(5,j)
+        nsend(ipe)=nsend(ipe)+1
+        j=mmode2_list(m,-imode)
+        ipe=mmode_list(5,j)
+        nsend(ipe)=nsend(ipe)+1
+     end do
+  end do
+
+  ndsend(1)=0
+  do i=2,npe+1
+     ndsend(i)=ndsend(i-1)+nsend(i-1)
+  end do
+  nallsend=ndsend(npe+1)
+  allocate(info_send(6,nallsend))
+  nsend=0
+  ibad =0
+  do k=nlatm_0,nlatm_1
+     ilat=mode_list(1,k)
+     do loop=1,2
+        imode=mode_list(2,k)
+        if(loop == 2) imode=-mode_list(2,k)
+        do m=0,sp_a%jcap
+           j=mmode2_list(m,imode)
+           m1=mmode_list(1,j)
+           m2=mmode_list(2,j)
+           imode1=mmode_list(3,j)
+           imode2=mmode_list(4,j)
+           ipe=mmode_list(5,j)
+           ip12=0
+           if(m1 == m2.and.imode == imode1) ip12=1
+           if(m1 == m2.and.imode == imode2) ip12=2
+           if(imode1 == imode2.and.m == m1) ip12=1
+           if(imode1 == imode2.and.m == m2) ip12=2
+           if(ip12 == 0) ibad=ibad+1
+           ipe=mmode_list(5,j)
+           nsend(ipe)=nsend(ipe)+1
+           info_send(1,ndsend(ipe)+nsend(ipe))=k
+           info_send(2,ndsend(ipe)+nsend(ipe))=ilat
+           info_send(3,ndsend(ipe)+nsend(ipe))=imode
+           info_send(4,ndsend(ipe)+nsend(ipe))=m
+           info_send(5,ndsend(ipe)+nsend(ipe))=j
+           info_send(6,ndsend(ipe)+nsend(ipe))=ip12
+        end do
+     end do
+  end do
+
+  call mpi_allreduce(ibad,ibad0,1,mpi_integer4,mpi_sum,gsi_mpi_comm_world,ierror)
+  if(ibad0 >  0) then
+     if(mype == 0) write(0,*)' ibad = ',ibad0,'  inconsistency in inmi_coupler_ew2ns1'
+     call mpi_finalize(ierror)
+     stop
+  end if
+
+  call mpi_alltoall(nsend,1,mpi_integer4,nrecv,1,mpi_integer4,gsi_mpi_comm_world,ierror)
+  ndrecv(1)=0
+  do i=2,npe+1
+     ndrecv(i)=ndrecv(i-1)+nrecv(i-1)
+  end do
+  nallrecv=ndrecv(npe+1)
+  allocate(info_recv(6,nallrecv))
+  call mpi_type_contiguous(6,mpi_integer4,mpi_string1,ierror)
+  call mpi_type_commit(mpi_string1,ierror)
+  call mpi_alltoallv(info_send,nsend,ndsend,mpi_string1, &
+                     info_recv,nrecv,ndrecv,mpi_string1,gsi_mpi_comm_world,ierror)
+  call mpi_type_free(mpi_string1,ierror)
+
+end subroutine inmi_coupler_ew2ns1
+
+subroutine inmi_coupler_ew2ns(uvm_ewtrans,uvm_ns)
+
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    inmi_coupler_ew2ns
+!
+!   prgrmmr:
+!
+! abstract:
+!
+! program history log:
+!   2008-04-04  safford -- add subprogram doc block, rm unused vars and uses
+!   2010-03-31  treadon - replace specmod components with sp_a structure
+!
+!   input argument list:
+!     uvm_ewtrans -
+!
+!   output argument list:
+!     uvm_ns      -
+!
+! attributes:
+!   language:  f90
+!   machine:   ibm rs/6000 sp
+!
+!$$$
+
+  implicit none
+
+  real(r_kind),dimension(2,0:sp_a%jcap,2,3,nlatm_0:nlatm_1),intent(in   ) :: uvm_ewtrans
+  real(r_kind),dimension(3,2,nlat,2,m_0:m_1)          ,intent(  out) :: uvm_ns
+
+  integer(i_kind) ip12,j,m,mm,ilat,ilatm,imode,mpi_string1,loop
+  real(r_kind),allocatable,dimension(:,:,:)::sendbuf,recvbuf
+
+  allocate(sendbuf(3,2,nallsend))
+  do j=1,nallsend
+     ilatm=info_send(1,j)
+     imode=info_send(3,j)
+     m=info_send(4,j)
+     loop=1
+     if(imode <  0) loop=2
+     sendbuf(1,1,j)=uvm_ewtrans(1,m,loop,1,ilatm)
+     sendbuf(2,1,j)=uvm_ewtrans(1,m,loop,2,ilatm)
+     sendbuf(3,1,j)=uvm_ewtrans(1,m,loop,3,ilatm)
+     sendbuf(1,2,j)=uvm_ewtrans(2,m,loop,1,ilatm)
+     sendbuf(2,2,j)=uvm_ewtrans(2,m,loop,2,ilatm)
+     sendbuf(3,2,j)=uvm_ewtrans(2,m,loop,3,ilatm)
+  end do
+  allocate(recvbuf(3,2,nallrecv))
+  call mpi_type_contiguous(6,mpi_rtype,mpi_string1,ierror)
+  call mpi_type_commit(mpi_string1,ierror)
+  call mpi_alltoallv(sendbuf,nsend,ndsend,mpi_string1, &
+                     recvbuf,nrecv,ndrecv,mpi_string1,gsi_mpi_comm_world,ierror)
+  call mpi_type_free(mpi_string1,ierror)
+  deallocate(sendbuf)
+
+  do j=1,nallrecv
+     ilat=info_recv(2,j)
+     mm=info_recv(5,j)
+     ip12=info_recv(6,j)
+     uvm_ns(1,1,ilat,ip12,mm)=recvbuf(1,1,j)
+     uvm_ns(2,1,ilat,ip12,mm)=recvbuf(2,1,j)
+     uvm_ns(3,1,ilat,ip12,mm)=recvbuf(3,1,j)
+     uvm_ns(1,2,ilat,ip12,mm)=recvbuf(1,2,j)
+     uvm_ns(2,2,ilat,ip12,mm)=recvbuf(2,2,j)
+     uvm_ns(3,2,ilat,ip12,mm)=recvbuf(3,2,j)
+  end do
+  deallocate(recvbuf)
+
+end subroutine inmi_coupler_ew2ns
+
+subroutine inmi_coupler_ns2ew(uvm_ewtrans,uvm_ns)
+
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    inmi_coupler_ns2ew
+!
+!   prgrmmr:
+!
+! abstract:
+!
+! program history log:
+!   2008-04-04  safford -- add subprogram doc block, rm unused vars and uses
+!   2010-03-31  treadon - replace specmod jcap with sp_a structure
+!
+!   input argument list:
+!     uvm_ns   -
+!
+!   output argument list:
+!     uvm_ewtrans -
+!
+! attributes:
+!   language:  f90
+!   machine:   ibm rs/6000 sp
+!
+!$$$
+
+  implicit none
+
+  real(r_kind),dimension(2,0:sp_a%jcap,2,3,nlatm_0:nlatm_1),intent(  out) :: uvm_ewtrans
+  real(r_kind),dimension(3,2,nlat,2,m_0:m_1)          ,intent(in   ) :: uvm_ns
+
+  integer(i_kind) ip12,j,m,mm,ilat,ilatm,imode,mpi_string1,loop
+  real(r_kind),allocatable,dimension(:,:,:)::sendbuf,recvbuf
+
+
+  allocate(recvbuf(3,2,nallrecv))
+  do j=1,nallrecv
+     ilat=info_recv(2,j)
+     mm=info_recv(5,j)
+     ip12=info_recv(6,j)
+     recvbuf(1,1,j)=uvm_ns(1,1,ilat,ip12,mm)
+     recvbuf(2,1,j)=uvm_ns(2,1,ilat,ip12,mm)
+     recvbuf(3,1,j)=uvm_ns(3,1,ilat,ip12,mm)
+     recvbuf(1,2,j)=uvm_ns(1,2,ilat,ip12,mm)
+     recvbuf(2,2,j)=uvm_ns(2,2,ilat,ip12,mm)
+     recvbuf(3,2,j)=uvm_ns(3,2,ilat,ip12,mm)
+  end do
+  allocate(sendbuf(3,2,nallsend))
+  call mpi_type_contiguous(6,mpi_rtype,mpi_string1,ierror)
+  call mpi_type_commit(mpi_string1,ierror)
+  call mpi_alltoallv(recvbuf,nrecv,ndrecv,mpi_string1, &
+                     sendbuf,nsend,ndsend,mpi_string1,gsi_mpi_comm_world,ierror)
+  call mpi_type_free(mpi_string1,ierror)
+  deallocate(recvbuf)
+  do j=1,nallsend
+     ilatm=info_send(1,j)
+     imode=info_send(3,j)
+     m=info_send(4,j)
+     loop=1
+     if(imode <  0) loop=2
+     uvm_ewtrans(1,m,loop,1,ilatm)=sendbuf(1,1,j)
+     uvm_ewtrans(1,m,loop,2,ilatm)=sendbuf(2,1,j)
+     uvm_ewtrans(1,m,loop,3,ilatm)=sendbuf(3,1,j)
+     uvm_ewtrans(2,m,loop,1,ilatm)=sendbuf(1,2,j)
+     uvm_ewtrans(2,m,loop,2,ilatm)=sendbuf(2,2,j)
+     uvm_ewtrans(2,m,loop,3,ilatm)=sendbuf(3,2,j)
+  end do
+  deallocate(sendbuf)
+
+end subroutine inmi_coupler_ns2ew
+
+subroutine inmi_nsuvm2zdm(uvm_ns,zdm_hat)
+
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    inmi_nsuv2zdm
+!
+!   prgrmmr:
+!
+! abstract:
+!
+! program history log:
+!   2008-04-04  safford -- add subprogram doc block, rm unused uses
+!   2010-03-31  treadon - replace specmod components with sp_a structure
+!   2012-11-23  parrish - replace calls to spanaly_ns with inline code
+!
+!   input argument list:
+!     uvm_ns   -
+!
+!   output argument list:
+!     zdm_had  -
+!
+! attributes:
+!   language:  f90
+!   machine:   ibm rs/6000 sp
+!   machine:   ibm rs/6000 sp
+!
+!$$$
+
+  implicit none
+
+  real(r_kind),dimension(3,2,nlat,2,m_0:m_1),intent(in   ) :: uvm_ns
+  real(r_kind),dimension(3,2,nlat,2,m_0:m_1),intent(  out) :: zdm_hat
+
+  integer(i_kind) i,ics,j,jnorth,jsouth,m,mm,n,ipair
+  real(r_kind),dimension(2,0:sp_a%jcap):: spcz,spcd,spcp
+  real(r_kind),dimension(2,0:sp_a%jcap+1):: spcu,spcv
+  real(r_kind),dimension(0:sp_a%jcap+1):: plnloc
+  real(r_kind),dimension(2,2):: fu,fv,fp
+  real(r_kind) f11u,f21u,f12u,f22u
+  real(r_kind) f11v,f21v,f12v,f22v
+  real(r_kind) f11p,f21p,f12p,f22p
+  real(r_kind):: c1,c2
+
+!$omp parallel do  schedule(dynamic,1) private(mm,ipair,m,ics,i,n) &
+!$omp private(spcz,spcd,spcp,spcu,spcv,j,jnorth,jsouth,plnloc,fu,fv,fp,c1,c2) &
+!$omp private(f11u,f21u,f12u,f22u,f11v,f21v,f12v,f22v,f11p,f21p,f12p,f22p)
+  do mm=m_0,m_1
+     do ipair=1,2
+        m=mmode_list(ipair,mm)
+        ics=1+m*(2*sp_a%jcap+3-m)/2-m
+
+        do n=m,sp_a%jcap
+           spcp(1,n)=zero
+           spcp(2,n)=zero
+           spcu(1,n)=zero
+           spcu(2,n)=zero
+           spcv(1,n)=zero
+           spcv(2,n)=zero
+        end do
+        spcu(1,sp_a%jcap+1)=zero
+        spcu(2,sp_a%jcap+1)=zero
+        spcv(1,sp_a%jcap+1)=zero
+        spcv(2,sp_a%jcap+1)=zero
+
+        do j=sp_a%jb,sp_a%je
+           jsouth=1+j
+           jnorth=nlat-j
+
+           c1=sp_a%wlat(j)
+           c2=c1/sp_a%clat(j)
+           fu(1,1)=uvm_ns(1,1,jnorth,ipair,mm)*c2
+           fu(2,1)=uvm_ns(1,2,jnorth,ipair,mm)*c2
+           fu(1,2)=uvm_ns(1,1,jsouth,ipair,mm)*c2
+           fu(2,2)=uvm_ns(1,2,jsouth,ipair,mm)*c2
+           fv(1,1)=uvm_ns(2,1,jnorth,ipair,mm)*c2
+           fv(2,1)=uvm_ns(2,2,jnorth,ipair,mm)*c2
+           fv(1,2)=uvm_ns(2,1,jsouth,ipair,mm)*c2
+           fv(2,2)=uvm_ns(2,2,jsouth,ipair,mm)*c2
+           fp(1,1)=uvm_ns(3,1,jnorth,ipair,mm)*c1
+           fp(2,1)=uvm_ns(3,2,jnorth,ipair,mm)*c1
+           fp(1,2)=uvm_ns(3,1,jsouth,ipair,mm)*c1
+           fp(2,2)=uvm_ns(3,2,jsouth,ipair,mm)*c1
+!           create plnloc
+
+   
+           do n=m,sp_a%jcap
+              plnloc(n)=sp_a%pln(ics+n,j)
+           end do
+           plnloc(sp_a%jcap+1)=sp_a%plntop(m+1,j)
+ 
+           f11u=fu(1,1)+fu(1,2)
+           f21u=fu(2,1)+fu(2,2)
+           f12u=fu(1,1)-fu(1,2)
+           f22u=fu(2,1)-fu(2,2)
+           f11v=fv(1,1)+fv(1,2)
+           f21v=fv(2,1)+fv(2,2)
+           f12v=fv(1,1)-fv(1,2)
+           f22v=fv(2,1)-fv(2,2)
+           f11p=fp(1,1)+fp(1,2)
+           f21p=fp(2,1)+fp(2,2)
+           f12p=fp(1,1)-fp(1,2)
+           f22p=fp(2,1)-fp(2,2)
+           do n=m,sp_a%jcap+1,2
+              spcu(1,n)=spcu(1,n)+plnloc(n)*f11u
+              spcu(2,n)=spcu(2,n)+plnloc(n)*f21u
+              spcv(1,n)=spcv(1,n)+plnloc(n)*f11v
+              spcv(2,n)=spcv(2,n)+plnloc(n)*f21v
+           end do
+           do n=m+1,sp_a%jcap+1,2
+              spcu(1,n)=spcu(1,n)+plnloc(n)*f12u
+              spcu(2,n)=spcu(2,n)+plnloc(n)*f22u
+              spcv(1,n)=spcv(1,n)+plnloc(n)*f12v
+              spcv(2,n)=spcv(2,n)+plnloc(n)*f22v
+           end do
+           do n=m,sp_a%jcap,2
+              spcp(1,n)=spcp(1,n)+plnloc(n)*f11p
+              spcp(2,n)=spcp(2,n)+plnloc(n)*f21p
+           end do
+           do n=m+1,sp_a%jcap,2
+              spcp(1,n)=spcp(1,n)+plnloc(n)*f12p
+              spcp(2,n)=spcp(2,n)+plnloc(n)*f22p
+           end do
+
+        end do
+
+        call spuv2dz_ns(sp_a%jcap,m,ics, &
+                spcu(1,m),spcv(1,m),spcu(1,sp_a%jcap+1),spcv(1,sp_a%jcap+1),spcd(1,m),spcz(1,m))
+
+        i=0
+        do n=m,sp_a%jcap
+           i=i+1
+           zdm_hat(1,1,i,ipair,mm)=spcz(1,n)*sp_a%enn1(ics+n)
+           zdm_hat(1,2,i,ipair,mm)=spcz(2,n)*sp_a%enn1(ics+n)
+           zdm_hat(2,1,i,ipair,mm)=spcd(1,n)*sp_a%enn1(ics+n)
+           zdm_hat(2,2,i,ipair,mm)=spcd(2,n)*sp_a%enn1(ics+n)
+           zdm_hat(3,1,i,ipair,mm)=spcp(1,n)
+           zdm_hat(3,2,i,ipair,mm)=spcp(2,n)
+        end do
+
+     end do
+
+  end do
+
+end subroutine inmi_nsuvm2zdm
+
+subroutine inmi_nszdm2uvm_ad(uvm_ns,zdm_hat)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    inmi_nszdm2uvm_ad
+!
+!   prgrmmr:
+!
+! abstract:
+!
+! program history log:
+!   2008-04-04  safford -- add subprogram doc block, rm unused uses
+!   2010-03-31  treadon - replace specmod components with sp_a structure
+!   2012-11-23  parrish - replace calls to spanaly_ns with inline code
+!
+!   input argument list:
+!     uvm_ns   -
+!
+!   output argument list:
+!     zdm_had  -
+!
+! attributes:
+!   language:  f90
+!   machine:   ibm rs/6000 sp
+!
+!$$$
+
+  implicit none
+
+  real(r_kind),dimension(3,2,nlat,2,m_0:m_1),intent(in   ) :: uvm_ns
+  real(r_kind),dimension(3,2,nlat,2,m_0:m_1),intent(  out) :: zdm_hat
+
+  integer(i_kind) i,ics,j,jnorth,jsouth,m,mm,n,ipair
+  real(r_kind),dimension(3,2,nlat)::uvm_ns_temp
+  real(r_kind),dimension(2,0:sp_a%jcap):: spcz,spcd,spcp
+  real(r_kind),dimension(2,0:sp_a%jcap+1):: spcu,spcv
+  real(r_kind),dimension(0:sp_a%jcap+1):: plnloc
+  real(r_kind),dimension(2,2):: fu,fv,fp
+  real(r_kind) f11u,f21u,f12u,f22u
+  real(r_kind) f11v,f21v,f12v,f22v
+  real(r_kind) f11p,f21p,f12p,f22p
+  real(r_kind):: c1
+
+!$omp parallel do  schedule(dynamic,1) private(mm,ipair,m,ics,i,n) &
+!$omp private(spcz,spcd,spcp,spcu,spcv,j,jnorth,jsouth,plnloc,fu,fv,fp,c1,uvm_ns_temp) &
+!$omp private(f11u,f21u,f12u,f22u,f11v,f21v,f12v,f22v,f11p,f21p,f12p,f22p)
+  do mm=m_0,m_1
+     do ipair=1,2
+        m=mmode_list(ipair,mm)
+        ics=1+m*(2*sp_a%jcap+3-m)/2-m
+
+        do n=m,sp_a%jcap
+           spcp(1,n)=zero
+           spcp(2,n)=zero
+           spcu(1,n)=zero
+           spcu(2,n)=zero
+           spcv(1,n)=zero
+           spcv(2,n)=zero
+        end do
+        spcu(1,sp_a%jcap+1)=zero
+        spcu(2,sp_a%jcap+1)=zero
+        spcv(1,sp_a%jcap+1)=zero
+        spcv(2,sp_a%jcap+1)=zero
+
+!  adjoint of set pole values
+        uvm_ns_temp(:,:,:)=uvm_ns(:,:,:,ipair,mm)
+        if(m == 0) then
+           uvm_ns_temp(3,1,     2)=uvm_ns_temp(3,1,   1)+uvm_ns_temp(3,1,     2)
+           uvm_ns_temp(3,1,nlat-1)=uvm_ns_temp(3,1,nlat)+uvm_ns_temp(3,1,nlat-1)
+        else if(m == 1) then
+           uvm_ns_temp(1,1,     2)=uvm_ns_temp(1,1,   1)+uvm_ns_temp(1,1,     2)
+           uvm_ns_temp(1,2,     2)=uvm_ns_temp(1,2,   1)+uvm_ns_temp(1,2,     2)
+           uvm_ns_temp(2,1,     2)=uvm_ns_temp(2,1,   1)+uvm_ns_temp(2,1,     2)
+           uvm_ns_temp(2,2,     2)=uvm_ns_temp(2,2,   1)+uvm_ns_temp(2,2,     2)
+           uvm_ns_temp(1,1,nlat-1)=uvm_ns_temp(1,1,nlat)+uvm_ns_temp(1,1,nlat-1)
+           uvm_ns_temp(1,2,nlat-1)=uvm_ns_temp(1,2,nlat)+uvm_ns_temp(1,2,nlat-1)
+           uvm_ns_temp(2,1,nlat-1)=uvm_ns_temp(2,1,nlat)+uvm_ns_temp(2,1,nlat-1)
+           uvm_ns_temp(2,2,nlat-1)=uvm_ns_temp(2,2,nlat)+uvm_ns_temp(2,2,nlat-1)
+        end if
+
+        do j=sp_a%jb,sp_a%je
+           jsouth=1+j
+           jnorth=nlat-j
+
+           c1=one/sp_a%clat(j)
+           fu(1,1)=uvm_ns_temp(1,1,jnorth)*c1
+           fu(2,1)=uvm_ns_temp(1,2,jnorth)*c1
+           fu(1,2)=uvm_ns_temp(1,1,jsouth)*c1
+           fu(2,2)=uvm_ns_temp(1,2,jsouth)*c1
+           fv(1,1)=uvm_ns_temp(2,1,jnorth)*c1
+           fv(2,1)=uvm_ns_temp(2,2,jnorth)*c1
+           fv(1,2)=uvm_ns_temp(2,1,jsouth)*c1
+           fv(2,2)=uvm_ns_temp(2,2,jsouth)*c1
+           fp(1,1)=uvm_ns_temp(3,1,jnorth)
+           fp(2,1)=uvm_ns_temp(3,2,jnorth)
+           fp(1,2)=uvm_ns_temp(3,1,jsouth)
+           fp(2,2)=uvm_ns_temp(3,2,jsouth)
+
+!           create plnloc
+
+   
+           do n=m,sp_a%jcap
+              plnloc(n)=sp_a%pln(ics+n,j)
+           end do
+           plnloc(sp_a%jcap+1)=sp_a%plntop(m+1,j)
+
+           f11u=fu(1,1)+fu(1,2)
+           f21u=fu(2,1)+fu(2,2)
+           f12u=fu(1,1)-fu(1,2)
+           f22u=fu(2,1)-fu(2,2)
+           f11v=fv(1,1)+fv(1,2)
+           f21v=fv(2,1)+fv(2,2)
+           f12v=fv(1,1)-fv(1,2)
+           f22v=fv(2,1)-fv(2,2)
+           f11p=fp(1,1)+fp(1,2)
+           f21p=fp(2,1)+fp(2,2)
+           f12p=fp(1,1)-fp(1,2)
+           f22p=fp(2,1)-fp(2,2)
+           do n=m,sp_a%jcap+1,2
+              spcu(1,n)=spcu(1,n)+plnloc(n)*f11u
+              spcu(2,n)=spcu(2,n)+plnloc(n)*f21u
+              spcv(1,n)=spcv(1,n)+plnloc(n)*f11v
+              spcv(2,n)=spcv(2,n)+plnloc(n)*f21v
+           end do
+           do n=m+1,sp_a%jcap+1,2
+              spcu(1,n)=spcu(1,n)+plnloc(n)*f12u
+              spcu(2,n)=spcu(2,n)+plnloc(n)*f22u
+              spcv(1,n)=spcv(1,n)+plnloc(n)*f12v
+              spcv(2,n)=spcv(2,n)+plnloc(n)*f22v
+           end do
+           do n=m,sp_a%jcap,2
+              spcp(1,n)=spcp(1,n)+plnloc(n)*f11p
+              spcp(2,n)=spcp(2,n)+plnloc(n)*f21p
+           end do
+           do n=m+1,sp_a%jcap,2
+              spcp(1,n)=spcp(1,n)+plnloc(n)*f12p
+              spcp(2,n)=spcp(2,n)+plnloc(n)*f22p
+           end do
+
+        end do
+
+        call spuv2dz_ns(sp_a%jcap,m,ics, &
+                spcu(1,m),spcv(1,m),spcu(1,sp_a%jcap+1),spcv(1,sp_a%jcap+1),spcd(1,m),spcz(1,m))
+
+        i=0
+        if(m == 0) then
+           i=i+1
+           zdm_hat(1,1,i,ipair,mm)=zero
+           zdm_hat(1,2,i,ipair,mm)=zero
+           zdm_hat(2,1,i,ipair,mm)=zero
+           zdm_hat(2,2,i,ipair,mm)=zero
+           zdm_hat(3,1,i,ipair,mm)=spcp(1,0)
+           zdm_hat(3,2,i,ipair,mm)=spcp(2,0)
+        end if
+        do n=max(1,m),sp_a%jcap
+           i=i+1
+           zdm_hat(1,1,i,ipair,mm)=spcz(1,n)
+           zdm_hat(1,2,i,ipair,mm)=spcz(2,n)
+           zdm_hat(2,1,i,ipair,mm)=spcd(1,n)
+           zdm_hat(2,2,i,ipair,mm)=spcd(2,n)
+           zdm_hat(3,1,i,ipair,mm)=spcp(1,n)
+           zdm_hat(3,2,i,ipair,mm)=spcp(2,n)
+        end do
+
+     end do
+
+  end do
+
+end subroutine inmi_nszdm2uvm_ad
+
+subroutine inmi_nszdm2uvm(uvm_ns,zdm_hat)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    inmi_szdm2uvm
+!
+!   prgrmmr:
+!
+! abstract:
+!
+! program history log:
+!   2008-04-04  safford -- add subprogram doc block, rm unused uses
+!   2010-03-31  treadon - replace specmod components with sp_a structure
+!   2012-11-23  parrish - replace calls to spsynth_ns with inline code
+!
+!   input argument list:
+!     uvm_ns   -
+!
+!   output argument list:
+!     zdm_had  -
+!
+! attributes:
+!   language:  f90
+!   machine:   ibm rs/6000 sp
+!
+!$$$
+
+  implicit none
+
+  real(r_kind),dimension(3,2,nlat,2,m_0:m_1),intent(  out) :: uvm_ns
+  real(r_kind),dimension(3,2,nlat,2,m_0:m_1),intent(in   ) :: zdm_hat
+
+  integer(i_kind) i,ics,j,jnorth,jsouth,m,mm,n,ipair
+  real(r_kind),dimension(2,0:sp_a%jcap):: spcz,spcd,spcp
+  real(r_kind),dimension(2,0:sp_a%jcap+1):: spcu,spcv
+  real(r_kind),dimension(0:sp_a%jcap+1):: plnloc
+  real(r_kind),dimension(2,2):: fu,fv,fp
+  real(r_kind) f1ur,f1ui,f2ur,f2ui
+  real(r_kind) f1vr,f1vi,f2vr,f2vi
+  real(r_kind) f1pr,f1pi,f2pr,f2pi
+
+  real(r_kind):: c1
+
+!$omp parallel do  schedule(dynamic,1) private(mm,ipair,m,ics,i,n) &
+!$omp private(spcz,spcd,spcp,spcu,spcv,j,jnorth,jsouth,plnloc,fu,fv,fp,c1) &
+!$omp private(f1ur,f1ui,f2ur,f2ui,f1vr,f1vi,f2vr,f2vi,f1pr,f1pi,f2pr,f2pi)
+  do mm=m_0,m_1
+     do ipair=1,2
+        m=mmode_list(ipair,mm)
+        ics=1+m*(2*sp_a%jcap+3-m)/2-m
+
+!           gather up spcz, spcd, spcp
+
+        i=0
+        do n=m,sp_a%jcap
+           i=i+1
+           spcz(1,n)=zdm_hat(1,1,i,ipair,mm)
+           spcz(2,n)=zdm_hat(1,2,i,ipair,mm)
+           spcd(1,n)=zdm_hat(2,1,i,ipair,mm)
+           spcd(2,n)=zdm_hat(2,2,i,ipair,mm)
+           spcp(1,n)=zdm_hat(3,1,i,ipair,mm)
+           spcp(2,n)=zdm_hat(3,2,i,ipair,mm)
+        end do
+
+!           convert to spcu, spcv
+
+        call spdz2uv_ns(sp_a%jcap,m,ics, &
+                spcd(1,m),spcz(1,m),spcu(1,m),spcv(1,m),spcu(1,sp_a%jcap+1),spcv(1,sp_a%jcap+1))
+
+        do j=sp_a%jb,sp_a%je
+           jsouth=1+j
+           jnorth=nlat-j
+
+!           create plnloc
+
+           do n=m,sp_a%jcap
+              plnloc(n)=sp_a%pln(ics+n,j)
+           end do
+           plnloc(sp_a%jcap+1)=sp_a%plntop(m+1,j)
+ 
+!          obtain f
+
+! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!  zero out fourier coefficients.
+           f1ur=zero
+           f1ui=zero
+           f2ur=zero
+           f2ui=zero
+           f1vr=zero
+           f1vi=zero
+           f2vr=zero
+           f2vi=zero
+           f1pr=zero
+           f1pi=zero
+           f2pr=zero
+           f2pi=zero
+! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!  synthesis over finite latitude.
+!  for each zonal wavenumber, synthesize terms over total wavenumber.
+!  synthesize even and odd polynomials separately.
+           do n=m,sp_a%jcap+1,2
+              f1ur=f1ur+plnloc(n)*spcu(1,n)
+              f1ui=f1ui+plnloc(n)*spcu(2,n)
+              f1vr=f1vr+plnloc(n)*spcv(1,n)
+              f1vi=f1vi+plnloc(n)*spcv(2,n)
+           enddo
+           do n=m+1,sp_a%jcap+1,2
+              f2ur=f2ur+plnloc(n)*spcu(1,n)
+              f2ui=f2ui+plnloc(n)*spcu(2,n)
+              f2vr=f2vr+plnloc(n)*spcv(1,n)
+              f2vi=f2vi+plnloc(n)*spcv(2,n)
+           enddo
+           do n=m,sp_a%jcap,2
+              f1pr=f1pr+plnloc(n)*spcp(1,n)
+              f1pi=f1pi+plnloc(n)*spcp(2,n)
+           enddo
+           do n=m+1,sp_a%jcap,2
+              f2pr=f2pr+plnloc(n)*spcp(1,n)
+              f2pi=f2pi+plnloc(n)*spcp(2,n)
+           enddo
+!  separate fourier coefficients from each hemisphere.
+!  odd polynomials contribute negatively to the southern hemisphere.
+           fu(1,1)=f1ur+f2ur
+           fu(2,1)=f1ui+f2ui
+           fu(1,2)=f1ur-f2ur
+           fu(2,2)=f1ui-f2ui
+           fv(1,1)=f1vr+f2vr
+           fv(2,1)=f1vi+f2vi
+           fv(1,2)=f1vr-f2vr
+           fv(2,2)=f1vi-f2vi
+           fp(1,1)=f1pr+f2pr
+           fp(2,1)=f1pi+f2pi
+           fp(1,2)=f1pr-f2pr
+           fp(2,2)=f1pi-f2pi
+! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+!          scatter back to output pairs of lats
+ 
+           c1=one/sp_a%clat(j)
+           uvm_ns(1,1,jnorth,ipair,mm)=fu(1,1)*c1
+           uvm_ns(1,2,jnorth,ipair,mm)=fu(2,1)*c1
+           uvm_ns(1,1,jsouth,ipair,mm)=fu(1,2)*c1
+           uvm_ns(1,2,jsouth,ipair,mm)=fu(2,2)*c1
+           uvm_ns(2,1,jnorth,ipair,mm)=fv(1,1)*c1
+           uvm_ns(2,2,jnorth,ipair,mm)=fv(2,1)*c1
+           uvm_ns(2,1,jsouth,ipair,mm)=fv(1,2)*c1
+           uvm_ns(2,2,jsouth,ipair,mm)=fv(2,2)*c1
+           uvm_ns(3,1,jnorth,ipair,mm)=fp(1,1)
+           uvm_ns(3,2,jnorth,ipair,mm)=fp(2,1)
+           uvm_ns(3,1,jsouth,ipair,mm)=fp(1,2)
+           uvm_ns(3,2,jsouth,ipair,mm)=fp(2,2)
+
+        end do
+
+!  set pole values
+        if(m == 0) then
+           uvm_ns(1,1,1,ipair,mm)=zero
+           uvm_ns(1,2,1,ipair,mm)=zero
+           uvm_ns(2,1,1,ipair,mm)=zero
+           uvm_ns(2,2,1,ipair,mm)=zero
+           uvm_ns(3,1,1,ipair,mm)=uvm_ns(3,1,2,ipair,mm)
+           uvm_ns(3,2,1,ipair,mm)=zero
+           uvm_ns(1,1,nlat,ipair,mm)=zero
+           uvm_ns(1,2,nlat,ipair,mm)=zero
+           uvm_ns(2,1,nlat,ipair,mm)=zero
+           uvm_ns(2,2,nlat,ipair,mm)=zero
+           uvm_ns(3,1,nlat,ipair,mm)=uvm_ns(3,1,nlat-1,ipair,mm)
+           uvm_ns(3,2,nlat,ipair,mm)=zero
+        else if(m == 1) then
+           uvm_ns(1,1,1,ipair,mm)=uvm_ns(1,1,2,ipair,mm)
+           uvm_ns(1,2,1,ipair,mm)=uvm_ns(1,2,2,ipair,mm)
+           uvm_ns(2,1,1,ipair,mm)=uvm_ns(2,1,2,ipair,mm)
+           uvm_ns(2,2,1,ipair,mm)=uvm_ns(2,2,2,ipair,mm)
+           uvm_ns(3,1,1,ipair,mm)=zero
+           uvm_ns(3,2,1,ipair,mm)=zero
+           uvm_ns(1,1,nlat,ipair,mm)=uvm_ns(1,1,nlat-1,ipair,mm)
+           uvm_ns(1,2,nlat,ipair,mm)=uvm_ns(1,2,nlat-1,ipair,mm)
+           uvm_ns(2,1,nlat,ipair,mm)=uvm_ns(2,1,nlat-1,ipair,mm)
+           uvm_ns(2,2,nlat,ipair,mm)=uvm_ns(2,2,nlat-1,ipair,mm)
+           uvm_ns(3,1,nlat,ipair,mm)=zero
+           uvm_ns(3,2,nlat,ipair,mm)=zero
+        else
+           uvm_ns(1,1,1,ipair,mm)=zero
+           uvm_ns(1,2,1,ipair,mm)=zero
+           uvm_ns(2,1,1,ipair,mm)=zero
+           uvm_ns(2,2,1,ipair,mm)=zero
+           uvm_ns(3,1,1,ipair,mm)=zero
+           uvm_ns(3,2,1,ipair,mm)=zero
+           uvm_ns(1,1,nlat,ipair,mm)=zero
+           uvm_ns(1,2,nlat,ipair,mm)=zero
+           uvm_ns(2,1,nlat,ipair,mm)=zero
+           uvm_ns(2,2,nlat,ipair,mm)=zero
+           uvm_ns(3,1,nlat,ipair,mm)=zero
+           uvm_ns(3,2,nlat,ipair,mm)=zero
+        end if
+
+     end do
+
+  end do
+
+end subroutine inmi_nszdm2uvm
+
+subroutine inmi_nspcm_hat2pcm(pcm_ns,pcm_hat)
+
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    inmi_nspcm_hat2pcm
+!   prgmmr:
+!
+! abstract:
+!
+! program history log:
+!   2009-08-13  lueken - added subprogram doc block
+!   2010-03-31  treadon - replace specmod components with sp_a structure
+!   2012-11-23  parrish - replace calls to spsynth_ns with inline code
+!
+!   input argument list:
+!    pcm_hat
+!
+!   output argument list:
+!    pcm_ns
+!
+! attributes:
+!   language: f90
+!   machine:
+!
+!$$$ end documentation block
+
+  implicit none
+
+  real(r_kind),dimension(3,2,nlat,2,m_0:m_1),intent(  out) :: pcm_ns
+  real(r_kind),dimension(3,2,nlat,2,m_0:m_1),intent(in   ) :: pcm_hat
+
+  integer(i_kind) i,ics,j,jnorth,jsouth,m,mm,n,ipair
+  real(r_kind),dimension(2,0:sp_a%jcap):: spcp,spcc,spcm
+  real(r_kind),dimension(0:sp_a%jcap+1):: plnloc
+  real(r_kind),dimension(2,2):: fp,fc,fm
+  real(r_kind) f1pr,f1pi,f2pr,f2pi
+  real(r_kind) f1cr,f1ci,f2cr,f2ci
+  real(r_kind) f1mr,f1mi,f2mr,f2mi
+
+!$omp parallel do  schedule(dynamic,1) private(mm,ipair,m,ics,i,n) &
+!$omp private(spcc,spcm,spcp,j,jnorth,jsouth,plnloc,fc,fm,fp) &
+!$omp private(f1pr,f1pi,f2pr,f2pi,f1cr,f1ci,f2cr,f2ci,f1mr,f1mi,f2mr,f2mi)
+  do mm=m_0,m_1
+     do ipair=1,2
+        m=mmode_list(ipair,mm)
+        ics=1+m*(2*sp_a%jcap+3-m)/2-m
+
+!           gather up spcp, spcc, spcm
+
+        i=0
+        do n=m,sp_a%jcap
+           i=i+1
+           spcp(1,n)=pcm_hat(1,1,i,ipair,mm)
+           spcp(2,n)=pcm_hat(1,2,i,ipair,mm)
+           spcc(1,n)=pcm_hat(2,1,i,ipair,mm)
+           spcc(2,n)=pcm_hat(2,2,i,ipair,mm)
+           spcm(1,n)=pcm_hat(3,1,i,ipair,mm)
+           spcm(2,n)=pcm_hat(3,2,i,ipair,mm)
+        end do
+
+        do j=sp_a%jb,sp_a%je
+           jsouth=1+j
+           jnorth=nlat-j
+
+!           create plnloc
+
+           do n=m,sp_a%jcap
+              plnloc(n)=sp_a%pln(ics+n,j)
+           end do
+
+!          obtain f
+
+! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!  zero out fourier coefficients.
+           f1pr=zero
+           f1pi=zero
+           f2pr=zero
+           f2pi=zero
+           f1cr=zero
+           f1ci=zero
+           f2cr=zero
+           f2ci=zero
+           f1mr=zero
+           f1mi=zero
+           f2mr=zero
+           f2mi=zero
+! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!  synthesis over finite latitude.
+!  for each zonal wavenumber, synthesize terms over total wavenumber.
+!  synthesize even and odd polynomials separately.
+           do n=m,sp_a%jcap,2
+              f1pr=f1pr+plnloc(n)*spcp(1,n)
+              f1pi=f1pi+plnloc(n)*spcp(2,n)
+              f1cr=f1cr+plnloc(n)*spcc(1,n)
+              f1ci=f1ci+plnloc(n)*spcc(2,n)
+              f1mr=f1mr+plnloc(n)*spcm(1,n)
+              f1mi=f1mi+plnloc(n)*spcm(2,n)
+           enddo
+           do n=m+1,sp_a%jcap,2
+              f2pr=f2pr+plnloc(n)*spcp(1,n)
+              f2pi=f2pi+plnloc(n)*spcp(2,n)
+              f2cr=f2cr+plnloc(n)*spcc(1,n)
+              f2ci=f2ci+plnloc(n)*spcc(2,n)
+              f2mr=f2mr+plnloc(n)*spcm(1,n)
+              f2mi=f2mi+plnloc(n)*spcm(2,n)
+           enddo
+!  separate fourier coefficients from each hemisphere.
+!  odd polynomials contribute negatively to the southern hemisphere.
+           fp(1,1)=f1pr+f2pr
+           fp(2,1)=f1pi+f2pi
+           fp(1,2)=f1pr-f2pr
+           fp(2,2)=f1pi-f2pi
+           fc(1,1)=f1cr+f2cr
+           fc(2,1)=f1ci+f2ci
+           fc(1,2)=f1cr-f2cr
+           fc(2,2)=f1ci-f2ci
+           fm(1,1)=f1mr+f2mr
+           fm(2,1)=f1mi+f2mi
+           fm(1,2)=f1mr-f2mr
+           fm(2,2)=f1mi-f2mi
+
+!          scatter back to output pairs of lats
+
+           pcm_ns(1,1,jnorth,ipair,mm)=fp(1,1)
+           pcm_ns(1,2,jnorth,ipair,mm)=fp(2,1)
+           pcm_ns(1,1,jsouth,ipair,mm)=fp(1,2)
+           pcm_ns(1,2,jsouth,ipair,mm)=fp(2,2)
+           pcm_ns(2,1,jnorth,ipair,mm)=fc(1,1)
+           pcm_ns(2,2,jnorth,ipair,mm)=fc(2,1)
+           pcm_ns(2,1,jsouth,ipair,mm)=fc(1,2)
+           pcm_ns(2,2,jsouth,ipair,mm)=fc(2,2)
+           pcm_ns(3,1,jnorth,ipair,mm)=fm(1,1)
+           pcm_ns(3,2,jnorth,ipair,mm)=fm(2,1)
+           pcm_ns(3,1,jsouth,ipair,mm)=fm(1,2)
+           pcm_ns(3,2,jsouth,ipair,mm)=fm(2,2)
+ 
+        end do
+
+!  set pole values
+        if(m == 0) then
+           pcm_ns(1,1,1,ipair,mm)=pcm_ns(1,1,2,ipair,mm)
+           pcm_ns(1,2,1,ipair,mm)=zero
+           pcm_ns(1,1,nlat,ipair,mm)=pcm_ns(1,1,nlat-1,ipair,mm)
+           pcm_ns(1,2,nlat,ipair,mm)=zero
+           pcm_ns(2,1,1,ipair,mm)=pcm_ns(2,1,2,ipair,mm)
+           pcm_ns(2,2,1,ipair,mm)=zero
+           pcm_ns(2,1,nlat,ipair,mm)=pcm_ns(2,1,nlat-1,ipair,mm)
+           pcm_ns(2,2,nlat,ipair,mm)=zero
+           pcm_ns(3,1,1,ipair,mm)=pcm_ns(3,1,2,ipair,mm)
+           pcm_ns(3,2,1,ipair,mm)=zero
+           pcm_ns(3,1,nlat,ipair,mm)=pcm_ns(3,1,nlat-1,ipair,mm)
+           pcm_ns(3,2,nlat,ipair,mm)=zero
+        else
+           pcm_ns(1,1,1,ipair,mm)=zero
+           pcm_ns(1,2,1,ipair,mm)=zero
+           pcm_ns(2,1,1,ipair,mm)=zero
+           pcm_ns(2,2,1,ipair,mm)=zero
+           pcm_ns(3,1,1,ipair,mm)=zero
+           pcm_ns(3,2,1,ipair,mm)=zero
+           pcm_ns(1,1,nlat,ipair,mm)=zero
+           pcm_ns(1,2,nlat,ipair,mm)=zero
+           pcm_ns(2,1,nlat,ipair,mm)=zero
+           pcm_ns(2,2,nlat,ipair,mm)=zero
+           pcm_ns(3,1,nlat,ipair,mm)=zero
+           pcm_ns(3,2,nlat,ipair,mm)=zero
+        end if
+
+     end do
+
+  end do
+
+end subroutine inmi_nspcm_hat2pcm
+
+subroutine inmi_nspcm_hat2pcm_ad(pcm_ns,pcm_hat)
+
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    inmi_nspcm_hat2pcm_ad
+!   prgmmr:
+!
+! abstract:
+!
+! program history log:
+!   2009-08-13  lueken - added subprogram doc block
+!   2010-03-31  treadon - replace specmod components with sp_a structure
+!   2012-11-23  parrish - replace calls to spanaly_ns with inline code
+!
+!   input argument list:
+!    pcm_ns
+!
+!   output argument list:
+!    pcm_hat
+!
+! attributes:
+!   language: f90
+!   machine:
+!
+!$$$ end documentation block
+  implicit none
+
+  real(r_kind),dimension(3,2,nlat,2,m_0:m_1),intent(in   ) :: pcm_ns
+  real(r_kind),dimension(3,2,nlat,2,m_0:m_1),intent(  out) :: pcm_hat
+
+  real(r_kind),dimension(3,2,nlat)::pcm_ns_temp
+  integer(i_kind) i,ics,j,jnorth,jsouth,m,mm,n,ipair
+  real(r_kind),dimension(2,0:sp_a%jcap):: spcp,spcc,spcm
+  real(r_kind),dimension(0:sp_a%jcap+1):: plnloc
+  real(r_kind),dimension(2,2):: fp,fc,fm
+  real(r_kind) f11p,f21p,f12p,f22p
+  real(r_kind) f11c,f21c,f12c,f22c
+  real(r_kind) f11m,f21m,f12m,f22m
+
+  pcm_hat=zero
+!$omp parallel do  schedule(dynamic,1) private(mm,ipair,m,ics,i,n) &
+!$omp private(spcc,spcm,spcp,j,jnorth,jsouth,plnloc,fc,fm,fp,pcm_ns_temp) &
+!$omp private(f11p,f21p,f12p,f22p,f11c,f21c,f12c,f22c,f11m,f21m,f12m,f22m)
+  do mm=m_0,m_1
+     do ipair=1,2
+        m=mmode_list(ipair,mm)
+        ics=1+m*(2*sp_a%jcap+3-m)/2-m
+ 
+        do n=m,sp_a%jcap
+           spcp(1,n)=zero
+           spcp(2,n)=zero
+           spcc(1,n)=zero
+           spcc(2,n)=zero
+           spcm(1,n)=zero
+           spcm(2,n)=zero
+        end do
+
+!  adjoint of set pole values
+
+        pcm_ns_temp(:,:,:)=pcm_ns(:,:,:,ipair,mm)
+        if(m == 0) then
+           pcm_ns_temp(1,1,     2)=pcm_ns_temp(1,1,   1)+pcm_ns_temp(1,1,     2)
+           pcm_ns_temp(1,1,nlat-1)=pcm_ns_temp(1,1,nlat)+pcm_ns_temp(1,1,nlat-1)
+           pcm_ns_temp(2,1,     2)=pcm_ns_temp(2,1,   1)+pcm_ns_temp(2,1,     2)
+           pcm_ns_temp(2,1,nlat-1)=pcm_ns_temp(2,1,nlat)+pcm_ns_temp(2,1,nlat-1)
+           pcm_ns_temp(3,1,     2)=pcm_ns_temp(3,1,   1)+pcm_ns_temp(3,1,     2)
+           pcm_ns_temp(3,1,nlat-1)=pcm_ns_temp(3,1,nlat)+pcm_ns_temp(3,1,nlat-1)
+        end if
+
+        do j=sp_a%jb,sp_a%je
+           jsouth=1+j
+           jnorth=nlat-j
+ 
+!          adjoint of scatter back to output pairs of lats
+
+           fp(1,1)=pcm_ns_temp(1,1,jnorth)
+           fp(2,1)=pcm_ns_temp(1,2,jnorth)
+           fp(1,2)=pcm_ns_temp(1,1,jsouth)
+           fp(2,2)=pcm_ns_temp(1,2,jsouth)
+           fc(1,1)=pcm_ns_temp(2,1,jnorth)
+           fc(2,1)=pcm_ns_temp(2,2,jnorth)
+           fc(1,2)=pcm_ns_temp(2,1,jsouth)
+           fc(2,2)=pcm_ns_temp(2,2,jsouth)
+           fm(1,1)=pcm_ns_temp(3,1,jnorth)
+           fm(2,1)=pcm_ns_temp(3,2,jnorth)
+           fm(1,2)=pcm_ns_temp(3,1,jsouth)
+           fm(2,2)=pcm_ns_temp(3,2,jsouth)
+ 
+!           create plnloc
+
+           do n=m,sp_a%jcap
+              plnloc(n)=sp_a%pln(ics+n,j)
+           end do
+
+!          adjoint of obtain f
+
+           f11p=fp(1,1)+fp(1,2)
+           f21p=fp(2,1)+fp(2,2)
+           f12p=fp(1,1)-fp(1,2)
+           f22p=fp(2,1)-fp(2,2)
+           f11c=fc(1,1)+fc(1,2)
+           f21c=fc(2,1)+fc(2,2)
+           f12c=fc(1,1)-fc(1,2)
+           f22c=fc(2,1)-fc(2,2)
+           f11m=fm(1,1)+fm(1,2)
+           f21m=fm(2,1)+fm(2,2)
+           f12m=fm(1,1)-fm(1,2)
+           f22m=fm(2,1)-fm(2,2)
+           do n=m,sp_a%jcap,2
+              spcp(1,n)=spcp(1,n)+plnloc(n)*f11p
+              spcp(2,n)=spcp(2,n)+plnloc(n)*f21p
+              spcc(1,n)=spcc(1,n)+plnloc(n)*f11c
+              spcc(2,n)=spcc(2,n)+plnloc(n)*f21c
+              spcm(1,n)=spcm(1,n)+plnloc(n)*f11m
+              spcm(2,n)=spcm(2,n)+plnloc(n)*f21m
+           end do
+           do n=m+1,sp_a%jcap,2
+              spcp(1,n)=spcp(1,n)+plnloc(n)*f12p
+              spcp(2,n)=spcp(2,n)+plnloc(n)*f22p
+              spcc(1,n)=spcc(1,n)+plnloc(n)*f12c
+              spcc(2,n)=spcc(2,n)+plnloc(n)*f22c
+              spcm(1,n)=spcm(1,n)+plnloc(n)*f12m
+              spcm(2,n)=spcm(2,n)+plnloc(n)*f22m
+           end do
+ 
+        end do
+
+!       adjoint of gather up spcp, spcc, spcm
+
+        i=0
+        do n=m,sp_a%jcap
+           i=i+1
+           pcm_hat(1,1,i,ipair,mm)=spcp(1,n)
+           pcm_hat(1,2,i,ipair,mm)=spcp(2,n)
+           pcm_hat(2,1,i,ipair,mm)=spcc(1,n)
+           pcm_hat(2,2,i,ipair,mm)=spcc(2,n)
+           pcm_hat(3,1,i,ipair,mm)=spcm(1,n)
+           pcm_hat(3,2,i,ipair,mm)=spcm(2,n)
+        end do
+
+     end do
+
+  end do
+
+end subroutine inmi_nspcm_hat2pcm_ad
+
+subroutine inmi_nsuvm2zdm_ad(uvm_ns,zdm_hat)
+
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    inmi_nsuvm2zdm_ad
+!   prgmmr:
+!
+! abstract:
+!
+! program history log:
+!   2009-08-13  lueken - added subprogram doc block
+!   2010-03-31  treadon - replace specmod components with sp_a structure
+!   2012-11-23  parrish - replace calls to spsynth_ns with inline code
+!
+!   input argument list:
+!    uvm_ns
+!    zdm_hat
+!
+!   output argument list:
+!    uvm_ns
+!
+! attributes:
+!   language: f90
+!   machine:
+!
+!$$$ end documentation block
+
+  implicit none
+
+  real(r_kind),dimension(3,2,nlat,2,m_0:m_1),intent(inout) :: uvm_ns
+  real(r_kind),dimension(3,2,nlat,2,m_0:m_1),intent(in   ) :: zdm_hat
+
+  integer(i_kind) i,ics,j,jnorth,jsouth,m,mm,n,ipair
+  real(r_kind),dimension(2,0:sp_a%jcap):: spcz,spcd,spcp
+  real(r_kind),dimension(2,0:sp_a%jcap+1):: spcu,spcv
+  real(r_kind),dimension(0:sp_a%jcap+1):: plnloc
+  real(r_kind),dimension(2,2):: fu,fv,fp
+  real(r_kind) f1ur,f1ui,f2ur,f2ui
+  real(r_kind) f1vr,f1vi,f2vr,f2vi
+  real(r_kind) f1pr,f1pi,f2pr,f2pi
+
+  real(r_kind):: c1,c2
+
+!$omp parallel do  schedule(dynamic,1) private(mm,ipair,m,ics,i,n) &
+!$omp private(spcz,spcd,spcp,spcu,spcv,j,jnorth,jsouth,plnloc,fu,fv,fp,c1,c2) &
+!$omp private(f1ur,f1ui,f2ur,f2ui,f1vr,f1vi,f2vr,f2vi,f1pr,f1pi,f2pr,f2pi)
+  do mm=m_0,m_1
+     do ipair=1,2
+        m=mmode_list(ipair,mm)
+        ics=1+m*(2*sp_a%jcap+3-m)/2-m
+
+!           gather up spcz, spcd, spcp
+
+        i=0
+        do n=m,sp_a%jcap
+           i=i+1
+           spcz(1,n)=zdm_hat(1,1,i,ipair,mm)*sp_a%enn1(ics+n)
+           spcz(2,n)=zdm_hat(1,2,i,ipair,mm)*sp_a%enn1(ics+n)
+           spcd(1,n)=zdm_hat(2,1,i,ipair,mm)*sp_a%enn1(ics+n)
+           spcd(2,n)=zdm_hat(2,2,i,ipair,mm)*sp_a%enn1(ics+n)
+           spcp(1,n)=zdm_hat(3,1,i,ipair,mm)
+           spcp(2,n)=zdm_hat(3,2,i,ipair,mm)
+        end do
+
+!           convert to spcu, spcv
+
+        call spdz2uv_ns(sp_a%jcap,m,ics, &
+                spcd(1,m),spcz(1,m),spcu(1,m),spcv(1,m),spcu(1,sp_a%jcap+1),spcv(1,sp_a%jcap+1))
+
+        do j=sp_a%jb,sp_a%je
+           jsouth=1+j
+           jnorth=nlat-j
+ 
+!           create plnloc
+
+           do n=m,sp_a%jcap
+              plnloc(n)=sp_a%pln(ics+n,j)
+           end do
+           plnloc(sp_a%jcap+1)=sp_a%plntop(m+1,j)
+
+!          obtain f
+
+! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!  zero out fourier coefficients.
+           f1ur=zero
+           f1ui=zero
+           f2ur=zero
+           f2ui=zero
+           f1vr=zero
+           f1vi=zero
+           f2vr=zero
+           f2vi=zero
+           f1pr=zero
+           f1pi=zero
+           f2pr=zero
+           f2pi=zero
+! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!  synthesis over finite latitude.
+!  for each zonal wavenumber, synthesize terms over total wavenumber.
+!  synthesize even and odd polynomials separately.
+           do n=m,sp_a%jcap+1,2
+              f1ur=f1ur+plnloc(n)*spcu(1,n)
+              f1ui=f1ui+plnloc(n)*spcu(2,n)
+              f1vr=f1vr+plnloc(n)*spcv(1,n)
+              f1vi=f1vi+plnloc(n)*spcv(2,n)
+           enddo
+           do n=m+1,sp_a%jcap+1,2
+              f2ur=f2ur+plnloc(n)*spcu(1,n)
+              f2ui=f2ui+plnloc(n)*spcu(2,n)
+              f2vr=f2vr+plnloc(n)*spcv(1,n)
+              f2vi=f2vi+plnloc(n)*spcv(2,n)
+           enddo
+           do n=m,sp_a%jcap,2
+              f1pr=f1pr+plnloc(n)*spcp(1,n)
+              f1pi=f1pi+plnloc(n)*spcp(2,n)
+           enddo
+           do n=m+1,sp_a%jcap,2
+              f2pr=f2pr+plnloc(n)*spcp(1,n)
+              f2pi=f2pi+plnloc(n)*spcp(2,n)
+           enddo
+!  separate fourier coefficients from each hemisphere.
+!  odd polynomials contribute negatively to the southern hemisphere.
+           fu(1,1)=f1ur+f2ur
+           fu(2,1)=f1ui+f2ui
+           fu(1,2)=f1ur-f2ur
+           fu(2,2)=f1ui-f2ui
+           fv(1,1)=f1vr+f2vr
+           fv(2,1)=f1vi+f2vi
+           fv(1,2)=f1vr-f2vr
+           fv(2,2)=f1vi-f2vi
+           fp(1,1)=f1pr+f2pr
+           fp(2,1)=f1pi+f2pi
+           fp(1,2)=f1pr-f2pr
+           fp(2,2)=f1pi-f2pi
+
+!          scatter back to output pairs of lats
+
+           c1=sp_a%wlat(j)
+           c2=c1/sp_a%clat(j)
+           uvm_ns(1,1,jnorth,ipair,mm)=fu(1,1)*c2
+           uvm_ns(1,2,jnorth,ipair,mm)=fu(2,1)*c2
+           uvm_ns(1,1,jsouth,ipair,mm)=fu(1,2)*c2
+           uvm_ns(1,2,jsouth,ipair,mm)=fu(2,2)*c2
+           uvm_ns(2,1,jnorth,ipair,mm)=fv(1,1)*c2
+           uvm_ns(2,2,jnorth,ipair,mm)=fv(2,1)*c2
+           uvm_ns(2,1,jsouth,ipair,mm)=fv(1,2)*c2
+           uvm_ns(2,2,jsouth,ipair,mm)=fv(2,2)*c2
+           uvm_ns(3,1,jnorth,ipair,mm)=fp(1,1)*c1
+           uvm_ns(3,2,jnorth,ipair,mm)=fp(2,1)*c1
+           uvm_ns(3,1,jsouth,ipair,mm)=fp(1,2)*c1
+           uvm_ns(3,2,jsouth,ipair,mm)=fp(2,2)*c1
+
+        end do
+
+     end do
+
+  end do
+
+end subroutine inmi_nsuvm2zdm_ad
+      subroutine spdz2uv_ns(m,l,ics,d,z,u,v,utop,vtop)
+!$$$  subprogram documentation block
+!
+! subprogram:    spdz2uv_ns  compute winds from div and vort for one zonal wave number
+!   prgmmr: iredell          org: w/nmc23     date: 92-10-31
+!
+! abstract: computes the wind components from divergence and vorticity
+!           in spectral space.
+!           subprogram speps should be called already.
+!           if l is the zonal wavenumber, n is the total wavenumber,
+!           eps(l,n)=sqrt((n**2-l**2)/(4*n**2-1)) and a is earth radius,
+!           then the zonal wind component u is computed as
+!             u(l,n)=-i*l/(n*(n+1))*a*d(l,n)
+!                    +eps(l,n+1)/(n+1)*a*z(l,n+1)-eps(l,n)/n*a*z(l,n-1)
+!           and the meridional wind component v is computed as
+!             v(l,n)=-i*l/(n*(n+1))*a*z(l,n)
+!                    -eps(l,n+1)/(n+1)*a*d(l,n+1)+eps(l,n)/n*a*d(l,n-1)
+!           where d is divergence and z is vorticity.
+!           u and v are weighted by the cosine of latitude.
+!           extra terms are computed over top of the spectral domain.
+!           advantage is taken of the fact that eps(l,l)=0
+!           in order to vectorize over the entire spectral domain.
+!           triangular truncation only
+!
+! program history log:
+!   91-10-31  mark iredell
+!   2006-09-05 parrish -- modify to do one zonal wave number only for parallel
+!                         computation across processors by zonal wave number.
+!   2010-05-14 derber  - make triangular truncation only
+!
+! usage:    call spdz2uv_ns(m,l,elonn1,eon,eontop,d,z,u,v,utop,vtop)
+!
+!   input argument list:
+!     m        - integer spectral truncation
+!     l        - zonal wave number
+!     ics      - starting point is full spectral array
+!     d        - real (2,l:m) divergence for zonal wave number l
+!     z        - real (2,l:m) vorticity for zonal wave number l
+!
+!   output argument list:
+!     u        - real (2,l:m) zonal wind (times coslat) for zonal wave number l
+!     v        - real (2,l:m) merid wind (times coslat) for zonal wave number l
+!     utop     - real (2) zonal wind (times coslat) over top for zonal wave number l
+!     vtop     - real (2) merid wind (times coslat) over top for zonal wave number l
+!
+! attributes:
+!   language: cray fortran
+!
+!$$$
+      implicit none
+
+      integer(i_kind),intent(in   ) :: m,l,ics
+      real(r_kind)   ,intent(in   ) :: d(2,l:m),z(2,l:m)
+      real(r_kind)   ,intent(  out) :: u(2,l:m),v(2,l:m)
+      real(r_kind)   ,intent(  out) :: utop(2),vtop(2)
+
+      integer(i_kind) n
+! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!  compute winds in the spectral domain
+
+      do n=l,m
+         u(1,n)= sp_a%elonn1(ics+n)*d(2,n)
+         u(2,n)=-sp_a%elonn1(ics+n)*d(1,n)
+         v(1,n)= sp_a%elonn1(ics+n)*z(2,n)
+         v(2,n)=-sp_a%elonn1(ics+n)*z(1,n)
+      end do
+      do n=l,m-1
+         u(1,n)=u(1,n)+sp_a%eon(ics+n+1)*z(1,n+1)
+         u(2,n)=u(2,n)+sp_a%eon(ics+n+1)*z(2,n+1)
+         v(1,n)=v(1,n)-sp_a%eon(ics+n+1)*d(1,n+1)
+         v(2,n)=v(2,n)-sp_a%eon(ics+n+1)*d(2,n+1)
+      end do
+      do n=l+1,m
+         u(1,n)=u(1,n)-sp_a%eon(ics+n)*z(1,n-1)
+         u(2,n)=u(2,n)-sp_a%eon(ics+n)*z(2,n-1)
+         v(1,n)=v(1,n)+sp_a%eon(ics+n)*d(1,n-1)
+         v(2,n)=v(2,n)+sp_a%eon(ics+n)*d(2,n-1)
+      end do
+! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!  compute winds over top of the spectral domain
+      utop(1)=-sp_a%eontop(l+1)*z(1,m)
+      utop(2)=-sp_a%eontop(l+1)*z(2,m)
+      vtop(1)= sp_a%eontop(l+1)*d(1,m)
+      vtop(2)= sp_a%eontop(l+1)*d(2,m)
+! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+      return
+      end subroutine spdz2uv_ns
+!-----------------------------------------------------------------------
+      subroutine spuv2dz_ns(m,l,ics,u,v,utop,vtop,d,z)
+!$$$  subprogram documentation block
+!
+! subprogram:    spuv2dz_ns  compute div,vort from winds for one zonal wave number
+!   prgmmr: iredell          org: w/nmc23     date: 92-10-31
+!
+! abstract: computes the divergence and vorticity from wind components
+!           in spectral space.
+!           subprogram speps should be called already.
+!           if l is the zonal wavenumber, n is the total wavenumber,
+!           eps(l,n)=sqrt((n**2-l**2)/(4*n**2-1)) and a is earth radius,
+!           then the divergence d is computed as
+!             d(l,n)=i*l*a*u(l,n)
+!                    +eps(l,n+1)*n*a*v(l,n+1)-eps(l,n)*(n+1)*a*v(l,n-1)
+!           and the vorticity z is computed as
+!             z(l,n)=i*l*a*v(l,n)
+!                    -eps(l,n+1)*n*a*u(l,n+1)+eps(l,n)*(n+1)*a*u(l,n-1)
+!           where u is the zonal wind and v is the meridional wind.
+!           u and v are weighted by the secant of latitude.
+!           extra terms are used over top of the spectral domain.
+!           advantage is taken of the fact that eps(l,l)=0
+!           in order to vectorize over the entire spectral domain.
+!           triangular truncation only
+!
+! program history log:
+!   91-10-31  mark iredell
+!   2006-09-05 parrish -- modify to do one zonal wave number only for parallel
+!                         computation across processors by zonal wave number.
+!   2010-05-14 derber  - triangular truncation only
+!
+! usage:    call spuv2dz_ns(m,l,ics,u,v,utop,vtop,d,z)
+!
+!   input argument list:
+!     l        - zonal wave number
+!     m        - integer spectral truncation
+!     ics      - starting point is full spectral array
+!     u        - real (2,l:m) zonal wind (over coslat)
+!     v        - real (2,l:m) merid wind (over coslat)
+!     utop     - real (2) zonal wind (over coslat) over top
+!     vtop     - real (2) merid wind (over coslat) over top
+!
+!   output argument list:
+!     d        - real (2,l:m) divergence
+!     z        - real (2,l:m) vorticity
+!
+! attributes:
+!   language: cray fortran
+!
+!$$$
+      implicit none
+
+      integer(i_kind),intent(in   ) :: m,l,ics
+      real(r_kind)   ,intent(in   ) :: u(2,l:m),v(2,l:m)
+      real(r_kind)   ,intent(in   ) :: utop(2),vtop(2)
+      real(r_kind)   ,intent(  out) :: d(2,l:m),z(2,l:m)
+
+      integer(i_kind) n
+! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!  compute terms from the spectral domain
+
+      do n=l,m
+         d(1,n)=-sp_a%elonn1(ics+n)*u(2,n)
+         d(2,n)= sp_a%elonn1(ics+n)*u(1,n)
+         z(1,n)=-sp_a%elonn1(ics+n)*v(2,n)
+         z(2,n)= sp_a%elonn1(ics+n)*v(1,n)
+      end do
+      do n=l,m-1
+         d(1,n)=d(1,n)+sp_a%eon(ics+n+1)*v(1,n+1)
+         d(2,n)=d(2,n)+sp_a%eon(ics+n+1)*v(2,n+1)
+         z(1,n)=z(1,n)-sp_a%eon(ics+n+1)*u(1,n+1)
+         z(2,n)=z(2,n)-sp_a%eon(ics+n+1)*u(2,n+1)
+      end do
+      do n=l+1,m
+         d(1,n)=d(1,n)-sp_a%eon(ics+n)*v(1,n-1)
+         d(2,n)=d(2,n)-sp_a%eon(ics+n)*v(2,n-1)
+         z(1,n)=z(1,n)+sp_a%eon(ics+n)*u(1,n-1)
+         z(2,n)=z(2,n)+sp_a%eon(ics+n)*u(2,n-1)
+      end do
+
+!  compute terms from over top of the spectral domain
+      n=m
+      d(1,n)=d(1,n)+sp_a%eontop(l+1)*vtop(1)
+      d(2,n)=d(2,n)+sp_a%eontop(l+1)*vtop(2)
+      z(1,n)=z(1,n)-sp_a%eontop(l+1)*utop(1)
+      z(2,n)=z(2,n)-sp_a%eontop(l+1)*utop(2)
+
+      return
+      end subroutine spuv2dz_ns
+
+end module strong_fast_global_mod

--- a/src/gsibec/gsi/strong_fast_global_mod.f90
+++ b/src/gsibec/gsi/strong_fast_global_mod.f90
@@ -101,6 +101,7 @@ module strong_fast_global_mod
   integer(i_kind),allocatable,dimension(:,:)::info_send_ew2sd,info_recv_ew2sd
   integer(i_kind),allocatable,dimension(:,:)::info_send,info_recv
 
+  logical, save :: initialized_ = .false.
 contains
 
 subroutine init_strongvars(mype)
@@ -131,6 +132,7 @@ subroutine init_strongvars(mype)
 
   integer(i_kind),intent(in   ) :: mype
 
+  if(initialized_) return
   allocate(mode_list(3,nlat*nvmodes_keep),mmode_list(5,(sp_a%jcap+1)*nvmodes_keep))
   call inmi_coupler_sd2ew0(mype)
   call inmi_coupler_ew2ns0(mype)
@@ -138,6 +140,7 @@ subroutine init_strongvars(mype)
   call inmi_coupler_sd2ew1(mype)
   call inmi_coupler_ew2ns1(mype)
   call inmi_coupler_ew2sd1(mype)
+  initialized_ = .true.
 
   return
 end subroutine init_strongvars

--- a/src/gsibec/gsi/turbl_ad.f90
+++ b/src/gsibec/gsi/turbl_ad.f90
@@ -1,0 +1,324 @@
+subroutine turbl_ad(pges,tges,oges,u,v,prs,t,termu,termv,termt,jstart,jstop)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    turbl_ad
+!
+!   prgrmmr:
+!
+! abstract:      Adjoint of turbl_tl
+!
+! program history log:
+!   2008-04-02  safford -- add subprogram doc block, rm unused vars and uses
+!
+!   input argument list:
+!     pges     -
+!     tges     -
+!     oges     -
+!     prs      -
+!     t        -
+!     u        -
+!     v        -
+!     termu    -
+!     termv    -
+!     termt    -
+!
+!   output argument list:
+!     prs      -
+!     t        -
+!     u        -
+!     v        -
+!     termu    -
+!     termv    -
+!     termt    -
+!
+! attributes:
+!   language:  f90
+!   machine:
+!
+!$$$
+
+  use constants, only: rd_over_cp,two,rd_over_g,half,zero,one,three,grav
+  use m_kinds, only: r_kind,i_kind 
+  use gridmod, only: lat2,lon2,nsig,nsig_hlf
+  use turblmod, only: use_pbl
+  use turblmod, only: dudz,dvdz,dodz,ri,rf,kar0my20,zi,km,kh,sm,sh
+  use turblmod, only: lmix,dudtm,dvdtm,dtdtm,rdzi,rdzl
+  use turblmod, only: a0my20,c0my20,d0my20, &
+                      f7my20,f8my20,karmy20
+  use turblmod, only: eps_m
+  use turblmod, only: fsm_my20,fsh_my20
+  use turblmod, only: ri_int
+  implicit none
+
+
+! Declare passed variables
+  real(r_kind),dimension(lat2,lon2,nsig+1),intent(in   ) :: pges
+  real(r_kind),dimension(lat2,lon2,nsig)  ,intent(in   ) :: tges,oges
+  real(r_kind),dimension(lat2,lon2,nsig+1),intent(inout) :: prs
+  real(r_kind),dimension(lat2,lon2,nsig)  ,intent(inout) :: t,u,v
+  real(r_kind),dimension(lat2,lon2,nsig)  ,intent(inout) :: termu,termv,termt
+  integer(i_kind)                         ,intent(in   ) :: jstart,jstop
+
+! Declare local variables
+  real(r_kind),dimension(nsig_hlf):: t_bck,o_bck
+  real(r_kind),dimension(nsig_hlf):: dudz_bck,dvdz_bck,dodz_bck,ri_bck,rf_bck
+  real(r_kind),dimension(nsig_hlf):: rdudz_bck,rdvdz_bck,sm_bck,sh_bck
+  real(r_kind),dimension(nsig_hlf):: rdzl_bck,rdzi_bck,t_tl,u_tl,v_tl,o_tl,dzi_tl,zl_tl
+  real(r_kind),dimension(nsig_hlf):: rssq,rofbck,rshbck
+  real(r_kind),dimension(nsig_hlf+1):: km_bck,kh_bck,p_bck,zi_bck
+  real(r_kind),dimension(nsig_hlf+1):: km_tl,kh_tl,p_tl,zi_tl
+  real(r_kind),dimension(2:nsig_hlf):: dzl_tl,dodz_tl,dudz_tl,dvdz_tl,ri_tl
+  real(r_kind),dimension(2:nsig_hlf):: rf_tl,sh_tl,sm_tl,lmix_tl
+  integer(i_kind),dimension(nsig_hlf):: lssq
+  real(r_kind):: px,rpx,a1,a2,ax,bx,ssq,rtbck
+  real(r_kind):: alph,beta,gamm,gam1,gam2,alph1,alph2,delt,bet
+  real(r_kind):: rdzibk,rdzlbk,kmbk,khbk,rpbck,hrdzbk,ardzbk
+  real(r_kind):: kmaz_bck,khaz_bck,kmaz_tl,khaz_tl
+  integer(i_kind) i,j,k
+
+  if(.not. use_pbl)return
+
+  do i=1,lat2
+     do j=jstart,jstop
+
+! background fields
+        do k=1,nsig_hlf
+           t_bck(k)=tges(i,j,k)
+           p_bck(k)=pges(i,j,k)
+           o_bck(k)=oges(i,j,k)
+           rdzi_bck(k)=rdzi(i,j,k)
+           rdzl_bck(k)=rdzl(i,j,k)
+           zi_bck(k)=zi(i,j,k)
+        end do
+        p_bck(nsig_hlf+1) =pges(i,j,nsig_hlf+1)
+        zi_bck(nsig_hlf+1)=zi  (i,j,nsig_hlf+1)
+
+        do k=1,nsig_hlf
+           dodz_bck(k)=dodz(i,j,k)
+           dudz_bck(k)=dudz(i,j,k)
+           dvdz_bck(k)=dvdz(i,j,k)
+           ri_bck(k)=ri(i,j,k)
+           rf_bck(k)=rf(i,j,k)
+           sm_bck(k)=sm(i,j,k)
+           sh_bck(k)=sh(i,j,k)
+           km_bck(k)=km(i,j,k)
+           kh_bck(k)=kh(i,j,k)
+        end do
+        km_bck(nsig_hlf+1)=zero
+        kh_bck(nsig_hlf+1)=zero
+
+        do k=2,nsig_hlf
+           ssq=dudz_bck(k)**2+dvdz_bck(k)**2
+           lssq(k)=1
+           if(ssq < eps_m) then
+              lssq(k)=0
+              ssq = eps_m
+           end if
+           rssq(k)=one/ssq
+           rdudz_bck(k)=dudz_bck(k)*rssq(k)
+           rdvdz_bck(k)=dvdz_bck(k)*rssq(k)
+           rofbck(k)=one/(one-rf_bck(k))
+           rshbck(k)=one/sh_bck(k)
+        end do 
+
+! initialize perturbations
+
+        do k=nsig_hlf,2,-1
+           dzl_tl(k)=zero
+           lmix_tl(k)=zero
+           sm_tl(k)=zero; sh_tl(k)=zero
+           ri_tl(k)=zero; rf_tl(k)=zero
+           dudz_tl(k)=zero; dvdz_tl(k)=zero; dodz_tl(k)=zero
+        enddo
+        do k=nsig_hlf,1,-1
+           dzi_tl(k)=zero
+           zi_tl(k)=zero;   zl_tl(k)=zero
+           km_tl(k)=zero; kh_tl(k)=zero
+           t_tl(k)=zero
+           o_tl(k)=zero; u_tl(k)=zero; v_tl(k)=zero; p_tl(k)=zero
+        end do
+        p_tl(nsig_hlf+1)=zero; zi_tl(nsig_hlf+1)=zero
+        km_tl(nsig_hlf+1)=zero; kh_tl(nsig_hlf+1)=zero
+
+        
+! adjoint of update of perturbation tendencies
+
+        do k=nsig_hlf,1,-1
+           kmaz_tl=zero
+           khaz_tl=zero
+           rdzibk=rdzi_bck(k)
+           ax=t_bck(k)/o_bck(k)
+           hrdzbk=half*rdzibk
+           ardzbk=ax*hrdzbk
+           kmaz_bck=(km_bck(k)+km_bck(k+1))*hrdzbk
+           khaz_bck=(kh_bck(k)+kh_bck(k+1))*ardzbk
+           if(k>1) then
+              kmaz_tl=-dudz_bck(k)*termu(i,j,k)-dvdz_bck(k)*termv(i,j,k)
+              khaz_tl=-dodz_bck(k)*termt(i,j,k)
+              dudz_tl(k)=-kmaz_bck*termu(i,j,k)
+              dvdz_tl(k)=-kmaz_bck*termv(i,j,k)
+              dodz_tl(k)=-khaz_bck*termt(i,j,k)
+           end if
+           if(k<nsig_hlf) then
+              kmaz_tl= dudz_bck(k+1)*termu(i,j,k)+dvdz_bck(k+1)*termv(i,j,k)+kmaz_tl
+              khaz_tl= dodz_bck(k+1)*termt(i,j,k)+khaz_tl
+              dudz_tl(k+1)= kmaz_bck*termu(i,j,k)+dudz_tl(k+1)
+              dvdz_tl(k+1)= kmaz_bck*termv(i,j,k)+dvdz_tl(k+1)
+              dodz_tl(k+1)= khaz_bck*termt(i,j,k)+dodz_tl(k+1)
+           end if
+           dzi_tl(k)= -rdzibk*(dudtm(i,j,k)*termu(i,j,k)+&
+                               dvdtm(i,j,k)*termv(i,j,k)+&
+                               dtdtm(i,j,k)*termt(i,j,k) )
+           if(k>1) then
+              km_tl(k)  =hrdzbk*kmaz_tl
+              kh_tl(k)  =ardzbk*khaz_tl
+           end if
+           if(k<nsig_hlf) then
+              km_tl(k+1)=hrdzbk*kmaz_tl+km_tl(k+1)
+              kh_tl(k+1)=ardzbk*khaz_tl+kh_tl(k+1)
+           end if
+        end do
+
+
+! adjoint of perturbation of km and kh
+
+        do k=nsig_hlf,2,-1
+           kmbk=km_bck(k)
+           khbk=kh_bck(k)
+           if(ri_int(i,j,k)==1) then
+              km_tl(k)=zero
+              kh_tl(k)=zero
+           end if
+           bx=half/sm_bck(k)
+           bet=-half*rofbck(k)
+           ax=two/lmix(i,j,k)
+           delt= kmbk*ax
+           gam1= kmbk*rdudz_bck(k)
+           gam2= kmbk*rdvdz_bck(k)
+           beta= kmbk*bet
+           alph= kmbk*three*bx
+           sm_tl(k)  =km_tl(k)*alph  
+           rf_tl(k)  =km_tl(k)*beta  
+           dudz_tl(k)=km_tl(k)*gam1+dudz_tl(k)
+           dvdz_tl(k)=km_tl(k)*gam2+dvdz_tl(k)
+           lmix_tl(k)=km_tl(k)*delt          
+ 
+           delt= khbk*ax
+           gam1= khbk*rdudz_bck(k)
+           gam2= khbk*rdvdz_bck(k)
+           beta= khbk*bet
+           alph2=khbk*rshbck(k)
+           alph= khbk *bx
+           sh_tl(k)  =kh_tl(k)*alph2  
+           sm_tl(k)  =kh_tl(k)*alph+sm_tl(k)
+           rf_tl(k)  =kh_tl(k)*beta+rf_tl(k)
+           dudz_tl(k)=kh_tl(k)*gam1+dudz_tl(k)
+           dvdz_tl(k)=kh_tl(k)*gam2+dvdz_tl(k)
+           lmix_tl(k)=kh_tl(k)*delt+lmix_tl(k)      
+        end do
+
+
+! adjoint of perturbation of flux Richardson number, sh, sm and lmix
+
+        do k=nsig_hlf,2,-1
+           zi_tl(k)=karmy20/(one+kar0my20(i,j)*(zi_bck(k)-zi_bck(1)))**2 *lmix_tl(k)  
+           if(ri_int(i,j,k)==1) then
+              sh_tl(k)=zero
+              rf_tl(k)=zero
+              sm_tl(k)=zero
+           end if 
+           sh_tl(k)=sh_tl(k)+sm_bck(k)*rshbck(k)           *sm_tl(k) 
+           rf_tl(k)=rf_tl(k)+fsm_my20*sh_bck(k)   &     
+                            /(f7my20-f8my20*rf_bck(k))**2  *sm_tl(k) &
+                            +fsh_my20*rofbck(k)**2         *sh_tl(k)
+           ri_tl(k)=        a0my20*(one-(two*ri_bck(k)-c0my20)/ &
+                   (two*sqrt(ri_bck(k)*(ri_bck(k)-c0my20)+d0my20))) *rf_tl(k)
+        end do
+
+
+! adjoint of perturbation of Richardson number
+
+        do k=nsig_hlf,2,-1
+           if(ri_int(i,j,k)==1) ri_tl(k) = zero
+           rtbck=one/(t_bck(k)+t_bck(k-1))
+           alph=-ri_bck(k)*two*lssq(k)
+           alph1=alph*rdudz_bck(k)
+           alph2=alph*rdvdz_bck(k)
+           beta= grav*rssq(k)*rtbck*two
+           gamm=-ri_bck(k)*rtbck
+           dudz_tl(k)=ri_tl(k)*alph1 + dudz_tl(k)
+           dvdz_tl(k)=ri_tl(k)*alph2 + dvdz_tl(k)
+           dodz_tl(k)=ri_tl(k)*beta  + dodz_tl(k)
+           t_tl(k)   =ri_tl(k)*gamm  + t_tl(k)
+           t_tl(k-1) =ri_tl(k)*gamm 
+        end do
+
+
+! adjoint of perturbation of vertical derivatives
+
+
+        do k=nsig_hlf,2,-1
+           rdzlbk=rdzl_bck(k)
+           o_tl(k  )=o_tl(k  )+rdzlbk*dodz_tl(k)
+           o_tl(k-1)=         -rdzlbk*dodz_tl(k)
+           v_tl(k  )=v_tl(k  )+rdzlbk*dvdz_tl(k)
+           v_tl(k-1)=         -rdzlbk*dvdz_tl(k)
+           u_tl(k  )=u_tl(k  )+rdzlbk*dudz_tl(k)
+           u_tl(k-1)=         -rdzlbk*dudz_tl(k)
+           dzl_tl(k)=         -rdzlbk*dvdz_bck(k)*dvdz_tl(k) &
+                              -rdzlbk*dodz_bck(k)*dodz_tl(k) &
+                              -rdzlbk*dudz_bck(k)*dudz_tl(k)
+        end do
+
+
+! adjoint of perturbation of heights
+
+        do k=nsig_hlf,2,-1
+           zl_tl(k  )=+dzl_tl(k)+zl_tl(k  )
+           zl_tl(k-1)=-dzl_tl(k) !+zl_tl(k-1)
+        end do
+
+        do k=nsig_hlf,1,-1
+           zi_tl(k+1)=zl_tl(k)*half  + zi_tl(k+1)
+           zi_tl(k     )=zl_tl(k)*half  + zi_tl(k  )
+        end do
+
+        do k=nsig_hlf,1,-1
+           zi_tl(k) =zi_tl(k+1)+zi_tl(k)
+           dzi_tl(k)=zi_tl(k+1)+dzi_tl(k)
+        end do
+        zi_tl(1)=zero    
+
+
+! adjoint of perturbation fields
+
+        do k=nsig_hlf,1,-1
+           rpbck=one/(p_bck(k)+p_bck(k+1))
+           rpx = two*rpbck
+           a1 = rd_over_g*rpx
+           a2 = a1*t_bck(k)*rpx
+           gamm=-a1*(p_bck(k+1)-p_bck(k))
+           beta=-a2*p_bck(k)
+           alph= a2*p_bck(k+1)
+           px=rd_over_cp*rpbck
+           alph1=o_bck(k)/t_bck(k)
+           alph2=-o_bck(k)*px
+           t_tl(k  )= gamm*dzi_tl(k)+o_tl(k)*alph1 + t_tl(k  )
+           p_tl(k+1)= beta*dzi_tl(k)+o_tl(k)*alph2 + p_tl(k+1)
+           p_tl(k     )= alph*dzi_tl(k)+o_tl(k)*alph2 
+        end do
+
+
+        do k=nsig_hlf,1,-1
+           t(i,j,k)=t_tl(k)+t(i,j,k)
+           u(i,j,k)=u_tl(k)+u(i,j,k)
+           v(i,j,k)=v_tl(k)+v(i,j,k)
+           prs(i,j,k)=p_tl(k)+prs(i,j,k)
+        end do
+        prs(i,j,nsig_hlf+1)=p_tl(nsig_hlf+1)+prs(i,j,nsig_hlf+1)
+
+     end do 
+  end do 
+
+  return
+end subroutine turbl_ad

--- a/src/gsibec/gsi/turbl_tl.f90
+++ b/src/gsibec/gsi/turbl_tl.f90
@@ -1,0 +1,308 @@
+subroutine turbl_tl(pges,tges,oges,u,v,prs,t,termu,termv,termt,jstart,jstop)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    turbl_tl
+!
+!   prgrmmr:
+!
+! abstract:      Tangent linear of turbl
+!
+! program history log:
+!   2008-04-01  safford - add subprogram doc block, rm unused vars and uses
+!   2008-11-01  guo     - remove reference to dzl_tl(1); out-of-bounds
+!
+!   input argument list:
+!     pges     -
+!     tges     -
+!     oges     -
+!     prs      -
+!     t        -
+!     u        -
+!     v        -
+!     termu    -
+!     termv    -
+!     termt    -
+!
+!   output argument list:
+!     termu    -
+!     termv    -
+!     termt    -
+!
+! attributes:
+!   language:  f90
+!   machine:
+!
+!$$$
+
+  use constants,only: rd_over_cp,two,rd_over_g,half,zero,one,three,grav
+  use m_kinds,only: r_kind,i_kind
+  use gridmod, only: lat2,lon2,nsig,nsig_hlf
+  use turblmod, only: use_pbl
+  use turblmod, only: dudz,dvdz,dodz,ri,rf,kar0my20,zi,km,kh,sm,sh
+  use turblmod, only: lmix,dudtm,dvdtm,dtdtm,rdzi,rdzl
+  use turblmod, only: a0my20,c0my20,d0my20,f7my20,f8my20,karmy20
+  use turblmod, only: eps_m,fsm_my20,fsh_my20,ri_int
+
+  implicit none
+
+
+! Declare passed variables
+  real(r_kind),dimension(lat2,lon2,nsig+1),intent(in   ) :: pges
+  real(r_kind),dimension(lat2,lon2,nsig)  ,intent(in   ) :: tges,oges
+  real(r_kind),dimension(lat2,lon2,nsig+1),intent(in   ) :: prs
+  real(r_kind),dimension(lat2,lon2,nsig)  ,intent(in   ) :: t,u,v
+  real(r_kind),dimension(lat2,lon2,nsig)  ,intent(inout) :: termu,termv,termt
+  integer(i_kind)                         ,intent(in   ) :: jstart,jstop  
+
+! Declare local variables
+  real(r_kind),dimension(nsig_hlf):: dzi_tl,t_bck,o_bck
+  real(r_kind),dimension(nsig_hlf):: dudz_bck,dvdz_bck,dodz_bck,ri_bck,rf_bck
+  real(r_kind),dimension(nsig_hlf):: rdudz_bck,rdvdz_bck,sm_bck,sh_bck,rdzl_bck,rdzi_bck
+  real(r_kind),dimension(nsig_hlf):: u_tl,v_tl,o_tl,zl_tl,t_tl,rssq,rofbck,rshbck
+  real(r_kind),dimension(nsig_hlf+1):: km_bck,kh_bck,p_bck,zi_bck,km_tl,kh_tl,zi_tl,p_tl
+  real(r_kind),dimension(2:nsig_hlf):: dzl_tl,dodz_tl,dudz_tl,dvdz_tl,ri_tl
+  real(r_kind),dimension(2:nsig_hlf):: rf_tl,sh_tl,sm_tl,lmix_tl
+  real(r_kind):: a1,a2,ax,bx,px,rpx,zx,ssq
+  real(r_kind):: alph,beta,gamm,gam1,gam2,alph1,alph2,delt,bet
+  real(r_kind):: rdzibk,rdzlbk,kmbk,khbk,rpbck,hrdzbk,ardzbk
+  real(r_kind):: kmaz_bck,khaz_bck,kmaz_tl,khaz_tl,rtbck
+
+  integer(i_kind) i,j,k
+  integer(i_kind),dimension(nsig):: lssq
+
+  if(.not. use_pbl)return
+  
+  do j=jstart,jstop
+     do i=1,lat2
+
+! background fields
+        do k=1,nsig_hlf
+           t_bck(k)=tges(i,j,k)
+           p_bck(k)=pges(i,j,k)
+           o_bck(k)=oges(i,j,k)
+           rdzi_bck(k)=rdzi(i,j,k)
+           rdzl_bck(k)=rdzl(i,j,k)
+           zi_bck(k)=zi(i,j,k)
+        end do
+        p_bck(nsig_hlf+1) =pges(i,j,nsig_hlf+1)
+        zi_bck(nsig_hlf+1)=zi  (i,j,nsig_hlf+1)
+
+        do k=1,nsig_hlf
+           dodz_bck(k)=dodz(i,j,k)
+           dudz_bck(k)=dudz(i,j,k)
+           dvdz_bck(k)=dvdz(i,j,k)
+           ri_bck(k)=ri(i,j,k)
+           rf_bck(k)=rf(i,j,k)
+           sm_bck(k)=sm(i,j,k)
+           sh_bck(k)=sh(i,j,k)
+           km_bck(k)=km(i,j,k)
+           kh_bck(k)=kh(i,j,k)
+        end do
+        km_bck(nsig_hlf+1)=zero
+        kh_bck(nsig_hlf+1)=zero
+      
+        do k=2,nsig_hlf
+           ssq=dudz_bck(k)**2+dvdz_bck(k)**2
+           lssq(k)=1
+           if(ssq < eps_m) then
+              lssq(k)=0
+              ssq = eps_m
+           end if
+           rssq(k)=one/ssq
+           rdudz_bck(k)=dudz_bck(k)*rssq(k)
+           rdvdz_bck(k)=dvdz_bck(k)*rssq(k)
+           rofbck(k)=one/(one-rf_bck(k))
+           rshbck(k)=one/sh_bck(k)
+        end do 
+
+
+! perturbation fields
+
+        do k=1,nsig_hlf
+           t_tl(k)=t(i,j,k)
+           u_tl(k)=u(i,j,k)
+           v_tl(k)=v(i,j,k)
+           p_tl(k)=prs(i,j,k)
+        end do
+        p_tl (nsig_hlf+1) =prs (i,j,nsig_hlf+1)
+
+! perturbations of potential temperature and heigh increment
+
+        do k=1,nsig_hlf
+           rpbck=one/(p_bck(k)+p_bck(k+1))
+           px=rd_over_cp*rpbck
+           alph1=o_bck(k)/t_bck(k)
+           alph2=-o_bck(k)*px
+           o_tl(k)=alph1* t_tl(k)+&
+                   alph2*(p_tl(k)+&
+                          p_tl(k+1))
+           rpx=two*rpbck
+           a1=rd_over_g*rpx
+           a2=a1*t_bck(k)*rpx
+           alph= a2*p_bck(k+1)
+           beta=-a2*p_bck(k)
+           gamm=-a1*(p_bck(k+1)-p_bck(k))
+           dzi_tl(k)=alph*p_tl(k)+&
+                     beta*p_tl(k+1)+&
+                     gamm*t_tl(k)
+        end do
+
+! perturbation of heights
+
+        zi_tl(1)=zero
+        do k=1,nsig_hlf
+           zi_tl(k+1)=zi_tl(k)+dzi_tl(k)
+        end do
+
+        do k=1,nsig_hlf
+           zl_tl(k)=half*(zi_tl(k)+zi_tl(k+1))
+        end do
+
+        do k=2,nsig_hlf
+           dzl_tl(k)=zl_tl(k)-zl_tl(k-1)
+        end do
+
+! perturbation of vertical derivatives
+
+        do k=2,nsig_hlf
+           rdzlbk=rdzl_bck(k)
+           zx=dzl_tl(k)*rdzlbk
+           dudz_tl(k)=(u_tl(k)-u_tl(k-1))*rdzlbk - & 
+                      dudz_bck(k)*zx
+           dvdz_tl(k)=(v_tl(k)-v_tl(k-1))*rdzlbk - & 
+                      dvdz_bck(k)*zx
+           dodz_tl(k)=(o_tl(k)-o_tl(k-1))*rdzlbk - & 
+                      dodz_bck(k)*zx
+        end do
+
+! perturbation of Richardson number
+
+        do k=2,nsig_hlf
+           if(ri_int(i,j,k)==1) then
+              ri_tl(k) = zero
+           else
+              rtbck = one/(t_bck(k)+t_bck(k-1))
+              alph=-ri_bck(k)*two*lssq(k)
+              alph1=alph*rdudz_bck(k)
+              alph2=alph*rdvdz_bck(k)
+              beta= grav*rssq(k)*rtbck*two
+              gamm=-ri_bck(k)*rtbck
+              ri_tl(k)=alph1*dudz_tl(k)+&
+                       alph2*dvdz_tl(k)+&
+                       beta* dodz_tl(k)+&
+                       gamm*(t_tl(k)+t_tl(k-1))
+           end if
+        end do
+
+
+! perturbation of flux Richardson number, sh, sm and lmix
+
+        do k=2,nsig_hlf
+           if(ri_int(i,j,k)==1) then
+              rf_tl(k)=zero
+              sh_tl(k)=zero
+              sm_tl(k)=zero
+           else
+              ax=one/(f7my20-f8my20*rf_bck(k))
+              rf_tl(k)=a0my20*(one-(two*ri_bck(k)-c0my20)/ &
+                 (two*sqrt(ri_bck(k)*(ri_bck(k)-c0my20)+d0my20))) *ri_tl(k)
+              sh_tl(k)=fsh_my20*rofbck(k)**2    *rf_tl(k)
+              sm_tl(k)=fsm_my20*sh_bck(k)*ax**2 *rf_tl(k) +&
+                       sm_bck(k)*rshbck(k)      *sh_tl(k)
+           end if
+           lmix_tl(k)=karmy20/(one+kar0my20(i,j)*(zi_bck(k)-zi_bck(1)))**2 *zi_tl(k)
+        end do
+
+
+! perturbation of km and kh
+
+        do k=2,nsig_hlf
+           kmbk=km_bck(k)
+           khbk=kh_bck(k)
+           if(ri_int(i,j,k)==1) then
+              km_tl(k)=zero
+              kh_tl(k)=zero
+           else
+              ax=two/lmix(i,j,k)
+              bet=-half*rofbck(k)
+              bx=half/sm_bck(k)
+              alph= kmbk*three*bx
+              beta= kmbk*bet
+              gam1= kmbk*rdudz_bck(k)
+              gam2= kmbk*rdvdz_bck(k)
+              delt= kmbk*ax
+              km_tl(k)=alph*sm_tl(k) + &
+                       beta*rf_tl(k) + &
+                       gam1*dudz_tl(k)+&
+                       gam2*dvdz_tl(k)+&
+                       delt*lmix_tl(k) 
+              alph= khbk*bx
+              alph2=khbk*rshbck(k)
+              beta= khbk*bet
+              gam1= khbk*rdudz_bck(k)
+              gam2= khbk*rdvdz_bck(k)
+              delt= khbk*ax
+              kh_tl(k)=alph*sm_tl(k) + &
+                       alph2*sh_tl(k)+ &
+                       beta*rf_tl(k) + &
+                       gam1*dudz_tl(k)+&
+                       gam2*dvdz_tl(k)+&
+                       delt*lmix_tl(k)
+           end if
+        end do
+
+        km_tl(1)=zero; kh_tl(1)=zero
+
+! update perturbation tendencies
+
+
+        do k=1,nsig_hlf
+           rdzibk=rdzi_bck(k)
+           ax=t_bck(k)/o_bck(k)
+           hrdzbk=half*rdzibk
+           ardzbk=ax*hrdzbk
+           zx= dzi_tl(k)*rdzibk
+           kmaz_bck=(km_bck(k)+km_bck(k+1))*hrdzbk
+           khaz_bck=(kh_bck(k)+kh_bck(k+1))*ardzbk
+   
+           termu(i,j,k)=termu(i,j,k)-zx*dudtm(i,j,k)
+           termv(i,j,k)=termv(i,j,k)-zx*dvdtm(i,j,k)
+           termt(i,j,k)=termt(i,j,k)-zx*dtdtm(i,j,k)
+           kmaz_tl=zero
+           khaz_tl=zero
+           if(k<nsig_hlf) then
+              kmaz_tl =kmaz_tl+km_tl (k+1)*hrdzbk
+              khaz_tl =khaz_tl+kh_tl (k+1)*ardzbk
+           end if
+           if(k>1) then
+              kmaz_tl= kmaz_tl+km_tl (k)*hrdzbk
+              khaz_tl= khaz_tl+kh_tl (k)*ardzbk
+           end if
+           if(k<nsig_hlf) then
+              termu(i,j,k)=termu(i,j,k)+&
+                 kmaz_bck*dudz_tl(k+1) +&
+                 kmaz_tl*dudz_bck(k+1)
+              termv(i,j,k)=termv(i,j,k)+&
+                 kmaz_bck*dvdz_tl(k+1) +&
+                 kmaz_tl*dvdz_bck(k+1)
+              termt(i,j,k)=termt(i,j,k)+&
+                 khaz_bck*dodz_tl(k+1) +&
+                 khaz_tl*dodz_bck(k+1)
+           end if
+           if(k>1) then
+              termu(i,j,k)=termu(i,j,k)-&
+                   kmaz_bck*dudz_tl(k) -&
+                   kmaz_tl*dudz_bck(k)
+              termv(i,j,k)=termv(i,j,k)-&
+                   kmaz_bck*dvdz_tl(k) -&
+                   kmaz_tl*dvdz_bck(k)
+              termt(i,j,k)=termt(i,j,k)-&
+                   khaz_bck*dodz_tl(k) -&
+                   khaz_tl*dodz_bck(k)
+           end if
+        end do 
+     end do
+  end do
+
+  return
+end subroutine turbl_tl

--- a/src/gsibec/gsi/turblmod.f90
+++ b/src/gsibec/gsi/turblmod.f90
@@ -1,0 +1,245 @@
+module turblmod
+!$$$   module documentation block
+!             .      .    .
+! module:     turblmod
+!  prgmmr:
+!
+! abstract:
+!
+! program history log:
+!   2008-04-01  safford - added doc blocks
+!
+! subroutines included:
+!   init_turbl          --
+!   create_turblvars    --
+!   destroy_turblvars   --
+!
+! variable definitions:
+!
+! attributes:
+!   language:  f90
+!   machine:   ibm RS/6000 SP
+!
+!$$$ end documentation block
+
+  use m_kinds, only: r_kind,i_kind
+  use gridmod, only: lat2,lon2,nsig_hlf
+  use constants, only: one
+  implicit none
+
+! set default to private
+  private
+! set subroutines to public
+  public :: init_turbl
+  public :: create_turblvars
+  public :: destroy_turblvars
+! set passed variables to public
+  public :: use_pbl,f5my20,f4my20,f7my20,f6my20,f3my20, &
+            d0my20,c0my20,f2my20,f1my20,f8my20,smcmy20, &
+            shcmy20,ri_int,eps_m,rfcmy20,karmy20,b1my20, &
+            ricmy20,l0my20,km,zi,sm,kh,rf,dvdz,dudz,ri, &
+            dodz,sh,kar0my20,rdzl,b0my20,a0my20,rdzi, &
+            dudtm,lmix,dtdtm,dvdtm,fsh_my20,fsm_my20
+
+  logical use_pbl
+  real(r_kind),allocatable,dimension(:,:,:):: dudz
+  real(r_kind),allocatable,dimension(:,:,:):: dvdz
+  real(r_kind),allocatable,dimension(:,:,:):: dodz
+  real(r_kind),allocatable,dimension(:,:,:):: dudtm
+  real(r_kind),allocatable,dimension(:,:,:):: dvdtm
+  real(r_kind),allocatable,dimension(:,:,:):: dtdtm
+  real(r_kind),allocatable,dimension(:,:,:):: rdzi
+  real(r_kind),allocatable,dimension(:,:,:):: rdzl
+  real(r_kind),allocatable,dimension(:,:,:):: ri
+  real(r_kind),allocatable,dimension(:,:,:):: rf
+  real(r_kind),allocatable,dimension(:,:,:):: zi
+  real(r_kind),allocatable,dimension(:,:,:):: km
+  real(r_kind),allocatable,dimension(:,:,:):: kh
+  real(r_kind),allocatable,dimension(:,:,:):: sm
+  real(r_kind),allocatable,dimension(:,:,:):: sh
+  real(r_kind),allocatable,dimension(:,:,:):: lmix
+
+  real(r_kind),allocatable,dimension(:,:):: kar0my20
+
+  integer(i_kind),allocatable,dimension(:,:,:):: ri_int
+
+! Constants used in MY20 PBL parameterization  
+
+  real(r_kind) a0my20,b0my20,c0my20,d0my20,f1my20,f2my20, &
+               f3my20,f4my20,f5my20,f6my20,f7my20,f8my20,b1my20, &
+               karmy20,l0my20, &
+               f85my20,f76my20
+  real(r_kind) ricmy20,rfcmy20,shcmy20,smcmy20,eps_m
+  real(r_kind) fsm_my20,fsh_my20
+
+!>>> These are original coefficients from MY(1974)
+
+  parameter( ricmy20= 0.2338021249_r_kind )
+  parameter( a0my20= 0.7162162662_r_kind )
+  parameter( b0my20= 0.1886792481_r_kind )
+  parameter( c0my20= 0.3197414279_r_kind )
+  parameter( d0my20= 0.03559985757_r_kind )
+  parameter( f1my20= 2.339999914_r_kind )
+  parameter( f2my20= 0.2293333411_r_kind )
+  parameter( f3my20= 1.074666739_r_kind )
+  parameter( f4my20= 1.000000000_r_kind )
+  parameter( f5my20= 2.600000143_r_kind )
+  parameter( f6my20= 9.619999886_r_kind )
+  parameter( f7my20= 3.440000057_r_kind )
+  parameter( f8my20= 13.78000069_r_kind )
+  parameter( f85my20=f8my20*f5my20)
+  parameter( f76my20=f7my20*f6my20)
+  parameter( b1my20=15.0_r_kind )
+ 
+!>>> These coefficients recalculated from Eta model based
+!>>> Janjic (1990) implementation
+
+!  parameter( ricmy20=0.5046048164_r_kind ) 
+!  parameter( a0my20=0.6892600656_r_kind )
+!  parameter( b0my20=0.2228188217_r_kind )
+!  parameter( c0my20=0.2009073496_r_kind )
+!  parameter( d0my20=0.04964822531_r_kind )
+!  parameter( f1my20=1.972262979_r_kind )
+!m  parameter( f1my20=.1972262979_r_kind )
+!  parameter( f2my20=0.2222222388_r_kind )
+!  parameter( f3my20=1.163989186_r_kind )
+!  parameter( f4my20=1.003753304_r_kind )
+!  parameter( f5my20=2.629684210_r_kind )
+!  parameter( f6my20=8.561278343_r_kind )
+!  parameter( f7my20=2.639554262_r_kind )
+!  parameter( f8my20=11.84619045_r_kind )
+!  parameter( b1my20=11.87799326209552761_r_kind )
+
+  parameter( karmy20=0.4_r_kind )
+  parameter( l0my20=80._r_kind )    
+!m  parameter( eps_m   = 0.00000002_r_kind )
+  parameter( eps_m   = 0.02_r_kind )
+
+contains
+
+  subroutine init_turbl
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    init_turbl
+!
+!   prgrmmr:
+!
+! abstract:
+!
+! program history log:
+!   2008-04-01  safford -- add subprogram doc block
+!
+!   input argument list:
+!
+!   output argument list:
+!
+! attributes:
+!   language:  f90
+!   machine:
+!
+!$$$
+
+    implicit none
+
+    use_pbl=.false.                      ! set to true to turn on effect of pbl
+    rfcmy20=a0my20*(ricmy20+b0my20-sqrt(ricmy20**2-c0my20*ricmy20+d0my20))
+    shcmy20=f1my20*(f2my20-f3my20*rfcmy20)/(one-rfcmy20)
+    smcmy20=f4my20*(f5my20-f6my20*rfcmy20)/(f7my20-f8my20*rfcmy20)*shcmy20
+    fsh_my20=f1my20*(f2my20-f3my20)
+    fsm_my20=f4my20*(f85my20-f76my20)
+    return
+  end subroutine init_turbl
+
+  subroutine create_turblvars
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    create_turblvars
+!
+!   prgrmmr:
+!
+! abstract:
+!
+! program history log:
+!   2008-04-01  safford -- add subprogram doc block
+!
+!   input argument list:
+!
+!   output argument list:
+!
+! attributes:
+!   language:  f90
+!   machine:
+!
+!$$$
+    implicit none
+    
+    if(.not. use_pbl)return
+    allocate(dudz (lat2,lon2,nsig_hlf) )
+    allocate(dvdz (lat2,lon2,nsig_hlf) )
+    allocate(dodz (lat2,lon2,nsig_hlf) )
+    allocate(dudtm(lat2,lon2,nsig_hlf) )
+    allocate(dvdtm(lat2,lon2,nsig_hlf) )
+    allocate(dtdtm(lat2,lon2,nsig_hlf) )
+    allocate(rdzi (lat2,lon2,nsig_hlf) )
+    allocate(rdzl (lat2,lon2,nsig_hlf) )
+    allocate(ri   (lat2,lon2,nsig_hlf) )
+    allocate(rf   (lat2,lon2,nsig_hlf) )
+    allocate(km   (lat2,lon2,nsig_hlf+1) )
+    allocate(kh   (lat2,lon2,nsig_hlf+1) )
+    allocate(zi   (lat2,lon2,nsig_hlf+1) )
+    allocate(sm   (lat2,lon2,nsig_hlf) )
+    allocate(sh   (lat2,lon2,nsig_hlf) )
+    allocate(lmix (lat2,lon2,nsig_hlf) )
+    allocate(ri_int(lat2,lon2,nsig_hlf) )
+    allocate(kar0my20(lat2,lon2) )
+    
+    return
+  end subroutine create_turblvars
+
+  subroutine destroy_turblvars
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    destroy_turblvars
+!
+!   prgrmmr:
+!
+! abstract:
+!
+! program history log:
+!   2008-04-01  safford -- add subprogram doc block
+!
+!   input argument list:
+!
+!   output argument list:
+!
+! attributes:
+!   language:  f90
+!   machine:
+!
+!$$$
+    implicit none
+
+    if(.not. use_pbl)return
+    deallocate(dudz  )
+    deallocate(dvdz  )
+    deallocate(dodz  )
+    deallocate(dudtm )
+    deallocate(dvdtm )
+    deallocate(dtdtm )
+    deallocate(rdzi  )
+    deallocate(rdzl  )
+    deallocate(ri    )
+    deallocate(rf    )
+    deallocate(km    )
+    deallocate(kh    )
+    deallocate(zi    )
+    deallocate(sm    )
+    deallocate(sh    )
+    deallocate(lmix  )
+    deallocate(kar0my20 )
+    deallocate(ri_int )
+
+    return
+  end subroutine destroy_turblvars
+
+end module turblmod 

--- a/src/gsibec/gsi/turblmod.f90
+++ b/src/gsibec/gsi/turblmod.f90
@@ -115,6 +115,8 @@ module turblmod
 !m  parameter( eps_m   = 0.00000002_r_kind )
   parameter( eps_m   = 0.02_r_kind )
 
+  logical, save :: turbl_initialized_=.false. 
+
 contains
 
   subroutine init_turbl
@@ -174,6 +176,7 @@ contains
     implicit none
     
     if(.not. use_pbl)return
+    if(turbl_initialized_) return
     allocate(dudz (lat2,lon2,nsig_hlf) )
     allocate(dvdz (lat2,lon2,nsig_hlf) )
     allocate(dodz (lat2,lon2,nsig_hlf) )
@@ -192,6 +195,7 @@ contains
     allocate(lmix (lat2,lon2,nsig_hlf) )
     allocate(ri_int(lat2,lon2,nsig_hlf) )
     allocate(kar0my20(lat2,lon2) )
+    turbl_initialized_ = .true.
     
     return
   end subroutine create_turblvars
@@ -220,6 +224,7 @@ contains
     implicit none
 
     if(.not. use_pbl)return
+    if(.not. turbl_initialized_)return
     deallocate(dudz  )
     deallocate(dvdz  )
     deallocate(dodz  )
@@ -238,6 +243,7 @@ contains
     deallocate(lmix  )
     deallocate(kar0my20 )
     deallocate(ri_int )
+    turbl_initialized_ = .false.
 
     return
   end subroutine destroy_turblvars

--- a/src/gsibec/gsi/zrnmi_mod.f90
+++ b/src/gsibec/gsi/zrnmi_mod.f90
@@ -1,0 +1,3571 @@
+module zrnmi_mod
+!$$$   module documentation block
+!                .      .    .                                       .
+! module:    zrnmi_mod
+!
+! abstract: Contains all routines necessary for regional normal mode
+!             projection/initialization.  These tools are used to 
+!             implement weak and strong dynamic constraints.
+!
+!             The normal modes are based on double sine series
+!             expansions, following briere, ??add ref here.
+!
+!             In this version, fields are first multiplied by a boundary 
+!             function which smoothly reduces fields to zero at first point outside domain.
+!
+! program history log:
+!   2006-11-03  parrish
+!   2008-03-26  safford -- rm unused vars, add subroutine doc blocks
+!   2011-07-04  todling - fixes to run either single or double precision
+!
+! subroutines included:
+!   sub zrnmi_initialize       --- 
+!   sub zrnmi_sd2x0            --- setup to convert from subdomains to x direction
+!   sub zrnmi_sd2x1            --- additional setup
+!   sub zrnmi_x2sd1            --- additional setup
+!   sub zrnmi_sd2x2            --- subdomains to x
+!   sub zrnmi_sd2x3            --- subdomains to x
+!   sub zrnmi_x2sd             --- x to subdomains
+!   sub zrnmi_x2sd2            --- x to subdomains
+!   sub zrnmi_x2sd3            --- x to subdomains
+!
+!    following required for finite difference derivatives and laplacians
+!   sub zrnmi_sd2y0            --- setup to convert from subdomains to y direction
+!   sub zrnmi_sd2y1            --- additional setup
+!   sub zrnmi_y2sd1            --- additional setup
+!   sub zrnmi_sd2y2            --- subdomains to y
+!   sub zrnmi_y2sd2            --- y to subdomains
+!
+!   sub zrnmi_x_strans0         - initialize constants for x transforms
+!   sub zrnmi_x_strans          - sin trans in x direction from grid to spectral
+!
+!   sub zrnmi_uvm2dzmhat
+!   sub zrnmi_uvm2dzmhat_ad
+!   sub zrnmi_pcmhat2uvm
+!   sub zrnmi_pcmhat2uvm_orig
+!   sub zrnmi_pcmhat2uvm_ad_orig
+!   sub zrnmi_pcmhat2uvm_ad
+!
+!   sub zrnmi_x2y0             - setup to convert from x to y
+!   sub zrnmi_x2y1             - additional setup for x to y
+!   sub zrnmi_x2y3             - x to y
+!   sub zrnmi_y2x3             - y to x
+!
+!   sub zrnmi_y_strans0         - initialize constants for y transforms
+!   sub zrnmi_y_strans          - almost copy of zrnmi_x_strans
+!
+!   sub zrnmi_delx_general
+! * sub zrnmi_delx              - equivalent(*) to delx_reg in psichi2uv_reg.f90, but more scalable
+! * sub zrnmi_delx_ad           - equivalent(*) to tdelx_reg in psichi2uvt_reg.f90, but more scalable
+!   sub zrnmi_dely_general
+! * sub zrnmi_dely              - equivalent(*) to dely_reg in psichi2uv_reg.f90, but more scalable
+! * sub zrnmi_dely_ad           - equivalent(*) to tdely_reg in psichi2uvt_reg.f90, but more scalable
+!                                    (*) :  except corner points are treated differently.
+!
+!   sub zrnmi_uv2dz
+!   sub zrnmi_uv2dz_ad
+!   sub zrnmi_pc2uv_orig
+!   sub zrnmi_pc2uv_ad_orig
+!   sub zrnmi_constants
+!   sub zrnmi_strong_bal_correction
+!   sub zrnmi_strong_bal_correction_ad
+!   sub zrnmi_filter_uvm
+!   sub zrnmi_filter_uvm_ad
+!   sub zrnmi_filter_uvm2
+!   sub zrnmi_filter_uvm2_ad
+!   sub zrnmi_uvm2uvmhat
+!   sub zrnmi_uvm2uvmhat_ad
+!   sub zrnmi_uvmhat2uvm
+!   sub zrnmi_uvmhat2uvm_ad
+!
+! Variable Definitions:
+!      
+! attributes:
+!   language: f90
+!   machine:  ibm RS/6000 SP
+!
+!$$$ end documentation block
+
+  use m_kinds, only: r_kind,i_kind
+  use constants, only: pi
+  implicit none
+
+! set default to private
+  private
+! set subroutines to public
+  public :: zrnmi_initialize
+  public :: zrnmi_sd2x0
+  public :: zrnmi_sd2x1
+  public :: zrnmi_x2sd1
+  public :: zrnmi_sd2x2
+  public :: zrnmi_sd2x3
+  public :: zrnmi_x2sd
+  public :: zrnmi_x2sd2
+  public :: zrnmi_x2sd3
+  public :: zrnmi_sd2y0
+  public :: zrnmi_sd2y1
+  public :: zrnmi_y2sd1
+  public :: zrnmi_sd2y2
+  public :: zrnmi_y2sd2
+  public :: zrnmi_x_strans0
+  public :: zrnmi_x_strans
+  public :: zrnmi_uvm2dzmhat
+  public :: zrnmi_uvm2dzmhat_ad
+  public :: zrnmi_pcmhat2uvm
+  public :: zrnmi_pcmhat2uvm_orig
+  public :: zrnmi_pcmhat2uvm_ad_orig
+  public :: zrnmi_pcmhat2uvm_ad
+  public :: zrnmi_x2y0
+  public :: zrnmi_x2y1
+  public :: zrnmi_x2y3
+  public :: zrnmi_y2x3
+  public :: zrnmi_y_strans0
+  public :: zrnmi_y_strans
+  public :: zrnmi_delx_general
+  public :: zrnmi_delx
+  public :: zrnmi_delx_ad
+  public :: zrnmi_dely_general
+  public :: zrnmi_dely
+  public :: zrnmi_dely_ad
+  public :: zrnmi_uv2dz
+  public :: zrnmi_uv2dz_ad
+  public :: zrnmi_pc2uv_orig
+  public :: zrnmi_pc2uv_ad_orig
+  public :: zrnmi_constants
+  public :: zrnmi_strong_bal_correction
+  public :: zrnmi_strong_bal_correction_ad
+  public :: zrnmi_filter_uvm
+  public :: zrnmi_filter_uvm_ad
+  public :: zrnmi_filter_uvm2
+  public :: zrnmi_filter_uvm2_ad
+  public :: zrnmi_uvm2uvmhat
+  public :: zrnmi_uvm2uvmhat_ad
+  public :: zrnmi_uvmhat2uvm
+  public :: zrnmi_uvmhat2uvm_ad
+
+  integer(i_kind) nx,ny
+  integer(i_kind) nvert
+
+!  communication info for sd <--> x strips
+  integer(i_kind) ny_0,ny_1
+  integer(i_kind),allocatable::list_sd2x(:,:)   ! list_sd2x(1,j) = y index for x strip j
+                                                 ! list_sd2x(2,j) = vert index for x strip j
+                                                 ! list_sd2x(3,j) = pe of this y/vert index strip
+  integer(i_kind),dimension(:),allocatable::nsend_sd2x,nrecv_sd2x,ndsend_sd2x,ndrecv_sd2x
+  integer(i_kind) nallsend_sd2x,nallrecv_sd2x
+  integer(i_kind),allocatable::  info_send_sd2x(:,:),info_recv_sd2x(:,:)
+  integer(i_kind),dimension(:),allocatable::nsend_x2sd,nrecv_x2sd,ndsend_x2sd,ndrecv_x2sd
+  integer(i_kind) nallsend_x2sd,nallrecv_x2sd
+  integer(i_kind),allocatable::  info_send_x2sd(:,:),info_recv_x2sd(:,:)
+
+!  communication info for sd <--> y strips
+  integer(i_kind) nx_0,nx_1
+  integer(i_kind),allocatable::list_sd2y(:,:)   ! list_sd2y(1,j) = x index for y strip j
+                                                 ! list_sd2y(2,j) = vert index for y strip j
+                                                 ! list_sd2y(3,j) = pe of this x/vert index strip
+  integer(i_kind),dimension(:),allocatable::nsend_sd2y,nrecv_sd2y,ndsend_sd2y,ndrecv_sd2y
+  integer(i_kind) nallsend_sd2y,nallrecv_sd2y
+  integer(i_kind),allocatable::  info_send_sd2y(:,:),info_recv_sd2y(:,:)
+  integer(i_kind),dimension(:),allocatable::nsend_y2sd,nrecv_y2sd,ndsend_y2sd,ndrecv_y2sd
+  integer(i_kind) nallsend_y2sd,nallrecv_y2sd
+  integer(i_kind),allocatable::  info_send_y2sd(:,:),info_recv_y2sd(:,:)
+
+!   x sine transform info
+  real(r_kind),allocatable:: sinx(:,:)
+
+!  communication info for x <--> y strips
+  integer(i_kind) mx_0,mx_1
+  integer(i_kind),allocatable::list_x2y(:,:)   ! list_x2y(1,j) = x index for y strip j
+                                               ! list_x2y(2,j) = vert index for y strip j
+                                               ! list_x2y(3,j) = pe of this x/vert index strip
+  integer(i_kind),dimension(:),allocatable::nsend_x2y,nrecv_x2y,ndsend_x2y,ndrecv_x2y
+  integer(i_kind) nallsend_x2y,nallrecv_x2y
+  integer(i_kind),allocatable::  info_send_x2y(:,:),info_recv_x2y(:,:)
+
+!   y sine transform info
+  real(r_kind),allocatable:: siny(:,:)
+
+!  constants for gravity projection operators
+  real(r_kind),allocatable,dimension(:,:):: am2,f_sm2_am2,sm2,a2_p0_sm2,f_p0_sm2,p0_sm2
+  real(r_kind) fbar
+  real(r_kind),allocatable,dimension(:,:):: pmask
+  real(r_kind) zrnmi_period_max,zrnmi_period_width
+
+contains
+
+
+  subroutine zrnmi_initialize(mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_initialize
+!
+!   prgrmmr: 
+!
+! abstract:
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block, rm unused uses
+!
+!   input argument list:
+!     mype     - mpi task id
+!
+!   output argument list:
+!
+! attributes:
+!   language:  f90
+!   machine:   ibm RS/6000 SP
+!
+!$$$ end documentation block
+    use mod_strong, only: period_max,period_width
+    use mod_vtrans, only: nvmodes_keep
+    implicit none
+
+    integer(i_kind),intent(in   ) :: mype
+
+    zrnmi_period_max=period_max
+    zrnmi_period_width=period_width
+    nvert=nvmodes_keep
+    call zrnmi_sd2x0(mype)
+    call zrnmi_sd2x1(mype)
+    call zrnmi_x2sd1(mype)
+    call zrnmi_sd2y0(mype)
+    call zrnmi_sd2y1(mype)
+    call zrnmi_y2sd1(mype)
+    call zrnmi_x_strans0
+    call zrnmi_x2y0(mype)
+    call zrnmi_x2y1(mype)
+    call zrnmi_y_strans0
+    call zrnmi_constants(mype)
+
+  end subroutine zrnmi_initialize
+
+  subroutine zrnmi_sd2x0(mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_sd2x0
+!
+!   prgrmmr: 
+!
+! abstract:
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block
+!
+!   input argument list:
+!     mype     - mpi task id
+!
+!   output argument list:
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+
+!  create x (y strips) subdivision for use with sine transform in x direction
+
+!  output:
+
+!     ny_0,ny_1:  range of y/vert index on processor mype
+
+!           1 <= ny_0 <= ny_1 <= ny*nvert
+!           if npe > ny*nvert, then will have ny_0 = -1, ny_1 = -2 on some processors,
+!               and ny_0=ny_1 on the remaining ny*nvert processors
+!
+!     list_sd2x(3,ny*nvert):  global definition of contents of each y/vert strip
+!                      list_sd2x(1,j) = y index for x strip j
+!                      list_sd2x(2,j) = vert level for x strip j
+!                      list_sd2x(3,j) = pe of this y/vert strip
+
+  use gridmod, only: nlon,nlat
+  use m_mpimod, only:  npe
+  implicit none
+
+  integer(i_kind),intent(in   ) :: mype
+
+  integer(i_kind) i,k,kchk,kk,n,nn,ny_this,ny_tot
+
+!  set analysis grid dimensions
+  nx=nlon
+  ny=nlat
+
+  allocate(list_sd2x(3,ny*nvert))
+
+  ny_tot=ny*nvert
+  ny_this=ny_tot/npe
+  if(mod(ny_tot,npe)/=0) ny_this=ny_this+1
+  if(mod(ny_tot,npe)==0) then
+     kchk=npe
+  else
+     kchk=mod(ny_tot,npe)
+  end if
+
+  nn=0
+  do k=1,nvert
+     do i=1,ny
+        nn=nn+1
+        list_sd2x(1,nn)=i
+        list_sd2x(2,nn)=k
+        list_sd2x(3,nn)=-1
+     end do
+  end do
+
+  if(mype == 0) write(6,*)' nn,ny_tot,ny,nvert=',nn,ny_tot,ny,nvert
+
+  ny_0=-1
+  ny_1=-2
+  nn=0
+  do n=1,npe
+     if(n <= kchk) then
+        kk=ny_this
+     else
+        kk=ny_this-1
+     end if
+     if(kk > 0) then
+        if(mype+1 == n) then
+           ny_0=nn+1
+           ny_1=nn+kk
+        end if
+        do k=1,kk
+           nn=nn+1
+           list_sd2x(3,nn)=n
+        end do
+     end if
+  end do
+
+  end subroutine zrnmi_sd2x0
+
+  subroutine zrnmi_sd2x1(mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_sd2x1
+!
+!   prgrmmr: 
+!
+! abstract:
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block, rm unused uses
+!
+!   input argument list:
+!     mype     - mpi task id
+!
+!   output argument list:
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+
+!  continue with setup for subdomain to lat strip interchanges
+
+    use gridmod, only: lon2,lat2,jstart,istart
+    use m_mpimod, only: npe,gsi_mpi_comm_world,ierror,mpi_integer4
+    implicit none
+
+    integer(i_kind),intent(in   ) :: mype
+
+    integer(i_kind) list2(ny,nvert)
+    integer(i_kind) i,ii,ii0,iy,ivert,j,mm1,nn,nxloc,ipe,iym,ix,mpi_string1
+    integer(i_kind) ny_tot
+
+    allocate(nsend_sd2x(npe),nrecv_sd2x(npe),ndsend_sd2x(npe+1),ndrecv_sd2x(npe+1))
+    mm1=mype+1
+    ny_tot=ny*nvert
+
+
+    nn=0
+    list2=0
+    do j=1,ny_tot
+       iy=list_sd2x(1,j)
+       ivert=list_sd2x(2,j)
+       if(list2(iy,ivert) /= 0) then
+          if(mype == 0) write(0,*)' problem in zrnmi_sd2x1'
+          call mpi_finalize(i)
+          stop
+       end if
+       list2(iy,ivert)=j
+    end do
+
+!  obtain counts of points to send to each pe from this pe
+
+    nsend_sd2x=0
+    nxloc=lon2-2
+    do ivert=1,nvert
+       do i=2,lat2-1
+          iy=i+istart(mm1)-2
+          j=list2(iy,ivert)
+          ipe=list_sd2x(3,j)
+          nsend_sd2x(ipe)=nsend_sd2x(ipe)+nxloc
+       end do
+    end do
+
+    ndsend_sd2x(1)=0
+    do i=2,npe+1
+       ndsend_sd2x(i)=ndsend_sd2x(i-1)+nsend_sd2x(i-1)
+    end do
+    nallsend_sd2x=ndsend_sd2x(npe+1)
+    allocate(info_send_sd2x(3,nallsend_sd2x))
+    nsend_sd2x=0
+    do ivert=1,nvert
+       do i=2,lat2-1
+          iy=i+istart(mm1)-2
+          iym=list2(iy,ivert)
+          ipe=list_sd2x(3,iym)
+          do ii=2,lon2-1
+             ix=ii+jstart(mm1)-2
+             nsend_sd2x(ipe)=nsend_sd2x(ipe)+1
+             ii0=ndsend_sd2x(ipe)+nsend_sd2x(ipe)
+             info_send_sd2x(1,ii0)=ix
+             info_send_sd2x(2,ii0)=iym
+             info_send_sd2x(3,ii0)=ivert
+          end do
+       end do
+    end do
+
+    call mpi_alltoall(nsend_sd2x,1,mpi_integer4,nrecv_sd2x,1,mpi_integer4,gsi_mpi_comm_world,ierror)
+    ndrecv_sd2x(1)=0
+    do i=2,npe+1
+       ndrecv_sd2x(i)=ndrecv_sd2x(i-1)+nrecv_sd2x(i-1)
+    end do
+    nallrecv_sd2x=ndrecv_sd2x(npe+1)
+    allocate(info_recv_sd2x(3,nallrecv_sd2x))
+    call mpi_type_contiguous(3,mpi_integer4,mpi_string1,ierror)
+    call mpi_type_commit(mpi_string1,ierror)
+    call mpi_alltoallv(info_send_sd2x,nsend_sd2x,ndsend_sd2x,mpi_string1, &
+                     info_recv_sd2x,nrecv_sd2x,ndrecv_sd2x,mpi_string1,gsi_mpi_comm_world,ierror)
+    call mpi_type_free(mpi_string1,ierror)
+
+  end subroutine zrnmi_sd2x1
+
+  subroutine zrnmi_x2sd1(mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_x2sd1
+!
+!   prgrmmr: 
+!
+! abstract:
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block, rm unused uses
+!
+!   input argument list:
+!     mype     - mpi task id
+!
+!   output argument list:
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+
+!  use mpi_alltoallv to move u_x (y strips) to u_sd (subdomains)
+
+    use m_kinds, only: r_kind,i_kind
+    use gridmod, only: jstart,istart,ilat1,jlon1
+    use m_mpimod, only: npe,gsi_mpi_comm_world,ierror,mpi_integer4
+    implicit none
+
+
+    integer(i_kind),intent(in   ) :: mype
+
+    integer(i_kind) i,iy,ivert,j,k,mm1,ipe,ix,mpi_string1,nn
+
+    allocate(nsend_x2sd(npe),nrecv_x2sd(npe),ndsend_x2sd(npe+1),ndrecv_x2sd(npe+1))
+    mm1=mype+1
+
+!      1.  for each pe, gather up list of points from this set of lat strips destined
+!             for subdomain of pe
+    do ipe=1,npe
+       nn=0
+       do k=ny_0,ny_1
+          iy=list_sd2x(1,k)
+          ivert=list_sd2x(2,k)
+          i=iy-istart(ipe)+2
+          if(i >= 1.and.i <= ilat1(ipe)+2) then
+             do j=1,jlon1(ipe)+2
+                ix=j+jstart(ipe)-2
+                if(ix >= 1.and.ix <= nx) nn=nn+1
+             end do
+          end if
+       end do
+       nsend_x2sd(ipe)=nn
+    end do
+
+    ndsend_x2sd(1)=0
+    do i=2,npe+1
+       ndsend_x2sd(i)=ndsend_x2sd(i-1)+nsend_x2sd(i-1)
+    end do
+    nallsend_x2sd=ndsend_x2sd(npe+1)
+    allocate(info_send_x2sd(3,nallsend_x2sd))
+    nn=0
+    do ipe=1,npe
+       do k=ny_0,ny_1
+          iy=list_sd2x(1,k)
+          ivert=list_sd2x(2,k)
+          i=iy-istart(ipe)+2
+          if(i >= 1.and.i <= ilat1(ipe)+2) then
+             do j=1,jlon1(ipe)+2
+                ix=j+jstart(ipe)-2
+                if(ix >= 1.and.ix <= nx) then
+                   nn=nn+1
+                   info_send_x2sd(1,nn)=ix
+                   info_send_x2sd(2,nn)=j
+                   info_send_x2sd(3,nn)=k
+                end if
+             end do
+          end if
+       end do
+    end do
+
+    call mpi_alltoall(nsend_x2sd,1,mpi_integer4,nrecv_x2sd,1,mpi_integer4,gsi_mpi_comm_world,ierror)
+    ndrecv_x2sd(1)=0
+    do i=2,npe+1
+       ndrecv_x2sd(i)=ndrecv_x2sd(i-1)+nrecv_x2sd(i-1)
+    end do
+    nallrecv_x2sd=ndrecv_x2sd(npe+1)
+    allocate(info_recv_x2sd(3,nallrecv_x2sd))
+    call mpi_type_contiguous(3,mpi_integer4,mpi_string1,ierror)
+    call mpi_type_commit(mpi_string1,ierror)
+    call mpi_alltoallv(info_send_x2sd,nsend_x2sd,ndsend_x2sd,mpi_string1, &
+                       info_recv_x2sd,nrecv_x2sd,ndrecv_x2sd,mpi_string1,gsi_mpi_comm_world,ierror)
+    call mpi_type_free(mpi_string1,ierror)
+
+  end subroutine zrnmi_x2sd1
+
+  subroutine zrnmi_sd2x2(u1_sd,u2_sd,u1_x,u2_x,mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_sd2x2
+!
+!   prgrmmr: 
+!
+! abstract:
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block, rm unused uses
+!
+!   input argument list:
+!     mype     - mpi task id
+!     u1_sd,u2_sd
+!
+!   output argument list:
+!     u1_x,u2_x
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+
+!  use mpi_alltoallv to move u_sd (subdomains) to u_x (y strips)
+
+    use m_kinds, only: r_kind,i_kind
+    use gridmod, only: lon2,lat2,jstart,istart
+    use m_mpimod, only: gsi_mpi_comm_world,ierror,mpi_rtype
+    implicit none
+
+    integer(i_kind)                        ,intent(in   ) :: mype
+
+    real(r_kind),dimension(lat2,lon2,nvert),intent(in   ) :: u1_sd,u2_sd
+    real(r_kind),dimension(nx,ny_0:ny_1)   ,intent(  out) :: u1_x,u2_x
+
+    integer(i_kind) iy,iym,ix,ivert,j,mm1,mpi_string1
+    real(r_kind),allocatable::sendbuf(:,:),recvbuf(:,:)
+
+    mm1=mype+1
+
+    allocate(sendbuf(2,nallsend_sd2x))
+    do j=1,nallsend_sd2x
+       ix=info_send_sd2x(1,j)
+       iym=info_send_sd2x(2,j)
+       iy=list_sd2x(1,iym)
+       ivert=list_sd2x(2,iym)
+       sendbuf(1,j)=u1_sd(iy-istart(mm1)+2,ix-jstart(mm1)+2,ivert)
+       sendbuf(2,j)=u2_sd(iy-istart(mm1)+2,ix-jstart(mm1)+2,ivert)
+    end do
+    call mpi_type_contiguous(2,mpi_rtype,mpi_string1,ierror)
+    call mpi_type_commit(mpi_string1,ierror)
+    allocate(recvbuf(2,nallrecv_sd2x))
+    call mpi_alltoallv(sendbuf,nsend_sd2x,ndsend_sd2x,mpi_string1, &
+                       recvbuf,nrecv_sd2x,ndrecv_sd2x,mpi_string1,gsi_mpi_comm_world,ierror)
+    call mpi_type_free(mpi_string1,ierror)
+    deallocate(sendbuf)
+
+    do j=1,nallrecv_sd2x
+       ix=info_recv_sd2x(1,j)
+       iym=info_recv_sd2x(2,j)
+       u1_x(ix,iym)=recvbuf(1,j)
+       u2_x(ix,iym)=recvbuf(2,j)
+    end do
+    deallocate(recvbuf)
+
+  end subroutine zrnmi_sd2x2
+
+  subroutine zrnmi_sd2x3(u1_sd,u2_sd,u3_sd,u1_x,u2_x,u3_x,mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_sd2x3
+!
+!   prgrmmr: 
+!
+! abstract:
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block, rm unused uses
+!
+!   input argument list:
+!     mype     - mpi task id
+!     u1_sd,u2_sd,u2_sd
+!
+!   output argument list:
+!     u1_x,u2_x,u3_x
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+
+!  use mpi_alltoallv to move u_sd (subdomains) to u_x (y strips)
+
+    use m_kinds, only: r_kind,i_kind
+    use gridmod, only: lon2,lat2,jstart,istart
+    use m_mpimod, only: gsi_mpi_comm_world,ierror,mpi_rtype
+    implicit none
+
+    integer(i_kind)                        ,intent(in   ) :: mype
+
+    real(r_kind),dimension(lat2,lon2,nvert),intent(in   ) :: u1_sd,u2_sd,u3_sd
+    real(r_kind),dimension(nx,ny_0:ny_1)   ,intent(  out) :: u1_x,u2_x,u3_x
+
+    integer(i_kind) iy,iym,ix,ivert,j,mm1,mpi_string1
+    real(r_kind),allocatable::sendbuf(:,:),recvbuf(:,:)
+
+    mm1=mype+1
+
+    allocate(sendbuf(3,nallsend_sd2x))
+    do j=1,nallsend_sd2x
+       ix=info_send_sd2x(1,j)
+       iym=info_send_sd2x(2,j)
+       iy=list_sd2x(1,iym)
+       ivert=list_sd2x(2,iym)
+       sendbuf(1,j)=u1_sd(iy-istart(mm1)+2,ix-jstart(mm1)+2,ivert)
+       sendbuf(2,j)=u2_sd(iy-istart(mm1)+2,ix-jstart(mm1)+2,ivert)
+       sendbuf(3,j)=u3_sd(iy-istart(mm1)+2,ix-jstart(mm1)+2,ivert)
+    end do
+    call mpi_type_contiguous(3,mpi_rtype,mpi_string1,ierror)
+    call mpi_type_commit(mpi_string1,ierror)
+    allocate(recvbuf(3,nallrecv_sd2x))
+    call mpi_alltoallv(sendbuf,nsend_sd2x,ndsend_sd2x,mpi_string1, &
+                       recvbuf,nrecv_sd2x,ndrecv_sd2x,mpi_string1,gsi_mpi_comm_world,ierror)
+    call mpi_type_free(mpi_string1,ierror)
+    deallocate(sendbuf)
+
+    do j=1,nallrecv_sd2x
+       ix=info_recv_sd2x(1,j)
+       iym=info_recv_sd2x(2,j)
+       u1_x(ix,iym)=recvbuf(1,j)
+       u2_x(ix,iym)=recvbuf(2,j)
+       u3_x(ix,iym)=recvbuf(3,j)
+    end do
+    deallocate(recvbuf)
+
+  end subroutine zrnmi_sd2x3
+
+  subroutine zrnmi_x2sd(u_sd,u_x,mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_x2sd
+!
+!   prgrmmr: 
+!
+! abstract:      move u_x (lat strips) to u_sd (subdomains)
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block, rm unused uses
+!
+!   input argument list:
+!     mype     - mpi task id
+!     u_x      - lat strips
+!
+!   output argument list:
+!     u_sd     - subdomains
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+
+!  use mpi_alltoallv to move u_ew (lat strips) to u_sd (subdomains)
+
+    use m_kinds, only: r_kind,i_kind
+    use gridmod, only: lon2,lat2,istart
+    use m_mpimod, only: gsi_mpi_comm_world,ierror,mpi_rtype
+    use constants, only: zero
+    implicit none
+
+
+    integer(i_kind)                        ,intent(in   ) :: mype
+    real(r_kind),dimension(lat2,lon2,nvert),intent(  out) :: u_sd
+    real(r_kind),dimension(nx,ny_0:ny_1)   ,intent(in   ) :: u_x
+
+    real(r_kind),allocatable::sendbuf(:),recvbuf(:)
+    integer(i_kind) iy,ivert,j,mm1,iym,ix,ixloc
+
+    mm1=mype+1
+
+    u_sd=zero
+    allocate(sendbuf(nallsend_x2sd))
+    do j=1,nallsend_x2sd
+       ix=info_send_x2sd(1,j)
+       iym=info_send_x2sd(3,j)
+       sendbuf(j)=u_x(ix,iym)
+    end do
+    allocate(recvbuf(nallrecv_x2sd))
+    call mpi_alltoallv(sendbuf,nsend_x2sd,ndsend_x2sd,mpi_rtype, &
+                       recvbuf,nrecv_x2sd,ndrecv_x2sd,mpi_rtype,gsi_mpi_comm_world,ierror)
+    deallocate(sendbuf)
+    do j=1,nallrecv_x2sd
+       ixloc=info_recv_x2sd(2,j)
+       iym=info_recv_x2sd(3,j)
+       iy=list_sd2x(1,iym)
+       ivert=list_sd2x(2,iym)
+       u_sd(iy-istart(mm1)+2,ixloc,ivert)=recvbuf(j)
+    end do
+    deallocate(recvbuf)
+
+  end subroutine zrnmi_x2sd
+
+  subroutine zrnmi_x2sd2(u1_sd,u2_sd,u1_x,u2_x,mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_x2sd2
+!
+!   prgrmmr: 
+!
+! abstract:      
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block, rm unused uses
+!
+!   input argument list:
+!     mype     - mpi task id
+!     u1_x     - 
+!     u2_x     - 
+!
+!   output argument list:
+!     u1_sd    - 
+!     u2_sd    - 
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+
+!  use mpi_alltoallv to move u_ew (lat strips) to u_sd (subdomains)
+
+    use m_kinds, only: r_kind,i_kind
+    use gridmod, only: lon2,lat2,istart
+    use m_mpimod, only: gsi_mpi_comm_world,ierror,mpi_rtype
+    use constants, only: zero
+    implicit none
+
+
+    integer(i_kind)                        ,intent(in   ) :: mype
+    real(r_kind),dimension(lat2,lon2,nvert),intent(  out) :: u1_sd,u2_sd
+    real(r_kind),dimension(nx,ny_0:ny_1)   ,intent(in   ) :: u1_x,u2_x
+
+    real(r_kind),allocatable::sendbuf(:,:),recvbuf(:,:)
+    integer(i_kind) iy,ivert,j,mm1,iym,ix,ixloc,mpi_string1
+
+    mm1=mype+1
+
+    u1_sd=zero
+    u2_sd=zero
+    allocate(sendbuf(2,nallsend_x2sd))
+    do j=1,nallsend_x2sd
+       ix=info_send_x2sd(1,j)
+       iym=info_send_x2sd(3,j)
+       sendbuf(1,j)=u1_x(ix,iym)
+       sendbuf(2,j)=u2_x(ix,iym)
+    end do
+    call mpi_type_contiguous(2,mpi_rtype,mpi_string1,ierror)
+    call mpi_type_commit(mpi_string1,ierror)
+    allocate(recvbuf(2,nallrecv_x2sd))
+    call mpi_alltoallv(sendbuf,nsend_x2sd,ndsend_x2sd,mpi_string1, &
+                       recvbuf,nrecv_x2sd,ndrecv_x2sd,mpi_string1,gsi_mpi_comm_world,ierror)
+    call mpi_type_free(mpi_string1,ierror)
+    deallocate(sendbuf)
+    do j=1,nallrecv_x2sd
+       ixloc=info_recv_x2sd(2,j)
+       iym=info_recv_x2sd(3,j)
+       iy=list_sd2x(1,iym)
+       ivert=list_sd2x(2,iym)
+       u1_sd(iy-istart(mm1)+2,ixloc,ivert)=recvbuf(1,j)
+       u2_sd(iy-istart(mm1)+2,ixloc,ivert)=recvbuf(2,j)
+    end do
+    deallocate(recvbuf)
+
+  end subroutine zrnmi_x2sd2
+
+  subroutine zrnmi_x2sd3(u1_sd,u2_sd,u3_sd,u1_x,u2_x,u3_x,mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_x2sd3
+!
+!   prgrmmr: 
+!
+! abstract:      
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block, rm unused uses
+!
+!   input argument list:
+!     mype     - mpi task id
+!     u1_x     - 
+!     u2_x     - 
+!     u3_x     - 
+!
+!   output argument list:
+!     u1_sd    - 
+!     u2_sd    - 
+!     u3_sd    - 
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+
+!  use mpi_alltoallv to move u_ew (lat strips) to u_sd (subdomains)
+
+    use m_kinds, only: r_kind,i_kind
+    use gridmod, only: lon2,lat2,istart
+    use m_mpimod, only: gsi_mpi_comm_world,ierror,mpi_rtype
+    use constants, only: zero
+    implicit none
+
+
+    integer(i_kind)                        ,intent(in   ) :: mype
+    real(r_kind),dimension(lat2,lon2,nvert),intent(  out) :: u1_sd,u2_sd,u3_sd
+    real(r_kind),dimension(nx,ny_0:ny_1)   ,intent(in   ) :: u1_x,u2_x,u3_x
+
+    real(r_kind),allocatable::sendbuf(:,:),recvbuf(:,:)
+    integer(i_kind) iy,ivert,j,mm1,iym,ix,ixloc, mpi_string1
+
+    mm1=mype+1
+
+    u1_sd=zero
+    u2_sd=zero
+    u3_sd=zero
+    allocate(sendbuf(3,nallsend_x2sd))
+    do j=1,nallsend_x2sd
+       ix=info_send_x2sd(1,j)
+       iym=info_send_x2sd(3,j)
+       sendbuf(1,j)=u1_x(ix,iym)
+       sendbuf(2,j)=u2_x(ix,iym)
+       sendbuf(3,j)=u3_x(ix,iym)
+    end do
+    call mpi_type_contiguous(3,mpi_rtype,mpi_string1,ierror)
+    call mpi_type_commit(mpi_string1,ierror)
+    allocate(recvbuf(3,nallrecv_x2sd))
+    call mpi_alltoallv(sendbuf,nsend_x2sd,ndsend_x2sd,mpi_string1, &
+                       recvbuf,nrecv_x2sd,ndrecv_x2sd,mpi_string1,gsi_mpi_comm_world,ierror)
+    call mpi_type_free(mpi_string1,ierror)
+    deallocate(sendbuf)
+    do j=1,nallrecv_x2sd
+       ixloc=info_recv_x2sd(2,j)
+       iym=info_recv_x2sd(3,j)
+       iy=list_sd2x(1,iym)
+       ivert=list_sd2x(2,iym)
+       u1_sd(iy-istart(mm1)+2,ixloc,ivert)=recvbuf(1,j)
+       u2_sd(iy-istart(mm1)+2,ixloc,ivert)=recvbuf(2,j)
+       u3_sd(iy-istart(mm1)+2,ixloc,ivert)=recvbuf(3,j)
+    end do
+    deallocate(recvbuf)
+
+  end subroutine zrnmi_x2sd3
+
+  subroutine zrnmi_sd2y0(mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_sd2y0
+!
+!   prgrmmr: 
+!
+! abstract:      
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block
+!
+!   input argument list:
+!     mype     - mpi task id
+!
+!   output argument list:
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+
+!  create y (x strips) subdivision for use with derivatives in the y direction
+
+!  output:
+
+!     nx_0,nx_1:  range of x/vert index on processor mype
+
+!           1 <= nx_0 <= nx_1 <= nx*nvert
+!           if npe > nx*nvert, then will have nx_0 = -1, nx_1 = -2 on some processors,
+!               and nx_0=nx_1 on the remaining nx*nvert processors
+!
+!     list_sd2y(3,nx*nvert):  global definition of contents of each x/vert strip
+!                      list_sd2y(1,j) = x index for y strip j
+!                      list_sd2y(2,j) = vert level for y strip j
+!                      list_sd2y(3,j) = pe of this x/vert strip
+
+  use m_mpimod, only:  npe
+  implicit none
+
+  integer(i_kind),intent(in   ) :: mype
+
+  integer(i_kind) i,k,kchk,kk,n,nn,nx_this,nx_tot
+
+  allocate(list_sd2y(3,nx*nvert))
+
+  nx_tot=nx*nvert
+  nx_this=nx_tot/npe
+  if(mod(nx_tot,npe)/=0) nx_this=nx_this+1
+  if(mod(nx_tot,npe)==0) then
+     kchk=npe
+  else
+     kchk=mod(nx_tot,npe)
+  end if
+
+  nn=0
+  do k=1,nvert
+     do i=1,nx
+        nn=nn+1
+        list_sd2y(1,nn)=i
+        list_sd2y(2,nn)=k
+        list_sd2y(3,nn)=-1
+     end do
+  end do
+
+  if(mype == 0) write(6,*)' in zrnmi_sd2x0, nn,nx_tot,nx,nvert=',nn,nx_tot,nx,nvert
+
+  nx_0=-1
+  nx_1=-2
+  nn=0
+  do n=1,npe
+     if(n <= kchk) then
+        kk=nx_this
+     else
+        kk=nx_this-1
+     end if
+     if(kk >  0) then
+        if(mype+1 == n) then
+           nx_0=nn+1
+           nx_1=nn+kk
+        end if
+        do k=1,kk
+           nn=nn+1
+           list_sd2y(3,nn)=n
+        end do
+     end if
+  end do
+
+  end subroutine zrnmi_sd2y0
+
+  subroutine zrnmi_sd2y1(mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_sd2y1
+!
+!   prgrmmr: 
+!
+! abstract:      
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block, rm unused uses
+!
+!   input argument list:
+!     mype     - mpi task id
+!
+!   output argument list:
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+
+!  continue with setup for subdomain to x strip interchanges
+
+    use gridmod, only: lon2,lat2,jstart,istart
+    use m_mpimod, only: npe,gsi_mpi_comm_world,ierror,mpi_integer4
+    implicit none
+
+    integer(i_kind),intent(in   ) :: mype
+
+    integer(i_kind) list2(nx,nvert)
+    integer(i_kind) i,ii,ii0,ix,ivert,j,mm1,nn,nyloc,ipe,ixm,iy,mpi_string1
+    integer(i_kind) nx_tot
+
+    allocate(nsend_sd2y(npe),nrecv_sd2y(npe),ndsend_sd2y(npe+1),ndrecv_sd2y(npe+1))
+    mm1=mype+1
+    nx_tot=nx*nvert
+
+
+    nn=0
+    list2=0
+    do j=1,nx_tot
+       ix=list_sd2y(1,j)
+       ivert=list_sd2y(2,j)
+       if(list2(ix,ivert) /= 0) then
+          if(mype == 0) write(0,*)' problem in zrnmi_sd2y1'
+          call mpi_finalize(i)
+          stop
+       end if
+       list2(ix,ivert)=j
+    end do
+    do ivert=1,nvert
+       do ix=1,nx
+          if(list2(ix,ivert) == 0) then
+             if(mype == 0) write(0,*)' problem in zrnmi_sd2y1'
+             call mpi_finalize(i)
+             stop
+          end if
+       end do
+    end do
+
+!  obtain counts of points to send to each pe from this pe
+
+    nsend_sd2y=0
+    nyloc=lat2-2
+    do ivert=1,nvert
+       do i=2,lon2-1
+          ix=i+jstart(mm1)-2
+          j=list2(ix,ivert)
+          ipe=list_sd2y(3,j)
+          nsend_sd2y(ipe)=nsend_sd2y(ipe)+nyloc
+       end do
+    end do
+
+    ndsend_sd2y(1)=0
+    do i=2,npe+1
+       ndsend_sd2y(i)=ndsend_sd2y(i-1)+nsend_sd2y(i-1)
+    end do
+    nallsend_sd2y=ndsend_sd2y(npe+1)
+    allocate(info_send_sd2y(3,nallsend_sd2y))
+    nsend_sd2y=0
+    do ivert=1,nvert
+       do i=2,lon2-1
+          ix=i+jstart(mm1)-2
+          ixm=list2(ix,ivert)
+          ipe=list_sd2y(3,ixm)
+          do ii=2,lat2-1
+             iy=ii+istart(mm1)-2
+             nsend_sd2y(ipe)=nsend_sd2y(ipe)+1
+             ii0=ndsend_sd2y(ipe)+nsend_sd2y(ipe)
+             info_send_sd2y(1,ii0)=iy
+             info_send_sd2y(2,ii0)=ixm
+             info_send_sd2y(3,ii0)=ivert
+          end do
+       end do
+    end do
+
+    call mpi_alltoall(nsend_sd2y,1,mpi_integer4,nrecv_sd2y,1,mpi_integer4,gsi_mpi_comm_world,ierror)
+    ndrecv_sd2y(1)=0
+    do i=2,npe+1
+       ndrecv_sd2y(i)=ndrecv_sd2y(i-1)+nrecv_sd2y(i-1)
+    end do
+    nallrecv_sd2y=ndrecv_sd2y(npe+1)
+    allocate(info_recv_sd2y(3,nallrecv_sd2y))
+    call mpi_type_contiguous(3,mpi_integer4,mpi_string1,ierror)
+    call mpi_type_commit(mpi_string1,ierror)
+    call mpi_alltoallv(info_send_sd2y,nsend_sd2y,ndsend_sd2y,mpi_string1, &
+                       info_recv_sd2y,nrecv_sd2y,ndrecv_sd2y,mpi_string1,gsi_mpi_comm_world,ierror)
+    call mpi_type_free(mpi_string1,ierror)
+
+  end subroutine zrnmi_sd2y1
+
+  subroutine zrnmi_y2sd1(mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_y2sd1
+!
+!   prgrmmr: 
+!
+! abstract:      
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block, rm unused uses
+!
+!   input argument list:
+!     mype     - mpi task id
+!
+!   output argument list:
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+
+!  use mpi_alltoallv to move u_y (x strips) to u_sd (subdomains)
+
+    use m_kinds, only: r_kind,i_kind
+    use gridmod, only: jstart,istart,ilat1,jlon1
+    use m_mpimod, only: npe,gsi_mpi_comm_world,ierror,mpi_integer4
+    implicit none
+
+
+    integer(i_kind),intent(in   ) :: mype
+
+    integer(i_kind) i,ix,ivert,j,k,mm1,mpi_string1,ipe,iy,nn
+
+    allocate(nsend_y2sd(npe),nrecv_y2sd(npe),ndsend_y2sd(npe+1),ndrecv_y2sd(npe+1))
+    mm1=mype+1
+
+!      1.  for each pe, gather up list of points from this set of lat strips destined
+!             for subdomain of pe
+    do ipe=1,npe
+       nn=0
+       do k=nx_0,nx_1
+          ix=list_sd2y(1,k)
+          ivert=list_sd2y(2,k)
+          i=ix-jstart(ipe)+2
+          if(i >= 1.and.i <= jlon1(ipe)+2) then
+             do j=1,ilat1(ipe)+2
+                iy=j+istart(ipe)-2
+                if(iy >= 1.and.iy <= ny) nn=nn+1
+             end do
+          end if
+       end do
+       nsend_y2sd(ipe)=nn
+    end do
+
+    ndsend_y2sd(1)=0
+    do i=2,npe+1
+       ndsend_y2sd(i)=ndsend_y2sd(i-1)+nsend_y2sd(i-1)
+    end do
+    nallsend_y2sd=ndsend_y2sd(npe+1)
+    allocate(info_send_y2sd(3,nallsend_y2sd))
+    nn=0
+    do ipe=1,npe
+       do k=nx_0,nx_1
+          ix=list_sd2y(1,k)
+          ivert=list_sd2y(2,k)
+          i=ix-jstart(ipe)+2
+          if(i >= 1.and.i <= jlon1(ipe)+2) then
+             do j=1,ilat1(ipe)+2
+                iy=j+istart(ipe)-2
+                if(iy >= 1.and.iy <= ny) then
+                   nn=nn+1
+                   info_send_y2sd(1,nn)=iy
+                   info_send_y2sd(2,nn)=j
+                   info_send_y2sd(3,nn)=k
+                end if
+             end do
+          end if
+       end do
+    end do
+
+    call mpi_alltoall(nsend_y2sd,1,mpi_integer4,nrecv_y2sd,1,mpi_integer4,gsi_mpi_comm_world,ierror)
+    ndrecv_y2sd(1)=0
+    do i=2,npe+1
+       ndrecv_y2sd(i)=ndrecv_y2sd(i-1)+nrecv_y2sd(i-1)
+    end do
+    nallrecv_y2sd=ndrecv_y2sd(npe+1)
+    allocate(info_recv_y2sd(3,nallrecv_y2sd))
+    call mpi_type_contiguous(3,mpi_integer4,mpi_string1,ierror)
+    call mpi_type_commit(mpi_string1,ierror)
+    call mpi_alltoallv(info_send_y2sd,nsend_y2sd,ndsend_y2sd,mpi_string1, &
+                       info_recv_y2sd,nrecv_y2sd,ndrecv_y2sd,mpi_string1,gsi_mpi_comm_world,ierror)
+    call mpi_type_free(mpi_string1,ierror)
+
+  end subroutine zrnmi_y2sd1
+
+  subroutine zrnmi_sd2y2(u1_sd,u2_sd,u1_y,u2_y,mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_sd2y2
+!
+!   prgrmmr: 
+!
+! abstract:      
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block, rm unused uses
+!
+!   input argument list:
+!     mype     - mpi task id
+!     u1_sd    -
+!     u2_sd    -
+!
+!   output argument list:
+!     u1_y     -
+!     u2_y     -
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+
+!  use mpi_alltoallv to move u_sd (subdomains) to u_y (x strips)
+
+    use m_kinds, only: r_kind,i_kind
+    use gridmod, only: lon2,lat2,jstart,istart
+    use m_mpimod, only: gsi_mpi_comm_world,ierror,mpi_rtype
+    implicit none
+
+    integer(i_kind)                        ,intent(in   ) :: mype
+
+    real(r_kind),dimension(lat2,lon2,nvert),intent(in   ) :: u1_sd,u2_sd
+    real(r_kind),dimension(ny,nx_0:nx_1)   ,intent(  out) :: u1_y,u2_y
+
+    integer(i_kind) ix,ixm,iy,ivert,j,mm1,mpi_string1
+    real(r_kind),allocatable::sendbuf(:,:),recvbuf(:,:)
+
+    mm1=mype+1
+
+    allocate(sendbuf(2,nallsend_sd2y))
+    do j=1,nallsend_sd2y
+       iy=info_send_sd2y(1,j)
+       ixm=info_send_sd2y(2,j)
+       ix=list_sd2y(1,ixm)
+       ivert=list_sd2y(2,ixm)
+       sendbuf(1,j)=u1_sd(iy-istart(mm1)+2,ix-jstart(mm1)+2,ivert)
+       sendbuf(2,j)=u2_sd(iy-istart(mm1)+2,ix-jstart(mm1)+2,ivert)
+    end do
+    call mpi_type_contiguous(2,mpi_rtype,mpi_string1,ierror)
+    call mpi_type_commit(mpi_string1,ierror)
+    allocate(recvbuf(2,nallrecv_sd2y))
+    call mpi_alltoallv(sendbuf,nsend_sd2y,ndsend_sd2y,mpi_string1, &
+                       recvbuf,nrecv_sd2y,ndrecv_sd2y,mpi_string1,gsi_mpi_comm_world,ierror)
+    call mpi_type_free(mpi_string1,ierror)
+    deallocate(sendbuf)
+
+    do j=1,nallrecv_sd2y
+       iy=info_recv_sd2y(1,j)
+       ixm=info_recv_sd2y(2,j)
+       u1_y(iy,ixm)=recvbuf(1,j)
+       u2_y(iy,ixm)=recvbuf(2,j)
+    end do
+    deallocate(recvbuf)
+
+  end subroutine zrnmi_sd2y2
+
+  subroutine zrnmi_y2sd2(u1_sd,u2_sd,u1_y,u2_y,mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_y2sd2
+!
+!   prgrmmr: 
+!
+! abstract:      
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block, rm unused uses
+!
+!   input argument list:
+!     mype     - mpi task id
+!     u1_y     -
+!     u2_y     -
+!
+!   output argument list:
+!     u1_sd    -
+!     u2_sd    -
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+
+!  use mpi_alltoallv to move u_y (x strips) to u_sd (subdomains)
+
+    use m_kinds, only: r_kind,i_kind
+    use gridmod, only: lon2,lat2,jstart
+    use m_mpimod, only: gsi_mpi_comm_world,ierror,mpi_rtype
+    use constants, only: zero
+    implicit none
+
+
+    integer(i_kind)                        ,intent(in   ) :: mype
+    real(r_kind),dimension(lat2,lon2,nvert),intent(  out) :: u1_sd,u2_sd
+    real(r_kind),dimension(ny,nx_0:nx_1)   ,intent(in   ) :: u1_y,u2_y
+
+    real(r_kind),allocatable::sendbuf(:,:),recvbuf(:,:)
+    integer(i_kind) ix,ivert,j,mm1,ixm,iy,iyloc,mpi_string1
+
+    mm1=mype+1
+
+    u1_sd=zero
+    u2_sd=zero
+    allocate(sendbuf(2,nallsend_y2sd))
+    do j=1,nallsend_y2sd
+       iy=info_send_y2sd(1,j)
+       ixm=info_send_y2sd(3,j)
+       sendbuf(1,j)=u1_y(iy,ixm)
+       sendbuf(2,j)=u2_y(iy,ixm)
+    end do
+    call mpi_type_contiguous(2,mpi_rtype,mpi_string1,ierror)
+    call mpi_type_commit(mpi_string1,ierror)
+    allocate(recvbuf(2,nallrecv_y2sd))
+    call mpi_alltoallv(sendbuf,nsend_y2sd,ndsend_y2sd,mpi_string1, &
+                       recvbuf,nrecv_y2sd,ndrecv_y2sd,mpi_string1,gsi_mpi_comm_world,ierror)
+    call mpi_type_free(mpi_string1,ierror)
+    deallocate(sendbuf)
+    do j=1,nallrecv_y2sd
+       iyloc=info_recv_y2sd(2,j)
+       ixm=info_recv_y2sd(3,j)
+       ix=list_sd2y(1,ixm)
+       ivert=list_sd2y(2,ixm)
+       u1_sd(iyloc,ix-jstart(mm1)+2,ivert)=recvbuf(1,j)
+       u2_sd(iyloc,ix-jstart(mm1)+2,ivert)=recvbuf(2,j)
+    end do
+    deallocate(recvbuf)
+
+  end subroutine zrnmi_y2sd2
+
+  subroutine zrnmi_x_strans0
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_x_strans0
+!
+!   prgrmmr: 
+!
+! abstract:      
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block, rm unused uses
+!
+!   input argument list:
+!
+!   output argument list:
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+
+    use constants, only: one,two,pi
+    implicit none
+
+    integer(i_kind) k,n
+
+    allocate(sinx(nx,nx))
+    do k=1,nx
+       do n=1,nx
+          sinx(n,k)=sqrt(two/(nx+one))*sin(pi*k*n/(nx+one))
+       end do
+    end do
+
+  end subroutine zrnmi_x_strans0
+
+  subroutine zrnmi_x_strans(g_x,gt_x)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_x_strans
+!
+!   prgrmmr: 
+!
+! abstract:      
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block
+!
+!   input argument list:
+!     g_x      - 
+!
+!   output argument list:
+!     gt_x     - 
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+
+    use constants, only: zero,half,one
+    implicit none
+
+    real(r_kind),intent(in   ) :: g_x(nx,ny_0:ny_1)
+    real(r_kind),intent(  out) :: gt_x(nx,ny_0:ny_1)
+
+    integer(i_kind) i,i1,j,k,k1
+    real(r_kind) diff,factor,sum,diff1,sum1
+
+    do j=ny_0,ny_1
+       do k=1,nx
+          gt_x(k,j)=zero
+       end do
+       do i=1,((nx+1)/2),2
+          factor=one
+          if(nx+1-i == i) factor=half
+          sum =factor*(g_x(i,j)+g_x(nx+1-i,j))
+          diff=        g_x(i,j)-g_x(nx+1-i,j)
+          i1=i+1
+          if(i1 <= (nx+1)/2) then
+             factor=one
+             if(nx+1-i1 == i1) factor=half
+             sum1 =factor*(g_x(i1,j)+g_x(nx+1-i1,j))
+             diff1=        g_x(i1,j)-g_x(nx+1-i1,j)
+             do k=1,nx-1,2
+                k1=k+1
+                gt_x(k ,j)=gt_x(k ,j)+sinx(k ,i)*sum +sinx(k ,i1)*sum1
+                gt_x(k1,j)=gt_x(k1,j)+sinx(k1,i)*diff+sinx(k1,i1)*diff1
+             end do
+             if(mod(nx,2) == 1) gt_x(nx,j)=gt_x(nx,j)+sinx(nx,i)*sum+sinx(nx,i1)*sum1
+          else
+             do k=1,nx-1,2
+                k1=k+1
+                gt_x(k,j)=gt_x(k,j)+sinx(k,i)*sum
+                gt_x(k1,j)=gt_x(k1,j)+sinx(k1,i)*diff
+             end do
+             if(mod(nx,2) == 1) gt_x(nx,j)=gt_x(nx,j)+sinx(nx,i)*sum
+          end if
+       end do
+    end do
+
+  end subroutine zrnmi_x_strans
+ 
+  subroutine zrnmi_uvm2dzmhat(u,v,m,dhat,zhat,mhat,mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_uvm2dzmhat
+!
+!   prgrmmr: 
+!
+! abstract:      
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block, rm unused uses
+!
+!   input argument list:
+!     mype     - mpi task id
+!     u        - 
+!     v        - 
+!     m        - 
+!
+!   output argument list:
+!     dhat     - 
+!     zhat     - 
+!     mhat     - 
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+
+    use gridmod, only: lon2,lat2
+    implicit none
+
+    integer(i_kind)                        ,intent(in   ) :: mype
+    real(r_kind),dimension(lat2,lon2,nvert),intent(in   ) :: u,v,m
+    real(r_kind),dimension(ny,mx_0:mx_1)   ,intent(  out) :: dhat,zhat,mhat
+
+    real(r_kind),dimension(lat2,lon2,nvert):: d,z
+    real(r_kind),dimension(nx,ny_0:ny_1):: d_x,z_x,m_x
+    real(r_kind),dimension(nx,ny_0:ny_1):: d4_x,z4_x,m4_x
+    real(r_kind),dimension(ny,mx_0:mx_1):: d_y,z_y,m_y
+
+    call zrnmi_uv2dz(u,v,d,z,mype)
+    call zrnmi_sd2x3(d,z,m,d_x,z_x,m_x,mype)
+    call zrnmi_x_strans(d_x,d4_x)
+    call zrnmi_x_strans(z_x,z4_x)
+    call zrnmi_x_strans(m_x,m4_x)
+    call zrnmi_x2y3(d4_x,z4_x,m4_x,d_y,z_y,m_y,mype)
+    call zrnmi_y_strans(d_y,dhat)
+    call zrnmi_y_strans(z_y,zhat)
+    call zrnmi_y_strans(m_y,mhat)
+
+  end subroutine zrnmi_uvm2dzmhat
+
+  subroutine zrnmi_uvm2dzmhat_ad(u,v,m,dhat,zhat,mhat,mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_uvm2dzmhat_ad
+!
+!   prgrmmr: 
+!
+! abstract:      
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block, rm unused uses
+!
+!   input argument list:
+!     mype     - mpi task id
+!     dhat     - 
+!     zhat     - 
+!     mhat     - 
+!
+!   output argument list:
+!     u        - 
+!     v        - 
+!     m        - 
+!     dhat     - 
+!     zhat     - 
+!     mhat     - 
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+
+    use gridmod, only: lon2,lat2
+    implicit none
+
+    integer(i_kind)                        ,intent(in   ) :: mype
+    real(r_kind),dimension(lat2,lon2,nvert),intent(  out) :: u,v,m
+    real(r_kind),dimension(ny,mx_0:mx_1)   ,intent(inout) :: dhat,zhat,mhat
+
+    real(r_kind),dimension(lat2,lon2,nvert):: d,z
+    real(r_kind),dimension(nx,ny_0:ny_1):: d_x,z_x,m_x
+    real(r_kind),dimension(nx,ny_0:ny_1):: d4_x,z4_x,m4_x
+    real(r_kind),dimension(ny,mx_0:mx_1):: d_y,z_y,m_y
+
+    call zrnmi_y_strans(mhat,m_y)
+    call zrnmi_y_strans(zhat,z_y)
+    call zrnmi_y_strans(dhat,d_y)
+    call zrnmi_y2x3(d4_x,z4_x,m4_x,d_y,z_y,m_y,mype)
+    call zrnmi_x_strans(m4_x,m_x)
+    call zrnmi_x_strans(z4_x,z_x)
+    call zrnmi_x_strans(d4_x,d_x)
+    call zrnmi_x2sd3(d,z,m,d_x,z_x,m_x,mype)
+    call zrnmi_uv2dz_ad(u,v,d,z,mype)
+
+  end subroutine zrnmi_uvm2dzmhat_ad
+
+  subroutine zrnmi_pcmhat2uvm(p,c,m,phat,chat,mhat,mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_pcmhat2uvm
+!
+!   prgrmmr: 
+!
+! abstract:      
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block, rm unused uses
+!
+!   input argument list:
+!     mype     - mpi task id
+!     phat     - 
+!     chat     - 
+!     mhat     - 
+!
+!   output argument list:
+!     p        - 
+!     c        - 
+!     m        - 
+!     phat     - 
+!     chat     - 
+!     mhat     - 
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+ 
+    use gridmod, only: lon2,lat2
+    implicit none
+ 
+    integer(i_kind)                        ,intent(in   ) :: mype
+    real(r_kind),dimension(lat2,lon2,nvert),intent(  out) :: p,c,m
+    real(r_kind),dimension(ny,mx_0:mx_1)   ,intent(inout) :: phat,chat,mhat
+ 
+    real(r_kind),dimension(nx,ny_0:ny_1):: p_x,c_x,m_x
+    real(r_kind),dimension(nx,ny_0:ny_1):: p4_x,c4_x,m4_x
+    real(r_kind),dimension(ny,mx_0:mx_1):: p_y,c_y,m_y
+
+    call zrnmi_y_strans(phat,p_y)
+    call zrnmi_y_strans(chat,c_y)
+    call zrnmi_y_strans(mhat,m_y)
+    call zrnmi_y2x3(p4_x,c4_x,m4_x,p_y,c_y,m_y,mype)
+    call zrnmi_x_strans(p4_x,p_x)
+    call zrnmi_x_strans(c4_x,c_x)
+    call zrnmi_x_strans(m4_x,m_x)
+    call zrnmi_x2sd3(p,c,m,p_x,c_x,m_x,mype)
+ 
+  end subroutine zrnmi_pcmhat2uvm
+
+  subroutine zrnmi_pcmhat2uvm_orig(u,v,m,phat,chat,mhat,mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_pcmhat2uvm
+!
+!   prgrmmr:
+!
+! abstract:
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block, rm unused uses
+!
+!   input argument list:
+!     mype     - mpi task id
+!     phat     -
+!     chat     -
+!     mhat     -
+!
+!   output argument list:
+!     p        -
+!     c        -
+!     m        -
+!     phat     -
+!     chat     -
+!     mhat     -
+!
+! attributes:
+!   language:  f90
+!   machine:
+!
+!$$$
+
+    use gridmod, only: lon2,lat2
+
+    integer(i_kind)                        ,intent(in   ) :: mype
+    real(r_kind),dimension(lat2,lon2,nvert),intent(  out) :: u,v,m
+    real(r_kind),dimension(ny,mx_0:mx_1)   ,intent(inout) :: phat,chat,mhat
+
+    real(r_kind),dimension(lat2,lon2,nvert):: p,c
+    real(r_kind),dimension(nx,ny_0:ny_1):: p_x,c_x,m_x
+    real(r_kind),dimension(nx,ny_0:ny_1):: p4_x,c4_x,m4_x
+    real(r_kind),dimension(ny,mx_0:mx_1):: p_y,c_y,m_y
+
+    call zrnmi_y_strans(phat,p_y)
+    call zrnmi_y_strans(chat,c_y)
+    call zrnmi_y_strans(mhat,m_y)
+    call zrnmi_y2x3(p4_x,c4_x,m4_x,p_y,c_y,m_y,mype)
+    call zrnmi_x_strans(p4_x,p_x)
+    call zrnmi_x_strans(c4_x,c_x)
+    call zrnmi_x_strans(m4_x,m_x)
+    call zrnmi_x2sd3(p,c,m,p_x,c_x,m_x,mype)
+    call zrnmi_pc2uv_orig(p,c,u,v,mype)
+
+  end subroutine zrnmi_pcmhat2uvm_orig
+
+  subroutine zrnmi_pcmhat2uvm_ad_orig(u,v,m,phat,chat,mhat,mype)
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    zrnmi_pcmhat2uvm_ad_orig
+!   prgmmr:
+!
+! abstract:
+!
+! program history log:
+!   2010-01-07  lueken - added subprogram doc block
+!
+!   input argument list:
+!    mype
+!    u,v,m
+!
+!   output argument list:
+!    u,v,m
+!    phat,chat,mhat
+!
+! attributes:
+!   language: f90
+!   machine:
+!
+!$$$ end documentation block
+    use constants, only: zero
+    use gridmod, only: lon2,lat2
+    implicit none
+
+    integer(i_kind)                        ,intent(in   ) :: mype
+    real(r_kind),dimension(lat2,lon2,nvert),intent(inout) :: u,v,m
+    real(r_kind),dimension(ny,mx_0:mx_1)   ,intent(  out) :: phat,chat,mhat
+
+    real(r_kind),dimension(lat2,lon2,nvert):: p,c
+    real(r_kind),dimension(nx,ny_0:ny_1):: p_x,c_x,m_x
+    real(r_kind),dimension(nx,ny_0:ny_1):: p4_x,c4_x,m4_x
+    real(r_kind),dimension(ny,mx_0:mx_1):: p_y,c_y,m_y
+
+    call zrnmi_pc2uv_ad_orig(p,c,u,v,mype)
+    call zrnmi_sd2x3(p,c,m,p_x,c_x,m_x,mype)
+    call zrnmi_x_strans(p_x,p4_x)
+    call zrnmi_x_strans(c_x,c4_x)
+    call zrnmi_x_strans(m_x,m4_x)
+    call zrnmi_x2y3(p4_x,c4_x,m4_x,p_y,c_y,m_y,mype)
+    call zrnmi_y_strans(p_y,phat)
+    call zrnmi_y_strans(c_y,chat)
+    call zrnmi_y_strans(m_y,mhat)
+
+  end subroutine zrnmi_pcmhat2uvm_ad_orig
+
+  subroutine zrnmi_pcmhat2uvm_ad(p,c,m,phat,chat,mhat,mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_pcmhat2uvm_ad
+!
+!   prgrmmr: 
+!
+! abstract:      
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block, rm unused uses
+!
+!   input argument list:
+!     mype     - mpi task id
+!     p        - 
+!     c        - 
+!     m        - 
+!
+!   output argument list:
+!     p        - 
+!     c        - 
+!     m        - 
+!     phat     - 
+!     chat     - 
+!     mhat     - 
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+ 
+    use gridmod, only: lon2,lat2
+    implicit none
+ 
+    integer(i_kind)                        ,intent(in   ) :: mype
+    real(r_kind),dimension(lat2,lon2,nvert),intent(inout) :: p,c,m
+    real(r_kind),dimension(ny,mx_0:mx_1)   ,intent(  out) :: phat,chat,mhat
+ 
+    real(r_kind),dimension(nx,ny_0:ny_1):: p_x,c_x,m_x
+    real(r_kind),dimension(nx,ny_0:ny_1):: p4_x,c4_x,m4_x
+    real(r_kind),dimension(ny,mx_0:mx_1):: p_y,c_y,m_y
+
+    call zrnmi_sd2x3(p,c,m,p_x,c_x,m_x,mype)
+    call zrnmi_x_strans(p_x,p4_x)
+    call zrnmi_x_strans(c_x,c4_x)
+    call zrnmi_x_strans(m_x,m4_x)
+    call zrnmi_x2y3(p4_x,c4_x,m4_x,p_y,c_y,m_y,mype)
+    call zrnmi_y_strans(p_y,phat)
+    call zrnmi_y_strans(c_y,chat)
+    call zrnmi_y_strans(m_y,mhat)
+ 
+  end subroutine zrnmi_pcmhat2uvm_ad
+
+  subroutine zrnmi_x2y0(mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_x2y0
+!
+!   prgrmmr: 
+!
+! abstract:      
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block
+!
+!   input argument list:
+!     mype     - mpi task id
+!
+!   output argument list:
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+
+!  create y (x strips) subdivision for use with sine transform in y direction
+
+!  output:
+
+!     mx_0,mx_1:  range of x/vert index on processor mype
+
+!           1 <= mx_0 <= mx_1 <= nx*nvert
+!           if npe > nx*nvert, then will have mx_0 = -1, mx_1 = -2 on some processors,
+!               and mx_0=mx_1 on the remaining nx*nvert processors
+!
+!     list_x2y(3,nx*nvert):  global definition of contents of each x/vert strip
+!                      list_x2y(1,j) = x index for y strip j
+!                      list_x2y(2,j) = vert level for y strip j
+!                      list_x2y(3,j) = pe of this x/vert strip
+
+    use m_mpimod, only:  npe
+    implicit none
+
+    integer(i_kind),intent(in   ) :: mype
+
+    integer(i_kind) i,k,kchk,kk,n,nn,mx_this,mx_tot
+
+    allocate(list_x2y(3,nx*nvert))
+
+    mx_tot=nx*nvert
+    mx_this=mx_tot/npe
+    if(mod(mx_tot,npe)/=0) mx_this=mx_this+1
+    if(mod(mx_tot,npe)==0) then
+       kchk=npe
+    else
+       kchk=mod(mx_tot,npe)
+    end if
+
+    nn=0
+    do k=1,nvert
+       do i=1,nx
+          nn=nn+1
+          list_x2y(1,nn)=i
+          list_x2y(2,nn)=k
+          list_x2y(3,nn)=-1
+       end do
+    end do
+
+    if(mype == 0) write(6,*)' in zrnmi_x2y0, nn,mx_tot,nx,nvert=',nn,mx_tot,nx,nvert
+
+    mx_0=-1
+    mx_1=-2
+    nn=0
+    do n=1,npe
+       if(n <= kchk) then
+          kk=mx_this
+       else
+          kk=mx_this-1
+       end if
+       if(kk >  0) then
+          if(mype+1 == n) then
+             mx_0=nn+1
+             mx_1=nn+kk
+          end if
+          do k=1,kk
+             nn=nn+1
+             list_x2y(3,nn)=n
+          end do
+       end if
+    end do
+
+  end subroutine zrnmi_x2y0
+
+  subroutine zrnmi_x2y1(mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_x2y1
+!
+!   prgrmmr: 
+!
+! abstract:      
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block, rm unused uses
+!
+!   input argument list:
+!     mype     - mpi task id
+!
+!   output argument list:
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+
+!  continue with setup for x strip to y strip communication
+
+    use m_mpimod, only: npe,gsi_mpi_comm_world,ierror,mpi_integer4
+    implicit none
+
+    integer(i_kind),intent(in   ) :: mype
+
+    integer(i_kind) list2(nx,nvert)
+    integer(i_kind) i,ii0,ix,ivert,j,k,ipe,ixm,iy,mpi_string1
+    integer(i_kind) mx_tot
+
+    allocate(nsend_x2y(npe),nrecv_x2y(npe),ndsend_x2y(npe+1),ndrecv_x2y(npe+1))
+    mx_tot=nx*nvert
+
+    list2=0
+    do j=1,mx_tot
+       ix=list_x2y(1,j)
+       ivert=list_x2y(2,j)
+       if(list2(ix,ivert) /= 0) then
+          if(mype == 0) write(0,*)' problem in zrnmi_x2y1'
+          call mpi_finalize(i)
+          stop
+       end if
+       list2(ix,ivert)=j
+    end do
+    do ivert=1,nvert
+       do ix=1,nx
+          if(list2(ix,ivert) == 0) then
+             if(mype == 0) write(0,*)' problem in zrnmi_x2y1'
+             call mpi_finalize(i)
+             stop
+          end if
+       end do
+    end do
+
+!  obtain counts of points to send to each pe from this pe
+
+    nsend_x2y=0
+    do k=ny_0,ny_1
+       ivert=list_sd2x(2,k)
+       do ix=1,nx
+          j=list2(ix,ivert)
+          ipe=list_x2y(3,j)
+          nsend_x2y(ipe)=nsend_x2y(ipe)+1
+       end do
+    end do
+
+    ndsend_x2y(1)=0
+    do i=2,npe+1
+       ndsend_x2y(i)=ndsend_x2y(i-1)+nsend_x2y(i-1)
+    end do
+    nallsend_x2y=ndsend_x2y(npe+1)
+    allocate(info_send_x2y(4,nallsend_x2y))
+    nsend_x2y=0
+    do k=ny_0,ny_1
+       iy=list_sd2x(1,k)
+       ivert=list_sd2x(2,k)
+       do ix=1,nx
+          ixm=list2(ix,ivert)
+          ipe=list_x2y(3,ixm)
+          nsend_x2y(ipe)=nsend_x2y(ipe)+1
+          ii0=ndsend_x2y(ipe)+nsend_x2y(ipe)
+          info_send_x2y(1,ii0)=ix
+          info_send_x2y(2,ii0)=k
+          info_send_x2y(3,ii0)=iy
+          info_send_x2y(4,ii0)=ixm
+       end do
+    end do
+
+    call mpi_alltoall(nsend_x2y,1,mpi_integer4,nrecv_x2y,1,mpi_integer4,gsi_mpi_comm_world,ierror)
+    ndrecv_x2y(1)=0
+    do i=2,npe+1
+       ndrecv_x2y(i)=ndrecv_x2y(i-1)+nrecv_x2y(i-1)
+    end do
+    nallrecv_x2y=ndrecv_x2y(npe+1)
+    allocate(info_recv_x2y(4,nallrecv_x2y))
+    call mpi_type_contiguous(4,mpi_integer4,mpi_string1,ierror)
+    call mpi_type_commit(mpi_string1,ierror)
+    call mpi_alltoallv(info_send_x2y,nsend_x2y,ndsend_x2y,mpi_string1, &
+                     info_recv_x2y,nrecv_x2y,ndrecv_x2y,mpi_string1,gsi_mpi_comm_world,ierror)
+    call mpi_type_free(mpi_string1,ierror)
+
+  end subroutine zrnmi_x2y1
+
+  subroutine zrnmi_x2y3(u1_x,u2_x,u3_x,u1_y,u2_y,u3_y,mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_x2y3
+!
+!   prgrmmr: 
+!
+! abstract:      
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block
+!
+!   input argument list:
+!     mype     - mpi task id
+!     u1_x     -
+!     u2_x     -
+!     u3_x     -
+!
+!   output argument list:
+!     u1_y     -
+!     u2_y     -
+!     u3_y     -
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+
+    use m_mpimod, only: gsi_mpi_comm_world,ierror,mpi_rtype
+    implicit none
+
+    integer(i_kind)                     ,intent(in   ) :: mype
+    real(r_kind),dimension(nx,ny_0:ny_1),intent(in   ) :: u1_x,u2_x,u3_x
+    real(r_kind),dimension(ny,mx_0:mx_1),intent(  out) :: u1_y,u2_y,u3_y
+
+    integer(i_kind) ixm,ix,iy,iym,j,mm1,mpi_string1
+    real(r_kind),allocatable::sendbuf(:,:),recvbuf(:,:)
+
+    mm1=mype+1
+
+    allocate(sendbuf(3,nallsend_x2y))
+    do j=1,nallsend_x2y
+       ix=info_send_x2y(1,j)
+       iym=info_send_x2y(2,j)
+       sendbuf(1,j)=u1_x(ix,iym)
+       sendbuf(2,j)=u2_x(ix,iym)
+       sendbuf(3,j)=u3_x(ix,iym)
+    end do
+    call mpi_type_contiguous(3,mpi_rtype,mpi_string1,ierror)
+    call mpi_type_commit(mpi_string1,ierror)
+    allocate(recvbuf(3,nallrecv_x2y))
+    call mpi_alltoallv(sendbuf,nsend_x2y,ndsend_x2y,mpi_string1, &
+                       recvbuf,nrecv_x2y,ndrecv_x2y,mpi_string1,gsi_mpi_comm_world,ierror)
+    call mpi_type_free(mpi_string1,ierror)
+    deallocate(sendbuf)
+
+    do j=1,nallrecv_x2y
+       iy=info_recv_x2y(3,j)
+       ixm=info_recv_x2y(4,j)
+       u1_y(iy,ixm)=recvbuf(1,j)
+       u2_y(iy,ixm)=recvbuf(2,j)
+       u3_y(iy,ixm)=recvbuf(3,j)
+    end do
+    deallocate(recvbuf)
+    
+  end subroutine zrnmi_x2y3
+
+  subroutine zrnmi_y2x3(u1_x,u2_x,u3_x,u1_y,u2_y,u3_y,mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_y2x3
+!
+!   prgrmmr: 
+!
+! abstract:      
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block, rm unused uses
+!
+!   input argument list:
+!     mype     - mpi task id
+!     u1_y     -
+!     u2_y     -
+!     u3_y     -
+!
+!   output argument list:
+!     u1_x     -
+!     u2_x     -
+!     u3_x     -
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+
+    use m_mpimod, only: gsi_mpi_comm_world,ierror,mpi_rtype
+    implicit none
+
+    integer(i_kind)                     ,intent(in   ) :: mype
+    real(r_kind),dimension(nx,ny_0:ny_1),intent(  out) :: u1_x,u2_x,u3_x
+    real(r_kind),dimension(ny,mx_0:mx_1),intent(in   ) :: u1_y,u2_y,u3_y
+
+    integer(i_kind) ixm,ix,iy,iym,j,mm1,mpi_string1
+    real(r_kind),allocatable::sendbuf(:,:),recvbuf(:,:)
+
+    mm1=mype+1
+
+    allocate(recvbuf(3,nallrecv_x2y))
+    do j=1,nallrecv_x2y
+       iy=info_recv_x2y(3,j)
+       ixm=info_recv_x2y(4,j)
+       recvbuf(1,j)=u1_y(iy,ixm)
+       recvbuf(2,j)=u2_y(iy,ixm)
+       recvbuf(3,j)=u3_y(iy,ixm)
+    end do
+    allocate(sendbuf(3,nallsend_x2y))
+    call mpi_type_contiguous(3,mpi_rtype,mpi_string1,ierror)
+    call mpi_type_commit(mpi_string1,ierror)
+    call mpi_alltoallv(recvbuf,nrecv_x2y,ndrecv_x2y,mpi_string1, &
+                       sendbuf,nsend_x2y,ndsend_x2y,mpi_string1,gsi_mpi_comm_world,ierror)
+    call mpi_type_free(mpi_string1,ierror)
+    deallocate(recvbuf)
+    do j=1,nallsend_x2y
+       ix=info_send_x2y(1,j)
+       iym=info_send_x2y(2,j)
+       u1_x(ix,iym)=sendbuf(1,j)
+       u2_x(ix,iym)=sendbuf(2,j)
+       u3_x(ix,iym)=sendbuf(3,j)
+    end do
+    deallocate(sendbuf)
+
+  end subroutine zrnmi_y2x3
+
+  subroutine zrnmi_y_strans0
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_y_strans0
+!
+!   prgrmmr: 
+!
+! abstract:      
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block, rm unused uses
+!
+!   input argument list:
+!
+!   output argument list:
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+
+    use constants, only: one,two,pi
+    implicit none
+
+    integer(i_kind) k,n
+
+    allocate(siny(ny,ny))
+    do k=1,ny
+       do n=1,ny
+          siny(n,k)=sqrt(two/(ny+one))*sin(pi*k*n/(ny+one))
+       end do
+    end do
+
+  end subroutine zrnmi_y_strans0
+
+  subroutine zrnmi_y_strans(g_y,gt_y)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_y_strans
+!
+!   prgrmmr: 
+!
+! abstract:      
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block
+!
+!   input argument list:
+!     g_y      - 
+!
+!   output argument list:
+!     gt_y     -
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+
+    use constants, only: zero,half,one
+    implicit none
+
+    real(r_kind),intent(in   ) :: g_y(ny,mx_0:mx_1)
+    real(r_kind),intent(  out) :: gt_y(ny,mx_0:mx_1)
+
+    integer(i_kind) i,i1,j,k,k1
+    real(r_kind) diff,factor,sum,diff1,sum1
+
+    do j=mx_0,mx_1
+       do k=1,ny
+          gt_y(k,j)=zero
+       end do
+       do i=1,((ny+1)/2),2
+          factor=one
+          if(ny+1-i == i) factor=half
+          sum =factor*(g_y(i,j)+g_y(ny+1-i,j))
+          diff=        g_y(i,j)-g_y(ny+1-i,j)
+          i1=i+1
+          if(i1 <= (ny+1)/2) then
+             factor=one
+             if(ny+1-i1 == i1) factor=half
+             sum1 =factor*(g_y(i1,j)+g_y(ny+1-i1,j))
+             diff1=        g_y(i1,j)-g_y(ny+1-i1,j)
+             do k=1,ny-1,2
+                k1=k+1
+                gt_y(k ,j)=gt_y(k ,j)+siny(k ,i)*sum +siny(k ,i1)*sum1
+                gt_y(k1,j)=gt_y(k1,j)+siny(k1,i)*diff+siny(k1,i1)*diff1
+             end do
+             if(mod(ny,2) == 1) gt_y(ny,j)=gt_y(ny,j)+siny(ny,i)*sum+siny(ny,i1)*sum1
+          else
+             do k=1,ny-1,2
+                k1=k+1
+                gt_y(k,j)=gt_y(k,j)+siny(k,i)*sum
+                gt_y(k1,j)=gt_y(k1,j)+siny(k1,i)*diff
+             end do
+             if(mod(ny,2) == 1) gt_y(ny,j)=gt_y(ny,j)+siny(ny,i)*sum
+          end if
+       end do
+    end do
+
+  end subroutine zrnmi_y_strans
+
+  subroutine zrnmi_delx_general(f_x,fx_x,vector,iord)
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    zrnmi_delx_general
+!   prgmmr:
+!
+! abstract:
+!
+! program history log:
+!   2010-01-07  lueken - added subprogram doc block
+!
+!   input argument list:
+!    f_x
+!    vector
+!    iord
+!
+!   output argument list:
+!    fx_x
+!
+! attributes:
+!   language: f90
+!   machine:
+!
+!$$$ end documentation block
+    use gridmod, only: region_dy,region_dyi
+
+    real(r_kind)   ,intent(in   ) ::  f_x(nx,ny_0:ny_1)
+    real(r_kind)   ,intent(  out) :: fx_x(nx,ny_0:ny_1)
+    logical        ,intent(in   ) :: vector
+    integer(i_kind),intent(in   ) :: iord
+
+    real(r_kind) work1(nx,ny_0:ny_1)
+    real(r_kind) work2(nx,ny_0:ny_1)
+    integer(i_kind) i,j,iy
+
+    if(vector) then
+       do i=ny_0,ny_1
+          iy=list_sd2x(1,i)
+          do j=1,nx
+             work1(j,i)=f_x(j,i)*region_dy(iy,j)
+          end do
+       end do
+    else
+       do i=ny_0,ny_1
+          do j=1,nx
+             work1(j,i)=f_x(j,i)
+          end do
+       end do
+    end if
+
+    if(iord == 2) call zrnmi_delx(work1,work2)
+   !if(iord == 4) call zrnmi_delx_4th_ord(work1,work2)
+
+    if(vector) then
+       do i=ny_0,ny_1
+          iy=list_sd2x(1,i)
+          do j=1,nx
+             fx_x(j,i)=work2(j,i)*region_dyi(iy,j)
+          end do
+       end do
+    else
+       do i=ny_0,ny_1
+          do j=1,nx
+             fx_x(j,i)=work2(j,i)
+          end do
+       end do
+    end if
+
+  end subroutine zrnmi_delx_general
+
+  subroutine zrnmi_delx(f_x,fx_x)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_delx
+!
+!   prgrmmr: 
+!
+! abstract:      
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block, rm unused uses
+!
+!   input argument list:
+!     f_x      -
+!
+!   output argument list:
+!     fx_x     -
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+
+    use gridmod, only: coeffx
+    implicit none
+
+    real(r_kind)  ,intent(in   ) :: f_x(nx,ny_0:ny_1)
+    real(r_kind),intent(  out) :: fx_x(nx,ny_0:ny_1)
+
+    integer(i_kind) i,j,iy
+
+    do i=ny_0,ny_1
+       iy=list_sd2x(1,i)
+       fx_x(1,i)=(f_x(3,i)-f_x(1,i))*coeffx(iy,1)
+       do j=2,nx-1
+          fx_x(j,i)=(f_x(j+1,i)-f_x(j-1,i))*coeffx(iy,j)
+       end do
+       fx_x(nx,i)=(f_x(nx,i)-f_x(nx-2,i))*coeffx(iy,nx)
+    end do
+
+  end subroutine zrnmi_delx
+
+  subroutine zrnmi_delx_ad(f_x,fx_x)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_delx_ad
+!
+!   prgrmmr: 
+!
+! abstract:      
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block, rm unused uses
+!
+!   input argument list:
+!     fx_x     - 
+!
+!   output argument list:
+!     f_x      - 
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+
+    use constants, only: zero
+    use gridmod, only: coeffx
+    implicit none
+
+    real(r_kind)  ,intent(  out) :: f_x(nx,ny_0:ny_1)
+    real(r_kind)  ,intent(in   ) :: fx_x(nx,ny_0:ny_1)
+
+    integer(i_kind) i,j,iy
+
+    f_x=zero
+    do i=ny_0,ny_1
+       iy=list_sd2x(1,i)
+       f_x(nx  ,i)=f_x(nx  ,i)+fx_x(nx,i)*coeffx(iy,nx)
+       f_x(nx-2,i)=f_x(nx-2,i)-fx_x(nx,i)*coeffx(iy,nx)
+       do j=2,nx-1
+          f_x(j+1,i)=f_x(j+1,i)+fx_x(j,i)*coeffx(iy,j)
+          f_x(j-1,i)=f_x(j-1,i)-fx_x(j,i)*coeffx(iy,j)
+       end do
+       f_x(1,i)=f_x(1,i)-fx_x(1,i)*coeffx(iy,1)
+       f_x(3,i)=f_x(3,i)+fx_x(1,i)*coeffx(iy,1)
+    end do
+
+  end subroutine zrnmi_delx_ad
+
+  subroutine zrnmi_dely_general(f_y,fy_y,vector,iord)
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    zrnmi_dely_general
+!   prgmmr:
+!
+! abstract:
+!
+! program history log:
+!   2010-01-07  lueken - added subprogram doc block
+!
+!   input argument list:
+!    f_y
+!    vector
+!    iord
+!
+!   output argument list:
+!    fy_y
+!
+! attributes:
+!   language: f90
+!   machine:
+!
+!$$$ end documentation block
+    use gridmod, only: region_dx,region_dxi
+    implicit none
+
+    real(r_kind)   ,intent(in   ) ::  f_y(ny,nx_0:nx_1)
+    real(r_kind)   ,intent(  out) :: fy_y(ny,nx_0:nx_1)
+    logical        ,intent(in   ) :: vector
+    integer(i_kind),intent(in   ) :: iord
+
+    real(r_kind) work1(ny,nx_0:nx_1)
+    real(r_kind) work2(ny,nx_0:nx_1)
+    integer(i_kind) i,j,ix
+
+    if(vector) then
+       do i=nx_0,nx_1
+          ix=list_sd2y(1,i)
+          do j=1,ny
+             work1(j,i)=f_y(j,i)*region_dx(j,ix)
+          end do
+       end do
+    else
+       do i=nx_0,nx_1
+          do j=1,ny
+             work1(j,i)=f_y(j,i)
+          end do
+       end do
+    end if
+
+    if(iord == 2) call zrnmi_dely(work1,work2)
+   !if(iord == 4) call zrnmi_dely_4th_ord(work1,work2)
+
+    if(vector) then
+       do i=nx_0,nx_1
+          ix=list_sd2y(1,i)
+          do j=1,ny
+             fy_y(j,i)=work2(j,i)*region_dxi(j,ix)
+          end do
+       end do
+    else
+       do i=nx_0,nx_1
+          do j=1,ny
+             fy_y(j,i)=work2(j,i)
+          end do
+       end do
+    end if
+
+  end subroutine zrnmi_dely_general
+
+  subroutine zrnmi_dely(f_y,fy_y)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_dely
+!
+!   prgrmmr: 
+!
+! abstract:      
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block, rm unused uses
+!
+!   input argument list:
+!     f_y      - 
+!
+!   output argument list:
+!     fy_y     - 
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+
+    use gridmod, only: coeffy
+    implicit none
+
+    real(r_kind)  ,intent(in   ) :: f_y(ny,nx_0:nx_1)
+    real(r_kind)  ,intent(  out) :: fy_y(ny,nx_0:nx_1)
+
+    integer(i_kind) i,j,ix
+
+    do i=nx_0,nx_1
+       ix=list_sd2y(1,i)
+       fy_y(1,i)=(f_y(3,i)-f_y(1,i))*coeffy(1,ix)
+       do j=2,ny-1
+          fy_y(j,i)=(f_y(j+1,i)-f_y(j-1,i))*coeffy(j,ix)
+       end do
+       fy_y(ny,i)=(f_y(ny,i)-f_y(ny-2,i))*coeffy(ny,ix)
+    end do
+
+  end subroutine zrnmi_dely
+
+  subroutine zrnmi_dely_ad(f_y,fy_y)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_dely_ad
+!
+!   prgrmmr: 
+!
+! abstract:      
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block, rm unused uses
+!
+!   input argument list:
+!     fy_y     - 
+!
+!   output argument list:
+!     f_y      - 
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+
+    use constants, only: zero
+    use gridmod, only: coeffy
+    implicit none
+
+    real(r_kind)  ,intent(  out) :: f_y(ny,nx_0:nx_1)
+    real(r_kind)  ,intent(in   ) :: fy_y(ny,nx_0:nx_1)
+
+    integer(i_kind) i,j,ix
+
+    f_y=zero
+    do i=nx_0,nx_1
+       ix=list_sd2y(1,i)
+       f_y(ny  ,i)=f_y(ny  ,i)+fy_y(ny,i)*coeffy(ny,ix)
+       f_y(ny-2,i)=f_y(ny-2,i)-fy_y(ny,i)*coeffy(ny,ix)
+       do j=2,ny-1
+          f_y(j+1,i)=f_y(j+1,i)+fy_y(j,i)*coeffy(j,ix)
+          f_y(j-1,i)=f_y(j-1,i)-fy_y(j,i)*coeffy(j,ix)
+       end do
+       f_y(3,i)=f_y(3,i)+fy_y(1,i)*coeffy(1,ix)
+       f_y(1,i)=f_y(1,i)-fy_y(1,i)*coeffy(1,ix)
+    end do
+
+  end subroutine zrnmi_dely_ad
+
+  subroutine zrnmi_uv2dz(u,v,div,vort,mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_uv2dz
+!
+!   prgrmmr: 
+!
+! abstract:      
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block
+!
+!   input argument list:
+!     mype     - mpi task id
+!     u        - 
+!     v        - 
+!
+!   output argument list:
+!     div      - 
+!     vort     - 
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+
+    use m_kinds, only: r_kind,i_kind
+    use constants, only: zero
+    use gridmod, only: lat2,lon2
+    implicit none
+
+! Declare passed variables
+    integer(i_kind)                        ,intent(in   ) :: mype
+    real(r_kind),dimension(lat2,lon2,nvert),intent(in   ) :: u,v
+    real(r_kind),dimension(lat2,lon2,nvert),intent(  out) :: div,vort
+
+! Declare local variables
+    real(r_kind),dimension(nx,ny_0:ny_1)::u_x,v_x,ux_x,vx_x
+    real(r_kind),dimension(ny,nx_0:nx_1)::u_y,v_y,uy_y,vy_y
+    real(r_kind),dimension(lat2,lon2,nvert)::ux,vx,uy,vy
+
+    u_x=zero ; v_x=zero
+    call zrnmi_sd2x2(u,v,u_x,v_x,mype)
+    u_y=zero ; v_y=zero
+    call zrnmi_sd2y2(u,v,u_y,v_y,mype)
+    ux_x=zero
+    call zrnmi_delx_general(u_x,ux_x,.true.,2)
+    vx_x=zero
+    call zrnmi_delx_general(v_x,vx_x,.true.,2)
+    uy_y=zero
+    call zrnmi_dely_general(u_y,uy_y,.true.,2)
+    vy_y=zero
+    call zrnmi_dely_general(v_y,vy_y,.true.,2)
+    ux=zero ; vx=zero
+    call zrnmi_x2sd2(ux,vx,ux_x,vx_x,mype)
+    uy=zero ; vy=zero
+    call zrnmi_y2sd2(uy,vy,uy_y,vy_y,mype)
+    div=ux+vy
+    vort=vx-uy
+
+  end subroutine zrnmi_uv2dz
+
+  subroutine zrnmi_uv2dz_ad(u,v,div,vort,mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_uv2dz_ad
+!
+!   prgrmmr: 
+!
+! abstract:      
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block
+!
+!   input argument list:
+!     mype     - mpi task id
+!     div      - 
+!     vort     - 
+!
+!   output argument list:
+!     u        -
+!     v        -
+!     div      - 
+!     vort     - 
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+
+    use constants, only: zero
+    use gridmod, only: lat2,lon2
+    implicit none
+
+! Declare passed variables
+    integer(i_kind)                        ,intent(in   ) :: mype
+    real(r_kind),dimension(lat2,lon2,nvert),intent(  out) :: u,v
+    real(r_kind),dimension(lat2,lon2,nvert),intent(inout) :: div,vort
+
+! Declare local variables
+    real(r_kind),dimension(nx,ny_0:ny_1)::u_x,v_x,ux_x,vx_x
+    real(r_kind),dimension(ny,nx_0:nx_1)::u_y,v_y,uy_y,vy_y
+    real(r_kind),dimension(lat2,lon2,nvert)::ux,vx,uy,vy
+
+    ux=div
+    uy=-vort
+    vx=vort
+    vy=div
+    uy_y=zero ; vy_y=zero
+    call zrnmi_sd2y2(uy,vy,uy_y,vy_y,mype)
+    ux_x=zero ; vx_x=zero
+    call zrnmi_sd2x2(ux,vx,ux_x,vx_x,mype)
+    v_y=zero
+    call zrnmi_dely_ad(v_y,vy_y)
+    u_y=zero
+    call zrnmi_dely_ad(u_y,uy_y)
+    v_x=zero
+    call zrnmi_delx_ad(v_x,vx_x)
+    u_x=zero
+    call zrnmi_delx_ad(u_x,ux_x)
+    ux=zero ; vx=zero
+    call zrnmi_y2sd2(ux,vx,u_y,v_y,mype)
+    u=zero ; v=zero
+    call zrnmi_x2sd2(u,v,u_x,v_x,mype)
+    u=u+ux ; v=v+vx
+
+  end subroutine zrnmi_uv2dz_ad
+
+  subroutine zrnmi_pc2uv_orig(psi,chi,u,v,mype)
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    zrnmi_pc2uv_orig
+!   prgmmr:
+!
+! abstract:
+!
+! program history log:
+!   2010-01-07  lueken - added subprogram doc block
+!
+!   input argument list:
+!    mype
+!    psi,chi
+!
+!   output argument list:
+!    u,v
+!
+! attributes:
+!   language: f90
+!   machine:
+!
+!$$$ end documentation block
+    use m_kinds, only: r_kind,i_kind
+    use constants, only: zero
+    use gridmod, only: lat2,lon2
+    implicit none
+
+! Declare passed variables
+    integer(i_kind)                        ,intent(in   ) :: mype
+    real(r_kind),dimension(lat2,lon2,nvert),intent(in   ) :: psi,chi
+    real(r_kind),dimension(lat2,lon2,nvert),intent(  out) :: u,v
+
+! Declare local variables
+    real(r_kind),dimension(nx,ny_0:ny_1)::p_x,c_x,px_x,cx_x
+    real(r_kind),dimension(ny,nx_0:nx_1)::p_y,c_y,py_y,cy_y
+    real(r_kind),dimension(lat2,lon2,nvert)::px,cx,py,cy
+
+    p_x=zero ; c_x=zero
+    call zrnmi_sd2x2(psi,chi,p_x,c_x,mype)
+    p_y=zero ; c_y=zero
+    call zrnmi_sd2y2(psi,chi,p_y,c_y,mype)
+    px_x=zero
+    call zrnmi_delx(p_x,px_x)
+    cx_x=zero
+    call zrnmi_delx(c_x,cx_x)
+    py_y=zero
+    call zrnmi_dely(p_y,py_y)
+    cy_y=zero
+    call zrnmi_dely(c_y,cy_y)
+    px=zero ; cx=zero
+    call zrnmi_x2sd2(px,cx,px_x,cx_x,mype)
+    py=zero ; cy=zero
+    call zrnmi_y2sd2(py,cy,py_y,cy_y,mype)
+    u=cx-py
+    v=px+cy
+
+  end subroutine zrnmi_pc2uv_orig
+
+  subroutine zrnmi_pc2uv_ad_orig(psi,chi,u,v,mype)
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    zrnmi_pc2uv_ad_orig
+!   prgmmr:
+!
+! abstract:
+!
+! program history log:
+!   2010-01-07  lueken - added subprogram doc block
+!
+!   input argument list:
+!    mype
+!    u,v
+!
+!   output argument list:
+!    psi,chi
+!    u,v
+!
+! attributes:
+!   language: f90
+!   machine:
+!
+!$$$ end documentation block
+    use m_kinds, only: r_kind,i_kind
+    use constants, only: zero
+    use gridmod, only: lat2,lon2
+    implicit none
+
+! Declare passed variables
+    integer(i_kind)                        ,intent(in   ) :: mype
+    real(r_kind),dimension(lat2,lon2,nvert),intent(  out) :: psi,chi
+    real(r_kind),dimension(lat2,lon2,nvert),intent(inout) :: u,v
+
+! Declare local variables
+    real(r_kind),dimension(nx,ny_0:ny_1)::p_x,c_x,px_x,cx_x
+    real(r_kind),dimension(ny,nx_0:nx_1)::p_y,c_y,py_y,cy_y
+    real(r_kind),dimension(lat2,lon2,nvert)::px,cx,py,cy
+
+    cx=u ; cy=v ; px=v ; py=-u
+    py_y=zero ; cy_y=zero
+    call zrnmi_sd2y2(py,cy,py_y,cy_y,mype)
+    px_x=zero ; cx_x=zero
+    call zrnmi_sd2x2(px,cx,px_x,cx_x,mype)
+    c_y=zero
+    call zrnmi_dely_ad(c_y,cy_y)
+    p_y=zero
+    call zrnmi_dely_ad(p_y,py_y)
+    c_x=zero
+    call zrnmi_delx_ad(c_x,cx_x)
+    p_x=zero
+    call zrnmi_delx_ad(p_x,px_x)
+    py=zero ; cy=zero
+    call zrnmi_y2sd2(py,cy,p_y,c_y,mype)
+    px=zero ; cx=zero
+    call zrnmi_x2sd2(px,cx,p_x,c_x,mype)
+    psi=px+py ; chi=cx+cy
+
+  end subroutine zrnmi_pc2uv_ad_orig
+
+  subroutine zrnmi_constants(mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_constants
+!
+!   prgrmmr: 
+!
+! abstract:      
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block
+!
+!   input argument list:
+!     mype     - mpi task id
+!
+!   output argument list:
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+
+
+    use constants, only: zero,half,one,two,omega,pi,one_tenth,r3600
+    use gridmod, only: region_dx,region_dy
+    use mod_vtrans, only: depths,speeds
+    use m_mpimod,only: mpi_rtype,mpi_integer,mpi_max,mpi_min,mpi_sum,gsi_mpi_comm_world,ierror
+    implicit none
+
+    integer(i_kind),intent(in   ) :: mype
+
+    integer(i_kind) i,j,k,mode
+    real(r_kind) bigk,bigl,dxbar,dybar,a2,ak2,s2
+    real(r_kind) thisperiod,thislength
+    real(r_kind) rlenmax(nvert),permax(nvert)
+    integer(i_kind) numkeep(nvert),numtot(nvert)
+    real(r_kind) rlenmax0(nvert),permax0(nvert)
+    integer(i_kind) numkeep0(nvert),numtot0(nvert)
+    real(r_kind) pmaskmax(nvert),pmaskmin(nvert),pmaskmax0(nvert),pmaskmin0(nvert)
+
+    fbar=two*omega
+    dxbar=zero
+    dybar=zero
+    do j=1,nx
+       do i=1,ny
+          dxbar=dxbar+region_dx(i,j)
+          dybar=dybar+region_dy(i,j)
+       end do
+    end do
+    dxbar=dxbar/(nx*ny)
+    dybar=dybar/(nx*ny)
+    if(mype == 0) then
+       write(6,*)' in zrnmi_constants, dxbar=',dxbar
+       write(6,*)' in zrnmi_constants, dybar=',dybar
+       write(6,*)' in zrnmi_constants,  fbar=', fbar
+       do k=1,nvert
+          write(6,*)' in zrnmi_constants, k,depths(k)=',k,depths(k)
+       end do
+    end if
+
+    allocate(am2(ny,mx_0:mx_1),f_sm2_am2(ny,mx_0:mx_1),sm2(ny,mx_0:mx_1))
+    allocate(a2_p0_sm2(ny,mx_0:mx_1),f_p0_sm2(ny,mx_0:mx_1),p0_sm2(ny,mx_0:mx_1))
+    allocate(pmask(ny,mx_0:mx_1))
+
+    permax=zero
+    rlenmax=zero
+    pmask=zero
+    am2=zero
+    sm2=zero
+    f_sm2_am2=zero
+    p0_sm2=zero
+    a2_p0_sm2=zero
+    f_p0_sm2=zero
+    pmaskmax=-huge(pmaskmax)
+    pmaskmin= huge(pmaskmin)
+    do j=mx_0,mx_1
+       k=list_x2y(1,j)
+       bigk=k
+       ak2=( (two/dxbar)*sin(pi*bigk/(two*(nx+one))) )**2
+       mode=list_x2y(2,j)
+       do i=1,ny
+          bigl=i
+          a2 = ak2 + ( (two/dybar)*sin(pi*bigl/(two*(ny+one))) )**2
+          s2=depths(mode)*a2+fbar**2
+          am2(i,j)=one/a2
+          sm2(i,j)=one/s2
+          f_sm2_am2(i,j)=fbar*sm2(i,j)*am2(i,j)
+          p0_sm2(i,j)=depths(mode)*sm2(i,j)
+          a2_p0_sm2(i,j)=a2*p0_sm2(i,j)
+          f_p0_sm2(i,j)=fbar*p0_sm2(i,j)
+ 
+          thislength=two*pi*sqrt(am2(i,j))
+      !   if(thislength <  3._r_kind*max(dxbar,dybar)) cycle
+          thisperiod=thislength/(speeds(mode)*r3600)
+        ! pmask(i,j)=half*(one-tanh((thisperiod-zrnmi_period_max)/zrnmi_period_width))
+          if(thisperiod <= zrnmi_period_max) pmask(i,j)=one
+          permax(mode)=max(permax(mode),thisperiod)
+          rlenmax(mode)=max(rlenmax(mode),thislength)
+       end do
+    end do
+    numkeep=zero
+    numtot=zero
+    do j=mx_0,mx_1
+       mode=list_x2y(2,j)
+       do i=1,ny
+          numtot(mode)=numtot(mode)+1
+          if(pmask(i,j) >  one_tenth) numkeep(mode)=numkeep(mode)+1
+          pmaskmax(mode)=max(pmask(i,j),pmaskmax(mode))
+          pmaskmin(mode)=min(pmask(i,j),pmaskmin(mode))
+       end do
+    end do
+    call mpi_allreduce(rlenmax,rlenmax0,nvert,mpi_rtype,mpi_max,gsi_mpi_comm_world,ierror)
+    call mpi_allreduce(permax,permax0,nvert,mpi_rtype,mpi_max,gsi_mpi_comm_world,ierror)
+    call mpi_allreduce(pmaskmax,pmaskmax0,nvert,mpi_rtype,mpi_max,gsi_mpi_comm_world,ierror)
+    call mpi_allreduce(pmaskmin,pmaskmin0,nvert,mpi_rtype,mpi_min,gsi_mpi_comm_world,ierror)
+    call mpi_allreduce(numkeep,numkeep0,nvert,mpi_integer,mpi_sum,gsi_mpi_comm_world,ierror)
+    call mpi_allreduce(numtot,numtot0,nvert,mpi_integer,mpi_sum,gsi_mpi_comm_world,ierror)
+    if(mype == 0) then
+       do k=1,nvert
+          write(6,*)' in zrnmi_constants, k,period_max,numkeep,numtot,lenmax,permax=', &
+                      k,zrnmi_period_max,numkeep0(k),numtot0(k),rlenmax0(k),permax0(k)
+       end do
+       do k=1,nvert
+          write(6,*)' in zrnmi_constants, k,pmaskmax,min=',k,pmaskmax0(k),pmaskmin0(k)
+       end do
+    end if
+
+ 
+  end subroutine zrnmi_constants
+
+  subroutine zrnmi_strong_bal_correction(ut,vt,tt,pst,psi,chi,t,ps,baldiag,fullfield,update,mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_strong_bal_correction
+!
+!   prgrmmr: 
+!
+! abstract:      
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block, rm unused uses
+!   2009-11-27  parrish - add uv_hyb_ens.  if present and true, then
+!                          input/output variables psi=u, chi=v.
+!
+!   input argument list:
+!     mype     - mpi task id
+!     ut       - 
+!     vt       - 
+!     tt       - 
+!     pst      - 
+!     psi      - 
+!     chi      - 
+!     t        - 
+!     ps       - 
+!     baldiag  - 
+!     update   - 
+!     fullfield- 
+!
+!   output argument list:
+!     ut       - 
+!     vt       - 
+!     tt       - 
+!     pst      - 
+!     u        - 
+!     v        - 
+!     t        - 
+!     ps       - 
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+
+    use constants, only: zero
+    use gridmod, only: lat2,lon2,nsig
+    use mod_vtrans, only: vtrans,vtrans_inv
+    use mod_vtrans, only: depths
+    use m_mpimod,only: mpi_rtype,mpi_sum,gsi_mpi_comm_world,ierror
+    use jfunc,only: jiter
+    use hybrid_ensemble_parameters, only: uv_hyb_ens
+    implicit none
+
+!   initially just generate projections and make maps
+
+    real(r_kind),dimension(lat2,lon2,nsig),intent(inout) :: ut,vt,tt
+    real(r_kind),dimension(lat2,lon2)     ,intent(inout) :: pst
+    real(r_kind),dimension(lat2,lon2,nsig),intent(inout) :: psi,chi,t
+    real(r_kind),dimension(lat2,lon2)     ,intent(inout) :: ps
+    logical                               ,intent(in   ) :: baldiag,update,fullfield
+    integer(i_kind)                       ,intent(in   ) :: mype
+
+    real(r_kind),dimension(ny,mx_0:mx_1,2)::rbalg
+    real(r_kind),dimension(lat2,lon2,nvert)::utilde,vtilde,mtilde
+    real(r_kind),dimension(ny,mx_0:mx_1)::dhat,zhat,mhat
+    real(r_kind),dimension(ny,mx_0:mx_1)::phat2,chat2,mhat2
+    real(r_kind),dimension(lat2,lon2,nsig)::dpsi,dchi,dt
+    real(r_kind),dimension(lat2,lon2)::dps
+    real(r_kind),dimension(nvert)::baldt(nvert),balagt(nvert)
+    real(r_kind),dimension(nvert)::baldt0(nvert),balagt0(nvert)
+    real(r_kind) baldt_all,balagt_all
+    integer(i_kind) i,j,k,mode
+
+!      vertical mode transform
+
+    utilde=zero ; vtilde=zero ; mtilde=zero
+    call vtrans(ut,vt,tt,pst,utilde,vtilde,mtilde)
+
+!      transform to spectral space
+
+    call zrnmi_uvm2dzmhat(utilde,vtilde,mtilde,dhat,zhat,mhat,mype)
+
+!      apply mask to input spectral fields to limit periods considered
+    dhat=pmask*dhat
+    zhat=pmask*zhat
+    mhat=pmask*mhat
+
+
+
+    if(update) then
+!      compute gravity projected corrections:
+    !  chat2=f_sm2_am2*zhat+sm2*mhat                     !  original, similar to bourke-mcgregor scheme B
+       chat2=               sm2*mhat                     !  emulate bourke-mcgregor scheme A
+       phat2=-f_sm2_am2*dhat
+       mhat2=p0_sm2*dhat
+
+!   transform to grid space
+       if(uv_hyb_ens) then
+          call zrnmi_pcmhat2uvm_orig(utilde,vtilde,mtilde,phat2,chat2,mhat2,mype)
+       else
+          call zrnmi_pcmhat2uvm(utilde,vtilde,mtilde,phat2,chat2,mhat2,mype)
+       end if
+       dt=zero
+       dpsi=zero
+       dchi=zero
+       dps=zero
+       call vtrans_inv(utilde,vtilde,mtilde,dpsi,dchi,dt,dps)
+
+       t=t-dt ; ps=ps-dps
+       psi=psi-dpsi ; chi=chi-dchi
+    end if
+
+
+!     compute baldt, balagt, and bal=baldt+balagt
+    if(baldiag) then
+
+!      compute gravity tendency amplitudes
+       do j=mx_0,mx_1
+          mode=list_x2y(2,j)
+          do i=1,ny
+             rbalg(i,j,1)=sqrt(am2(i,j)*depths(mode))*dhat(i,j)
+             rbalg(i,j,2)=sqrt(a2_p0_sm2(i,j))*(fbar*am2(i,j)*zhat(i,j)+mhat(i,j))
+          end do
+       end do
+       baldt=zero
+       balagt=zero
+       do j=mx_0,mx_1
+          mode=list_x2y(2,j)
+          do i=1,ny
+             baldt(mode)=baldt(mode)  +rbalg(i,j,1)**2
+             balagt(mode)=balagt(mode)+rbalg(i,j,2)**2
+          end do
+       end do
+       call mpi_allreduce(balagt,balagt0,nvert,mpi_rtype,mpi_sum,gsi_mpi_comm_world,ierror)
+       call mpi_allreduce(baldt,baldt0,nvert,mpi_rtype,mpi_sum,gsi_mpi_comm_world,ierror)
+       if(mype == 0) then
+
+          if (fullfield) then
+             write(6,*) 'ZRNMI_STRONG_BAL:   FULL FIELD BALANCE DIAGNOSTICS --  '
+          else
+             write(6,*) 'ZRNMI_STRONG_BAL:   INCREMENTAL BALANCE DIAGNOSTICS --  '
+          end if
+
+          baldt_all=zero ; balagt_all=zero
+          do k=1,nvert
+             baldt_all=baldt_all+baldt0(k)
+             balagt_all=balagt_all+balagt0(k)
+             write(6,*)' jiter, k,baldt,balagt,bal=',jiter,k,baldt0(k),balagt0(k),baldt0(k)+balagt0(k)
+          end do
+          write(6,*)' jiter, baldt,balagt,bal=',jiter,baldt_all,balagt_all,baldt_all+balagt_all
+       end if
+    end if
+
+  end subroutine zrnmi_strong_bal_correction
+
+  subroutine zrnmi_strong_bal_correction_ad(ut,vt,tt,pst,psi,chi,t,ps,update,mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_strong_bal_correction_ad
+!
+!   prgrmmr: 
+!
+! abstract:      
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block, rm unused uses
+!   2009-11-27  parrish - add uv_hyb_ens.  if present and true, then
+!                          input/output variables psi=u, chi=v.
+!
+!   input argument list:
+!     mype     - mpi task id
+!     ut       - 
+!     vt       - 
+!     tt       - 
+!     pst      - 
+!     u        - 
+!     v        - 
+!     t        - 
+!     ps       - 
+!     update   - 
+!
+!   output argument list:
+!     ut       - 
+!     vt       - 
+!     tt       - 
+!     pst      - 
+!     ps       - 
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+
+    use gridmod, only: lat2,lon2,nsig
+    use constants, only: zero
+    use mod_vtrans, only: vtrans_ad,vtrans_inv_ad
+    use hybrid_ensemble_parameters, only: uv_hyb_ens
+    implicit none
+
+!   initially just generate projections and make maps
+
+    real(r_kind),dimension(lat2,lon2,nsig),intent(inout) :: ut,vt,tt
+    real(r_kind),dimension(lat2,lon2)     ,intent(inout) :: pst
+    real(r_kind),dimension(lat2,lon2,nsig),intent(in   ) :: psi,chi,t
+    real(r_kind),dimension(lat2,lon2)     ,intent(in   ) :: ps
+    logical                               ,intent(in   ) :: update
+    integer(i_kind)                       ,intent(in   ) :: mype
+
+    real(r_kind),dimension(lat2,lon2,nvert)::utilde,vtilde,mtilde
+    real(r_kind),dimension(ny,mx_0:mx_1)::dhat,zhat,mhat
+    real(r_kind),dimension(ny,mx_0:mx_1)::phat2,chat2,mhat2
+    real(r_kind),dimension(lat2,lon2,nsig)::dpsi,dchi,dt
+    real(r_kind),dimension(lat2,lon2)::dps
+
+    dhat=zero ; zhat=zero ; mhat=zero
+    dpsi=zero ; dchi=zero ; dt=zero ; dps=zero
+    if(update) then
+       dpsi=-psi ; dchi=-chi ; dt=-t ; dps=-ps
+    
+       utilde=zero ; vtilde=zero ; mtilde=zero
+       call vtrans_inv_ad(utilde,vtilde,mtilde,dpsi,dchi,dt,dps)
+       phat2=zero ; chat2=zero ; mhat2=zero
+       if(uv_hyb_ens) then
+          call zrnmi_pcmhat2uvm_ad_orig(utilde,vtilde,mtilde,phat2,chat2,mhat2,mype)
+       else
+          call zrnmi_pcmhat2uvm_ad(utilde,vtilde,mtilde,phat2,chat2,mhat2,mype)
+       end if
+!       adjoint of gravity projected corrections
+       dhat=p0_sm2*mhat2-f_sm2_am2*phat2
+       zhat=f_sm2_am2*chat2
+       mhat=sm2*chat2
+    end if
+
+!      adjoint of apply mask to input spectral fields to limit periods considered
+    dhat=pmask*dhat
+    zhat=pmask*zhat
+    mhat=pmask*mhat
+
+!      adjoint of transform to spectral space
+    utilde=zero ; vtilde=zero ; mtilde=zero
+    call zrnmi_uvm2dzmhat_ad(utilde,vtilde,mtilde,dhat,zhat,mhat,mype)
+
+!      vertical mode transform
+
+    call vtrans_ad(ut,vt,tt,pst,utilde,vtilde,mtilde)
+
+  end subroutine zrnmi_strong_bal_correction_ad
+
+  subroutine zrnmi_filter_uvm(utilde,vtilde,mtilde,mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    filter low frequency scales from input
+!
+!   prgrmmr: parrish
+!
+! abstract:      
+!
+! program history log:
+!   2009-08-28  parrish
+!
+!   input argument list:
+!     mype     - mpi task id
+!     utilde   - 
+!     vtilde   - 
+!     mtilde   - 
+!
+!   output argument list:
+!     utilde   - 
+!     vtilde   - 
+!     mtilde   - 
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+
+    use constants, only: zero
+    use gridmod, only: lat2,lon2
+
+!   initially just generate projections and make maps
+
+    integer(i_kind)                        ,intent(in   ) :: mype
+    real(r_kind),dimension(lat2,lon2,nvert),intent(inout) :: utilde,vtilde,mtilde
+
+    real(r_kind),dimension(ny,mx_0:mx_1)::dhat,zhat,mhat
+
+!      transform to spectral space
+
+    call zrnmi_uvm2dzmhat(utilde,vtilde,mtilde,dhat,zhat,mhat,mype)
+
+!      apply mask to input spectral fields to limit periods considered
+    dhat=pmask*dhat*am2
+    zhat=pmask*zhat*am2
+    mhat=pmask*mhat
+
+!      transform back to grid space
+    call zrnmi_pcmhat2uvm_orig(utilde,vtilde,mtilde,zhat,dhat,mhat,mype)
+
+  end subroutine zrnmi_filter_uvm
+
+  subroutine zrnmi_filter_uvm_ad(utilde,vtilde,mtilde,mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_filter_uvm_ad
+!
+!   prgrmmr:  parrish
+!
+! abstract:      
+!
+! program history log:
+!   2009-08-28  parrish
+!
+!   input argument list:
+!     mype     - mpi task id
+!     utilde   - 
+!     vtilde   - 
+!     mtilde   - 
+!
+!   output argument list:
+!     utilde   - 
+!     vtilde   - 
+!     mtilde   - 
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+
+    use gridmod, only: lat2,lon2
+    use constants, only: zero
+
+!   initially just generate projections and make maps
+
+    integer(i_kind)                        ,intent(in   ) :: mype
+    real(r_kind),dimension(lat2,lon2,nvert),intent(inout) :: utilde,vtilde,mtilde
+
+    real(r_kind),dimension(ny,mx_0:mx_1)::dhat,zhat,mhat
+
+    dhat=zero ; zhat=zero ; mhat=zero
+    call zrnmi_pcmhat2uvm_ad_orig(utilde,vtilde,mtilde,zhat,dhat,mhat,mype)
+
+!      adjoint of apply mask to input spectral fields to limit periods considered
+    dhat=pmask*dhat*am2
+    zhat=pmask*zhat*am2
+    mhat=pmask*mhat
+
+!      adjoint of transform to spectral space
+    utilde=zero ; vtilde=zero ; mtilde=zero
+    call zrnmi_uvm2dzmhat_ad(utilde,vtilde,mtilde,dhat,zhat,mhat,mype)
+
+  end subroutine zrnmi_filter_uvm_ad
+
+  subroutine zrnmi_filter_uvm2(utilde,vtilde,mtilde,mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    filter low frequency scales from input
+!
+!   prgrmmr: parrish
+!
+! abstract:      
+!
+! program history log:
+!   2009-08-28  parrish
+!
+!   input argument list:
+!     mype     - mpi task id
+!     utilde   - 
+!     vtilde   - 
+!     mtilde   - 
+!
+!   output argument list:
+!     utilde   - 
+!     vtilde   - 
+!     mtilde   - 
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+
+    use constants, only: zero
+    use gridmod, only: lat2,lon2
+
+!   initially just generate projections and make maps
+
+    integer(i_kind)                        ,intent(in   ) :: mype
+    real(r_kind),dimension(lat2,lon2,nvert),intent(inout) :: utilde,vtilde,mtilde
+
+    real(r_kind),dimension(ny,mx_0:mx_1)::uhat,vhat,mhat
+
+!      transform to spectral space
+
+    call zrnmi_uvm2uvmhat(utilde,vtilde,mtilde,uhat,vhat,mhat,mype)
+
+!      apply mask to input spectral fields to limit periods considered
+    uhat=pmask*uhat
+    vhat=pmask*vhat
+    mhat=pmask*mhat
+
+!      transform back to grid space
+    call zrnmi_uvmhat2uvm(utilde,vtilde,mtilde,uhat,vhat,mhat,mype)
+
+  end subroutine zrnmi_filter_uvm2
+
+  subroutine zrnmi_filter_uvm2_ad(utilde,vtilde,mtilde,mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_filter_uvm2_ad
+!
+!   prgrmmr:  parrish
+!
+! abstract:      
+!
+! program history log:
+!   2009-08-28  parrish
+!
+!   input argument list:
+!     mype     - mpi task id
+!     utilde   - 
+!     vtilde   - 
+!     mtilde   - 
+!
+!   output argument list:
+!     utilde   - 
+!     vtilde   - 
+!     mtilde   - 
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+
+    use gridmod, only: lat2,lon2
+    use constants, only: zero
+    implicit none
+
+!   initially just generate projections and make maps
+
+    integer(i_kind)                        ,intent(in   ) :: mype
+    real(r_kind),dimension(lat2,lon2,nvert),intent(inout) :: utilde,vtilde,mtilde
+
+    real(r_kind),dimension(ny,mx_0:mx_1)::uhat,vhat,mhat
+
+    uhat=zero ; vhat=zero ; mhat=zero
+    call zrnmi_uvmhat2uvm_ad(utilde,vtilde,mtilde,uhat,vhat,mhat,mype)
+
+!      adjoint of apply mask to input spectral fields to limit periods considered
+    uhat=pmask*uhat
+    vhat=pmask*vhat
+    mhat=pmask*mhat
+
+!      adjoint of transform to spectral space
+    utilde=zero ; vtilde=zero ; mtilde=zero
+    call zrnmi_uvm2uvmhat_ad(utilde,vtilde,mtilde,uhat,vhat,mhat,mype)
+
+  end subroutine zrnmi_filter_uvm2_ad
+ 
+  subroutine zrnmi_uvm2uvmhat(u,v,m,uhat,vhat,mhat,mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_uvm2uvmhat
+!
+!   prgrmmr: 
+!
+! abstract:      
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block, rm unused uses
+!
+!   input argument list:
+!     mype     - mpi task id
+!     u        - 
+!     v        - 
+!     m        - 
+!
+!   output argument list:
+!     dhat     - 
+!     zhat     - 
+!     mhat     - 
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+
+    use gridmod, only: lon2,lat2
+    implicit none
+
+    integer(i_kind)                        ,intent(in   ) :: mype
+    real(r_kind),dimension(lat2,lon2,nvert),intent(in   ) :: u,v,m
+    real(r_kind),dimension(ny,mx_0:mx_1)   ,intent(  out) :: uhat,vhat,mhat
+
+    real(r_kind),dimension(nx,ny_0:ny_1):: u_x,v_x,m_x
+    real(r_kind),dimension(nx,ny_0:ny_1):: u4_x,v4_x,m4_x
+    real(r_kind),dimension(ny,mx_0:mx_1):: u_y,v_y,m_y
+
+    call zrnmi_sd2x3(u,v,m,u_x,v_x,m_x,mype)
+    call zrnmi_x_strans(u_x,u4_x)
+    call zrnmi_x_strans(v_x,v4_x)
+    call zrnmi_x_strans(m_x,m4_x)
+    call zrnmi_x2y3(u4_x,v4_x,m4_x,u_y,v_y,m_y,mype)
+    call zrnmi_y_strans(u_y,uhat)
+    call zrnmi_y_strans(v_y,vhat)
+    call zrnmi_y_strans(m_y,mhat)
+
+  end subroutine zrnmi_uvm2uvmhat
+
+  subroutine zrnmi_uvm2uvmhat_ad(u,v,m,uhat,vhat,mhat,mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_uvm2uvmhat_ad
+!
+!   prgrmmr: 
+!
+! abstract:      
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block, rm unused uses
+!
+!   input argument list:
+!     mype     - mpi task id
+!     dhat     - 
+!     zhat     - 
+!     mhat     - 
+!
+!   output argument list:
+!     u        - 
+!     v        - 
+!     m        - 
+!     dhat     - 
+!     zhat     - 
+!     mhat     - 
+!
+! attributes:
+!   language:  f90
+!   machine:   
+!
+!$$$
+
+    use gridmod, only: lon2,lat2
+    implicit none
+
+    integer(i_kind)                        ,intent(in   ) :: mype
+    real(r_kind),dimension(lat2,lon2,nvert),intent(  out) :: u,v,m
+    real(r_kind),dimension(ny,mx_0:mx_1)   ,intent(inout) :: uhat,vhat,mhat
+
+    real(r_kind),dimension(nx,ny_0:ny_1):: u_x,v_x,m_x
+    real(r_kind),dimension(nx,ny_0:ny_1):: u4_x,v4_x,m4_x
+    real(r_kind),dimension(ny,mx_0:mx_1):: u_y,v_y,m_y
+
+    call zrnmi_y_strans(mhat,m_y)
+    call zrnmi_y_strans(vhat,v_y)
+    call zrnmi_y_strans(uhat,u_y)
+    call zrnmi_y2x3(u4_x,v4_x,m4_x,u_y,v_y,m_y,mype)
+    call zrnmi_x_strans(m4_x,m_x)
+    call zrnmi_x_strans(v4_x,v_x)
+    call zrnmi_x_strans(u4_x,u_x)
+    call zrnmi_x2sd3(u,v,m,u_x,v_x,m_x,mype)
+
+  end subroutine zrnmi_uvm2uvmhat_ad
+
+  subroutine zrnmi_uvmhat2uvm(u,v,m,uhat,vhat,mhat,mype)
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    zrnmi_uvmhat2uvm
+!
+!   prgrmmr:
+!
+! abstract:
+!
+! program history log:
+!   2008-03-25  safford -- add subprogram doc block, rm unused uses
+!
+!   input argument list:
+!     mype     - mpi task id
+!     phat     -
+!     chat     -
+!     mhat     -
+!
+!   output argument list:
+!     p        -
+!     c        -
+!     m        -
+!     phat     -
+!     chat     -
+!     mhat     -
+!
+! attributes:
+!   language:  f90
+!   machine:
+!
+!$$$
+
+    use gridmod, only: lon2,lat2
+    implicit none
+
+    integer(i_kind)                        ,intent(in   ) :: mype
+    real(r_kind),dimension(lat2,lon2,nvert),intent(  out) :: u,v,m
+    real(r_kind),dimension(ny,mx_0:mx_1)   ,intent(inout) :: uhat,vhat,mhat
+
+    real(r_kind),dimension(nx,ny_0:ny_1):: u_x,v_x,m_x
+    real(r_kind),dimension(nx,ny_0:ny_1):: u4_x,v4_x,m4_x
+    real(r_kind),dimension(ny,mx_0:mx_1):: u_y,v_y,m_y
+
+    call zrnmi_y_strans(uhat,u_y)
+    call zrnmi_y_strans(vhat,v_y)
+    call zrnmi_y_strans(mhat,m_y)
+    call zrnmi_y2x3(u4_x,v4_x,m4_x,u_y,v_y,m_y,mype)
+    call zrnmi_x_strans(u4_x,u_x)
+    call zrnmi_x_strans(v4_x,v_x)
+    call zrnmi_x_strans(m4_x,m_x)
+    call zrnmi_x2sd3(u,v,m,u_x,v_x,m_x,mype)
+
+  end subroutine zrnmi_uvmhat2uvm
+
+  subroutine zrnmi_uvmhat2uvm_ad(u,v,m,uhat,vhat,mhat,mype)
+!$$$  subprogram doucmentation block
+!                .      .    .                                       .
+! subprogram:    zrnmi_uvmhat2uvm_ad
+!   prgmmr:
+!
+! abstract:
+!
+! program history log:
+!   2010-01-07  lueken - added subprogram doc block
+!
+!   input argument list:
+!    mype
+!    u,v,m
+!
+!   output argument list:
+!    uhat,vhat,mhat
+!    u,v,m
+!
+! attributes:
+!   language: f90
+!   machine:
+!
+!$$$ end documentation block
+    use constants, only: zero
+    use gridmod, only: lon2,lat2
+    implicit none
+
+    integer(i_kind)                        ,intent(in   ) :: mype
+    real(r_kind),dimension(lat2,lon2,nvert),intent(inout) :: u,v,m
+    real(r_kind),dimension(ny,mx_0:mx_1)   ,intent(  out) :: uhat,vhat,mhat
+
+    real(r_kind),dimension(nx,ny_0:ny_1):: u_x,v_x,m_x
+    real(r_kind),dimension(nx,ny_0:ny_1):: u4_x,v4_x,m4_x
+    real(r_kind),dimension(ny,mx_0:mx_1):: u_y,v_y,m_y
+
+    call zrnmi_sd2x3(u,v,m,u_x,v_x,m_x,mype)
+    call zrnmi_x_strans(u_x,u4_x)
+    call zrnmi_x_strans(v_x,v4_x)
+    call zrnmi_x_strans(m_x,m4_x)
+    call zrnmi_x2y3(u4_x,v4_x,m4_x,u_y,v_y,m_y,mype)
+    call zrnmi_y_strans(u_y,uhat)
+    call zrnmi_y_strans(v_y,vhat)
+    call zrnmi_y_strans(m_y,mhat)
+
+  end subroutine zrnmi_uvmhat2uvm_ad
+
+end module zrnmi_mod


### PR DESCRIPTION
This now works when triggering the TLNMC machinery as in the original GSI code. For simplicity the code added here brings in all of the machinery including the regional part; though some work would need to done to fully reconnect the regional component (avoiding the WRF and other regional model things) - this is not work in GMAO's horizon.

The additions here are zero-diff as long as the TLNMC knob is kept off.