### PR TITLE
tags in JEDI are wired in source code - bad, bad

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 ################################################################################
 
 cmake_minimum_required( VERSION 3.12 )
-project( gsibec VERSION 1.3.1 LANGUAGES Fortran )
+project( gsibec VERSION 1.3.2 LANGUAGES Fortran )
 
 ## Ecbuild integration
 set( ECBUILD_DEFAULT_BUILD_TYPE Release )


### PR DESCRIPTION
I completely dislike this in JEDI - Tags wired in the source code. 

Fixed now.