### PR TITLE
Echo TLNMC namelist

### DIFF
--- a/src/gsibec/gsi/gsimod.F90
+++ b/src/gsibec/gsi/gsimod.F90
@@ -648,6 +648,7 @@
      write(6,setup)
      write(6,gridopts)
      write(6,bkgerr)
+     write(6,strongopts)
      write(6,hybrid_ensemble)
   endif
 


### PR DESCRIPTION
This is a trivial change to simply echo the TLNMC namelist the log file as others. Zero diff