### PR TITLE
Sill under evaluation: remove redundancy

### DIFF
--- a/src/gsibec/gsi/control2state.F90
+++ b/src/gsibec/gsi/control2state.F90
@@ -294,13 +294,13 @@ do jj=1,nsubwin
    call gsi_bundlegetpointer (wbundle,'q'  ,cv_rh ,istatus)
 
 !  Get 3d pressure
-   if(do_getprs_tl) call getprs_tl(cv_ps,cv_t,sv_prse)
+!_RT   if(do_getprs_tl) call getprs_tl(cv_ps,cv_t,sv_prse)
 
 !  Convert input normalized RH to q
    if(do_normal_rh_to_q) call normal_rh_to_q(cv_rh,cv_t,sv_prse,sv_q)
 
 !  Calculate sensible temperature
-   if(do_tv_to_tsen .and. .not.regional) call tv_to_tsen(cv_t,sv_q,sv_tsen)
+!_RT   if(do_tv_to_tsen .and. .not.regional) call tv_to_tsen(cv_t,sv_q,sv_tsen)
 
 !  Copy other variables
    call gsi_bundlegetvar ( wbundle, 't'  , sv_tv,  istatus )  

--- a/src/gsibec/gsi/control2state_ad.F90
+++ b/src/gsibec/gsi/control2state_ad.F90
@@ -306,14 +306,14 @@ do jj=1,nsubwin
       enddo
    end if
 !  Calculate sensible temperature
-   if(do_tv_to_tsen_ad .and. .not.regional) call tv_to_tsen_ad(cv_t,rv_q,rv_tsen)
+!_RT   if(do_tv_to_tsen_ad .and. .not.regional) call tv_to_tsen_ad(cv_t,rv_q,rv_tsen)
 
 !  Adjoint of convert input normalized RH to q to add contribution of moisture
 !  to t, p , and normalized rh
    if(do_normal_rh_to_q_ad) call normal_rh_to_q_ad(cv_rh,cv_t,rv_prse,rv_q)
 
 !  Adjoint to convert ps to 3-d pressure
-   if(do_getprs_ad) call getprs_ad(cv_ps,cv_t,rv_prse)
+!_RT   if(do_getprs_ad) call getprs_ad(cv_ps,cv_t,rv_prse)
 
 
 !$omp section


### PR DESCRIPTION
This removes redundant - and perhaps incorrect - calculation being done in GSIBEC that is now cared for in fv3-jedi - **this requires 3d-pressure to be in analysis vector of fv3-jedi.**