### PR TITLE
Regional filtering grid generation without depending on “fv3_grid_spec”

### DIFF
--- a/src/gsibec/gsi/control2state.F90
+++ b/src/gsibec/gsi/control2state.F90
@@ -59,7 +59,7 @@ use m_kinds, only: r_kind,i_kind
 use control_vectors, only: control_vector
 use control_vectors, only: cvars3d,cvars2d
 use bias_predictors, only: predictors
-use gridmod, only: regional,lat2,lon2,nsig, nlat, nlon, twodvar_regional            
+use gridmod, only: regional,lat2,lon2,nsig, nlat, nlon, twodvar_regional, mpas_regional 
 use jfunc, only: nsclen,npclen,ntclen
 use gsi_4dvar, only: nsubwin, l4dvar, lsqrtb, ladtest_obs
 #ifdef USE_ALL_ORIGINAL
@@ -301,7 +301,7 @@ do jj=1,nsubwin
    if(do_getprs_tl) call getprs_tl(cv_ps,cv_t,sv_prse)
 
 !  Convert input normalized RH to q
-   if(do_normal_rh_to_q) call normal_rh_to_q(cv_rh,cv_t,sv_prse,sv_q)
+   if(do_normal_rh_to_q .or. mpas_regional) call normal_rh_to_q(cv_rh,cv_t,sv_prse,sv_q)
 
 !  Calculate sensible temperature
    if(do_tv_to_tsen .and. .not.regional) call tv_to_tsen(cv_t,sv_q,sv_tsen)

--- a/src/gsibec/gsi/control2state_ad.F90
+++ b/src/gsibec/gsi/control2state_ad.F90
@@ -54,7 +54,7 @@ use m_kinds, only: i_kind,r_kind
 use control_vectors, only: control_vector
 use control_vectors, only: cvars3d,cvars2d
 use bias_predictors, only: predictors
-use gridmod, only: regional,lat2,lon2,nsig,twodvar_regional
+use gridmod, only: regional,lat2,lon2,nsig,twodvar_regional,mpas_regional
 use jfunc, only: nsclen,npclen,ntclen
 use gsi_4dvar, only: nsubwin, lsqrtb
 #ifdef USE_ALL_ORIGINAL
@@ -315,7 +315,7 @@ do jj=1,nsubwin
 !  Adjoint of convert input normalized RH to q to add contribution of moisture
 !  to t, p , and normalized rh
    if(regional .and. ls_prse) rv_prse = 0.
-   if(do_normal_rh_to_q_ad) call normal_rh_to_q_ad(cv_rh,cv_t,rv_prse,rv_q)
+   if(do_normal_rh_to_q_ad .or. mpas_regional) call normal_rh_to_q_ad(cv_rh,cv_t,rv_prse,rv_q)
 
 !  Adjoint to convert ps to 3-d pressure
    if(do_getprs_ad) call getprs_ad(cv_ps,cv_t,rv_prse)

--- a/src/gsibec/gsi/gridmod.F90
+++ b/src/gsibec/gsi/gridmod.F90
@@ -149,6 +149,7 @@ module gridmod
   public :: diagnostic_reg,nmmb_reference_grid,filled_grid
   public :: grid_ratio_nmmb,isd_g,isc_g,dx_gfs,lpl_gfs,nsig5,nmmb_verttype
   public :: grid_ratio_fv3_regional,fv3_io_layout_y,fv3_regional,fv3_cmaq_regional,grid_type_fv3_regional
+  public :: use_fv3_grid_spec
   public :: nsig3,nsig4,grid_ratio_wrfmass
   public :: use_gfs_ozone,check_gfs_ozone_date,regional_ozone,nvege_type
   public :: jcap,jcap_b,hires_b,sp_a,grd_a
@@ -162,6 +163,7 @@ module gridmod
   public :: use_sp_eqspace,jcap_cut
   public :: wrf_mass_hybridcord
   public :: mpas_regional
+  public :: rlat_start,rlat_end,rlon_start,rlon_end,north_pole_lat,north_pole_lon
 
   interface gridmod_vgrid
      module procedure load_vert_coord_
@@ -194,6 +196,7 @@ module gridmod
   logical netcdf            ! .t. for regional netcdf i/o
 
   logical mpas_regional
+  logical use_fv3_grid_spec
 
   logical filled_grid       ! 
   logical half_grid         !
@@ -329,6 +332,14 @@ module gridmod
   real(r_kind) rlon_min_dd,rlon_max_dd,rlat_min_dd,rlat_max_dd
   real(r_kind) dt_ll,pdtop_ll,pt_ll
 
+  ! variables to define a regional rotated lat-lon grid
+  real(r_kind):: rlat_start
+  real(r_kind):: rlat_end
+  real(r_kind):: rlon_start
+  real(r_kind):: rlon_end
+  real(r_kind):: north_pole_lat
+  real(r_kind):: north_pole_lon
+
   integer(i_kind) nlon_regional,nlat_regional,nlon_regionalens,nlat_regionalens
   real(r_kind) regional_fhr,regional_fmin
   integer(i_kind) regional_time(6)
@@ -460,6 +471,7 @@ contains
     fv3_regional=.false.
     fv3_cmaq_regional=.false.
     mpas_regional=.false.
+    use_fv3_grid_spec=.false.
     l_reg_update_hydro_delz=.false.
     nems_nmmb_regional = .false.
     twodvar_regional = .false. 
@@ -480,6 +492,13 @@ contains
     lon1 = nlon
     lat2 = lat1+2
     lon2 = lon1+2
+
+    rlat_start = 0.
+    rlat_end = 0.
+    rlon_start = 0.
+    rlon_end = 0.
+    north_pole_lat = 0.
+    north_pole_lon = 0.
 
     diagnostic_reg = .false.
     if(verbose)diagnostic_reg = .true.

--- a/src/gsibec/gsi/gsi_rfv3io_mod.f90
+++ b/src/gsibec/gsi/gsi_rfv3io_mod.f90
@@ -3612,10 +3612,10 @@ subroutine m_gsi_rfv3io_get_grid_specs(gsi_lats,gsi_lons,ierr)
   use netcdf, only: nf90_nowrite,nf90_inquire,nf90_inquire_dimension
   use netcdf, only: nf90_inquire_variable
   use m_mpimod, only: mype
-  use mod_fv3_lola, only: m_generate_anl_grid
+  use mod_fv3_lola, only: m_generate_anl_grid, m_generate_anl_grid_without_fv3gridspec
   use gridmod,  only:nsig,regional_time,regional_fhr,regional_fmin,aeta1_ll,aeta2_ll
   use gridmod,  only:nlon_regional,nlat_regional,eta1_ll,eta2_ll
-  use gridmod,  only:grid_type_fv3_regional
+  use gridmod,  only:grid_type_fv3_regional,fv3_regional,mpas_regional,use_fv3_grid_spec
   use m_kinds, only: i_kind,r_kind
   use constants, only: half,zero
   use m_mpimod, only: gsi_mpi_comm_world,mpi_itype,mpi_rtype
@@ -3638,6 +3638,10 @@ subroutine m_gsi_rfv3io_get_grid_specs(gsi_lats,gsi_lons,ierr)
   integer(i_kind) :: nio,nylen
   integer(i_kind),allocatable :: gfile_loc_layout(:)
   character(len=180)  :: filename_layout
+  integer(i_kind) :: ios
+  real(r_kind) :: pmpas
+
+  if(fv3_regional) then
 
     coupler_res_filenam='coupler.res'
     grid_spec='fv3_grid_spec'
@@ -3659,84 +3663,85 @@ subroutine m_gsi_rfv3io_get_grid_specs(gsi_lats,gsi_lons,ierr)
     regional_fhr=zero          ! forecast hour set zero for now
     regional_fmin=zero          ! forecast min set zero for now
 
+    if(use_fv3_grid_spec) then
 !!!!!!!!!!    grid_spec  !!!!!!!!!!!!!!!
-    ierr=0
-    iret=nf90_open(trim(grid_spec),nf90_nowrite,gfile_grid_spec)
-    if(iret/=nf90_noerr) then
-       write(6,*)' gsi_rfv3io_get_grid_specs: problem opening ',trim(grid_spec),', Status = ',iret
-       ierr=1
-       return
-    endif
+      ierr=0
+      iret=nf90_open(trim(grid_spec),nf90_nowrite,gfile_grid_spec)
+      if(iret/=nf90_noerr) then
+         write(6,*)' gsi_rfv3io_get_grid_specs: problem opening ',trim(grid_spec),', Status = ',iret
+         ierr=1
+         return
+      endif
 
-    iret=nf90_inquire(gfile_grid_spec,ndimensions,nvariables,nattributes,unlimiteddimid)
-    gfile_loc=gfile_grid_spec
-    do k=1,ndimensions
-       iret=nf90_inquire_dimension(gfile_loc,k,name,len)
-       if(trim(name)=='grid_xt') nx=len
-       if(trim(name)=='grid_yt') ny=len
-    enddo
-    nlon_regional=nx
-    nlat_regional=ny
+      iret=nf90_inquire(gfile_grid_spec,ndimensions,nvariables,nattributes,unlimiteddimid)
+      gfile_loc=gfile_grid_spec
+      do k=1,ndimensions
+         iret=nf90_inquire_dimension(gfile_loc,k,name,len)
+         if(trim(name)=='grid_xt') nx=len
+         if(trim(name)=='grid_yt') ny=len
+      enddo
+      nlon_regional=nx
+      nlat_regional=ny
 
-    if(.not.allocated(ny_layout_len)) allocate(ny_layout_len(0:fv3_io_layout_y-1))
-    if(.not.allocated(ny_layout_b)) allocate(ny_layout_b(0:fv3_io_layout_y-1))
-    if(.not.allocated(ny_layout_e)) allocate(ny_layout_e(0:fv3_io_layout_y-1))
-    ny_layout_len=ny
-    ny_layout_b=0
-    ny_layout_e=0
-    if(fv3_io_layout_y > 1) then
-       if(.not.allocated(gfile_loc_layout)) allocate(gfile_loc_layout(0:fv3_io_layout_y-1))
-       do nio=0,fv3_io_layout_y-1
-          write(filename_layout,'(a,a,I4.4)') trim(grid_spec),'.',nio
-          iret=nf90_open(filename_layout,nf90_nowrite,gfile_loc_layout(nio))
-          if(iret/=nf90_noerr) then
-             write(6,*)' problem opening ',trim(filename_layout),', Status =',iret
-             ierr=1
-             return
-          endif
-          iret=nf90_inquire(gfile_loc_layout(nio),ndimensions,nvariables,nattributes,unlimiteddimid)
-          do k=1,ndimensions
-              iret=nf90_inquire_dimension(gfile_loc_layout(nio),k,name,len)
-              if(trim(name)=='grid_yt') ny_layout_len(nio)=len
-          enddo
-          iret=nf90_close(gfile_loc_layout(nio))
-       enddo
-       deallocate(gfile_loc_layout)
+      if(.not.allocated(ny_layout_len)) allocate(ny_layout_len(0:fv3_io_layout_y-1))
+      if(.not.allocated(ny_layout_b)) allocate(ny_layout_b(0:fv3_io_layout_y-1))
+      if(.not.allocated(ny_layout_e)) allocate(ny_layout_e(0:fv3_io_layout_y-1))
+      ny_layout_len=ny
+      ny_layout_b=0
+      ny_layout_e=0
+      if(fv3_io_layout_y > 1) then
+         if(.not.allocated(gfile_loc_layout)) allocate(gfile_loc_layout(0:fv3_io_layout_y-1))
+         do nio=0,fv3_io_layout_y-1
+            write(filename_layout,'(a,a,I4.4)') trim(grid_spec),'.',nio
+            iret=nf90_open(filename_layout,nf90_nowrite,gfile_loc_layout(nio))
+            if(iret/=nf90_noerr) then
+               write(6,*)' problem opening ',trim(filename_layout),', Status =',iret
+               ierr=1
+               return
+            endif
+            iret=nf90_inquire(gfile_loc_layout(nio),ndimensions,nvariables,nattributes,unlimiteddimid)
+            do k=1,ndimensions
+                iret=nf90_inquire_dimension(gfile_loc_layout(nio),k,name,len)
+                if(trim(name)=='grid_yt') ny_layout_len(nio)=len
+            enddo
+            iret=nf90_close(gfile_loc_layout(nio))
+         enddo
+         deallocate(gfile_loc_layout)
 ! figure out begin and end of each subdomain restart file
-       nylen=0
-       do nio=0,fv3_io_layout_y-1
-          ny_layout_b(nio)=nylen + 1
-          nylen=nylen+ny_layout_len(nio)
-          ny_layout_e(nio)=nylen
-       enddo
-    endif
-   ! if(mype==0)write(6,*),'nx,ny=',nx,ny
-   ! if(mype==0)write(6,*),'ny_layout_len=',ny_layout_len
-   ! if(mype==0)write(6,*),'ny_layout_b=',ny_layout_b
-   ! if(mype==0)write(6,*),'ny_layout_e=',ny_layout_e
+         nylen=0
+         do nio=0,fv3_io_layout_y-1
+            ny_layout_b(nio)=nylen + 1
+            nylen=nylen+ny_layout_len(nio)
+            ny_layout_e(nio)=nylen
+         enddo
+      endif
+     ! if(mype==0)write(6,*),'nx,ny=',nx,ny
+     ! if(mype==0)write(6,*),'ny_layout_len=',ny_layout_len
+     ! if(mype==0)write(6,*),'ny_layout_b=',ny_layout_b
+     ! if(mype==0)write(6,*),'ny_layout_e=',ny_layout_e
 
 !!!    get nx,ny,grid_lon,grid_lont,grid_lat,grid_latt,nz,ak,bk
 
-    if(.not.allocated(grid_lat)) allocate(grid_lat(nx+1,ny+1))
-    if(.not.allocated(grid_lon)) allocate(grid_lon(nx+1,ny+1))
-    if(.not.allocated(grid_latt)) allocate(grid_latt(nx,ny))
-    if(.not.allocated(grid_lont)) allocate(grid_lont(nx,ny))
+      if(.not.allocated(grid_lat)) allocate(grid_lat(nx+1,ny+1))
+      if(.not.allocated(grid_lon)) allocate(grid_lon(nx+1,ny+1))
+      if(.not.allocated(grid_latt)) allocate(grid_latt(nx,ny))
+      if(.not.allocated(grid_lont)) allocate(grid_lont(nx,ny))
 
-    do k=ndimensions+1,nvariables
-       iret=nf90_inquire_variable(gfile_loc,k,name,len)
-       if(trim(name)=='grid_lat') then
-          iret=nf90_get_var(gfile_loc,k,grid_lat)
-       endif
-       if(trim(name)=='grid_lon') then
-          iret=nf90_get_var(gfile_loc,k,grid_lon)
-       endif
-       if(trim(name)=='grid_latt') then
-          iret=nf90_get_var(gfile_loc,k,grid_latt)
-       endif
-       if(trim(name)=='grid_lont') then
-          iret=nf90_get_var(gfile_loc,k,grid_lont)
-       endif
-    enddo
+      do k=ndimensions+1,nvariables
+         iret=nf90_inquire_variable(gfile_loc,k,name,len)
+         if(trim(name)=='grid_lat') then
+            iret=nf90_get_var(gfile_loc,k,grid_lat)
+         endif
+         if(trim(name)=='grid_lon') then
+            iret=nf90_get_var(gfile_loc,k,grid_lon)
+         endif
+         if(trim(name)=='grid_latt') then
+            iret=nf90_get_var(gfile_loc,k,grid_latt)
+         endif
+         if(trim(name)=='grid_lont') then
+            iret=nf90_get_var(gfile_loc,k,grid_lont)
+         endif
+      enddo
 !
 !  need to decide the grid orientation of the FV regional model    
 !
@@ -3745,36 +3750,37 @@ subroutine m_gsi_rfv3io_get_grid_specs(gsi_lats,gsi_lons,ierr)
 !                            1 : input is E-W N-S grid
 !                            2 : input is W-E S-N grid
 !
-    if(grid_type_fv3_regional == 0) then
-        imiddle=nx/2
-        jmiddle=ny/2
-        if( (grid_latt(imiddle,1) < grid_latt(imiddle,ny)) .and. &
-            (grid_lont(1,jmiddle) < grid_lont(nx,jmiddle)) ) then 
-            grid_type_fv3_regional = 2
-        else
-            grid_type_fv3_regional = 1
-        endif
-    endif
+      if(grid_type_fv3_regional == 0) then
+          imiddle=nx/2
+          jmiddle=ny/2
+          if( (grid_latt(imiddle,1) < grid_latt(imiddle,ny)) .and. &
+              (grid_lont(1,jmiddle) < grid_lont(nx,jmiddle)) ) then 
+              grid_type_fv3_regional = 2
+          else
+              grid_type_fv3_regional = 1
+          endif
+      endif
 ! check the grid type
-    if( grid_type_fv3_regional == 1 ) then
-       !if(mype==0) write(6,*) 'FV3 regional input grid is  E-W N-S grid'
-       grid_reverse_flag=.true.    ! grid is revered comparing to usual map view
-    else if(grid_type_fv3_regional == 2) then
-       !if(mype==0) write(6,*) 'FV3 regional input grid is  W-E S-N grid'
-       grid_reverse_flag=.false.   ! grid orientated just like we see on map view    
-    else
-       write(6,*) 'Error: FV3 regional input grid is unknown grid'
-       call stop2(678)
-    endif
-!
-    if(grid_type_fv3_regional == 2) then
-       call reverse_grid_r(grid_lont,nx,ny,1)
-       call reverse_grid_r(grid_latt,nx,ny,1)
-       call reverse_grid_r(grid_lon,nx+1,ny+1,1)
-       call reverse_grid_r(grid_lat,nx+1,ny+1,1)
-    endif
+      if( grid_type_fv3_regional == 1 ) then
+         !if(mype==0) write(6,*) 'FV3 regional input grid is  E-W N-S grid'
+         grid_reverse_flag=.true.    ! grid is revered comparing to usual map view
+      else if(grid_type_fv3_regional == 2) then
+         !if(mype==0) write(6,*) 'FV3 regional input grid is  W-E S-N grid'
+         grid_reverse_flag=.false.   ! grid orientated just like we see on map view    
+      else
+         write(6,*) 'Error: FV3 regional input grid is unknown grid'
+         call stop2(678)
+      endif
 
-    iret=nf90_close(gfile_loc)
+      if(grid_type_fv3_regional == 2) then
+         call reverse_grid_r(grid_lont,nx,ny,1)
+         call reverse_grid_r(grid_latt,nx,ny,1)
+         call reverse_grid_r(grid_lon,nx+1,ny+1,1)
+         call reverse_grid_r(grid_lat,nx+1,ny+1,1)
+      endif
+
+      iret=nf90_close(gfile_loc)
+    endif
 
     iret=nf90_open(ak_bk,nf90_nowrite,gfile_loc)
     if(iret/=nf90_noerr) then
@@ -3833,11 +3839,29 @@ subroutine m_gsi_rfv3io_get_grid_specs(gsi_lats,gsi_lons,ierr)
     !   enddo
     !endif
 
-!!!!!!! setup A grid and interpolation/rotation coeff.
-    call m_generate_anl_grid(nx,ny,grid_lon,grid_lont,grid_lat,grid_latt,gsi_lats,gsi_lons)
+  endif
 
+  if(mpas_regional) then
+    nsig=0
+    open(11,file='mpas_pave.txt')
+    do
+      read(11,*,iostat=ios) pmpas
+      if(ios /= 0) exit
+      nsig = nsig + 1
+    enddo
+    close(11)
+  endif
+
+!!!!!!! setup A grid and interpolation/rotation coeff.
+  if(fv3_regional .and. use_fv3_grid_spec) then
+    call m_generate_anl_grid(nx,ny,grid_lon,grid_lont,grid_lat,grid_latt,gsi_lats,gsi_lons)
     deallocate (grid_lon,grid_lat,grid_lont,grid_latt)
     deallocate(ny_layout_len,ny_layout_b,ny_layout_e)
+  endif
+
+  if(.not.use_fv3_grid_spec) then
+    call m_generate_anl_grid_without_fv3gridspec(gsi_lats,gsi_lons)
+  endif
 
     return
 end subroutine m_gsi_rfv3io_get_grid_specs

--- a/src/gsibec/gsi/gsimod.F90
+++ b/src/gsibec/gsi/gsimod.F90
@@ -44,9 +44,12 @@
      init_grid,init_grid_vars,&
      nlayers,jcap,jcap_b,vlevs,&
      use_sp_eqspace,final_grid_vars,&
-     jcap_gfs,nlat_gfs,nlon_gfs,jcap_cut
+     jcap_gfs,nlat_gfs,nlon_gfs,jcap_cut,&
+     rlat_start,rlat_end,&
+     rlon_start,rlon_end,&
+     north_pole_lat,north_pole_lon
 
-  use gridmod, only: init_reg_glob_ll,regional,fv3_regional,grid_ratio_fv3_regional,mpas_regional
+  use gridmod, only: init_reg_glob_ll,regional,fv3_regional,grid_ratio_fv3_regional,mpas_regional,use_fv3_grid_spec
 
   use constants, only: zero,one,init_constants,gps_constants,three
   use constants, only: init_constants,init_constants_derived
@@ -387,7 +390,8 @@
 
 
   namelist/gridopts/jcap,jcap_b,nlat,nlon,nsig,use_sp_eqspace,fv3_regional,grid_ratio_fv3_regional,&
-                    regional,mpas_regional
+                    regional,mpas_regional,use_fv3_grid_spec,rlat_start,rlat_end,rlon_start,rlon_end,&
+                    north_pole_lat,north_pole_lon
 
 ! BKGERR (background error related variables):
 !     vs       - scale factor for vertical correlation lengths for background error

--- a/src/gsibec/gsi/guess_grids.f90
+++ b/src/gsibec/gsi/guess_grids.f90
@@ -600,6 +600,7 @@ end subroutine final_
     real(r_kind) kap1,kapr,trk
     real(r_kind),dimension(:,:)  ,pointer::ges_ps=>NULL()
     real(r_kind),dimension(:,:,:),pointer::ges_tv=>NULL()
+    real(r_kind),dimension(:,:,:),pointer::ges_p=>NULL()
     real(r_kind) pinc(lat2,lon2)
     integer(i_kind) i,j,k,ii,jj,itv,ips,kp
     logical ihaveprs(nfldsig)
@@ -673,6 +674,21 @@ end subroutine final_
           end do
        end if   ! end if fv3 regional
 
+       if (mpas_regional) then
+          do jj=1,nfldsig
+            call gsi_bundlegetpointer(gsi_metguess_bundle(jj),'prsl' ,ges_p,ips)
+            if(ips/=0) call die(myname_,': prsl not available in guess, abort',ips)
+             do k=1,nsig
+                do j=1,lon2
+                   do i=1,lat2
+                      ges_prsl(i,j,k,jj)=ges_p(i,j,k)
+                      ges_lnprsl(i,j,k,jj)=log(ges_prsl(i,j,k,jj))
+                   end do
+                end do
+             end do
+          end do
+       endif
+
     else
 
 !      load mid-layer pressure by using phillips vertical interpolation
@@ -720,7 +736,7 @@ end subroutine final_
              ges_prslavg(k)=aeta1_ll(k)*ten+r1013*aeta2_ll(k)
           end do
        endif
-       if (fv3_regional .and. mpas_regional) then
+       if (mpas_regional) then
           open(10,file="mpas_pave.txt")
           do k=1,nsig
             read(10,*)ges_prslavg(k)
@@ -1139,6 +1155,7 @@ end subroutine final_
     call die(myname_,'pointer to '//trim(vname)//" not found",ier)
   endif
   ptr=var
+  if ( trim(vname) == 'prsl' ) ptr=kPa_per_Pa*ptr ! To read 3D pressure from MPAS-JEDI
   if ( trim(vname) == 'oz' ) then
       call gsi_metguess_get ( 'usrvar::o3ppmv', uvar, ier )
       if (trim(uvar)=='o3ppmv') then

--- a/src/gsibec/gsi/guess_grids.f90
+++ b/src/gsibec/gsi/guess_grids.f90
@@ -1109,89 +1109,16 @@ end subroutine final_
   end subroutine guess_basics0_
 !--------------------------------------------------------
   subroutine guess_basics2_(vname,islot,var)
-  use gridmod, only: regional
   character(len=*),intent(in) :: vname
   integer(i_kind), intent(in) :: islot
   real(r_kind),dimension(:,:) :: var
   character(len=*), parameter :: myname_ = myname//'*guess_basics2_'
   real(r_kind),dimension(:,:),pointer::ptr
-  integer jj,ier,i,j
+  integer jj,ier
   jj=islot
   call gsi_bundlegetpointer(gsi_metguess_bundle(jj),trim(vname),ptr,ier)
   if (ier/=0) then
     call die(myname_,'pointer to '//trim(vname)//" not found",ier)
-  endif
-
-  if(regional) then
-    if(mype == 0) then
-      !$omp parallel do default(shared) private(i)
-      do i = 1, size(var,2)
-        call put_data_1d(var(:,i))
-      enddo
-      !$omp end parallel do
-      !$omp parallel do default(shared) private(j)
-      do j = 1, size(var,1)
-        call put_data_1d(var(j,:))
-      enddo
-      !$omp end parallel do
-    else if(mype == nxpe-1) then
-      !$omp parallel do default(shared) private(i)
-      do i = 1, size(var,2)
-        call put_data_1d(var(:,i))
-      enddo
-      !$omp end parallel do
-      !$omp parallel do default(shared) private(j)
-      do j = 1, size(var,1)
-        call put_data_1d_rev(var(j,:))
-      enddo
-      !$omp end parallel do
-    else if(mype == nxpe*(nype-1)) then
-      !$omp parallel do default(shared) private(i)
-      do i = 1, size(var,2)
-        call put_data_1d_rev(var(:,i))
-      enddo
-      !$omp end parallel do
-      !$omp parallel do default(shared) private(j)
-      do j = 1, size(var,1)
-        call put_data_1d(var(j,:))
-      enddo
-      !$omp end parallel do
-    else if(mype == nxpe*nype-1) then
-      !$omp parallel do default(shared) private(i)
-      do i = 1, size(var,2)
-        call put_data_1d_rev(var(:,i))
-      enddo
-      !$omp end parallel do
-      !$omp parallel do default(shared) private(j)
-      do j = 1, size(var,1)
-        call put_data_1d_rev(var(j,:))
-      enddo
-      !$omp end parallel do
-    else if(mype>0 .and. mype<nxpe-1) then
-      !$omp parallel do default(shared) private(i)
-      do i = 1, size(var,2)
-        call put_data_1d(var(:,i))
-      enddo
-      !$omp end parallel do
-    else if(mype>nxpe*(nype-1) .and. mype<nxpe*nype-1) then
-      !$omp parallel do default(shared) private(i)
-      do i = 1, size(var,2)
-        call put_data_1d_rev(var(:,i))
-      enddo
-      !$omp end parallel do
-    else if(mod(mype,nxpe)==0 .and. mype>0 .and. mype<nxpe*(nype-1)) then
-      !$omp parallel do default(shared) private(j)
-      do j = 1, size(var,1)
-        call put_data_1d(var(j,:))
-      enddo
-      !$omp end parallel do
-    else if(mod(mype,nxpe)==nxpe-1 .and. mype>nxpe-1 .and. mype<nxpe*nype-1) then
-      !$omp parallel do default(shared) private(j)
-      do j = 1, size(var,1)
-        call put_data_1d_rev(var(j,:))
-      enddo
-      !$omp end parallel do
-    endif
   endif
   ptr=var
   if ( trim(vname) == 'ps' ) ptr=kPa_per_Pa*ptr ! RT_TBD: is this the best place for this?
@@ -1199,91 +1126,17 @@ end subroutine final_
   end subroutine guess_basics2_
 !--------------------------------------------------------
   subroutine guess_basics3_(vname,islot,var)
-  use gridmod, only: regional
   character(len=*),intent(in)   :: vname
   integer(i_kind), intent(in) :: islot
   real(r_kind),dimension(:,:,:) :: var
   character(len=*), parameter :: myname_ = myname//'*guess_basics3_'
   real(r_kind),dimension(:,:,:),pointer::ptr
   character(len=80) :: uvar
-  integer jj,ier,i,j
-
+  integer jj,ier
   jj=islot
   call gsi_bundlegetpointer(gsi_metguess_bundle(jj),trim(vname),ptr,ier)
   if (ier/=0) then
     call die(myname_,'pointer to '//trim(vname)//" not found",ier)
-  endif
-
-  if(regional) then
-    if(mype == 0) then
-      !$omp parallel do default(shared) private(i)
-      do i = 1, size(var,2)
-        call put_data_2d(var(:,i,:))
-      enddo
-      !$omp end parallel do
-      !$omp parallel do default(shared) private(j)
-      do j = 1, size(var,1)
-        call put_data_2d(var(j,:,:))
-      enddo
-      !$omp end parallel do
-    else if(mype == nxpe-1) then
-      !$omp parallel do default(shared) private(i)
-      do i = 1, size(var,2)
-        call put_data_2d(var(:,i,:))
-      enddo
-      !$omp end parallel do
-      !$omp parallel do default(shared) private(j)
-      do j = 1, size(var,1)
-        call put_data_2d_rev(var(j,:,:))
-      enddo
-      !$omp end parallel do
-    else if(mype == nxpe*(nype-1)) then
-      !$omp parallel do default(shared) private(i)
-      do i = 1, size(var,2)
-        call put_data_2d_rev(var(:,i,:))
-      enddo
-      !$omp end parallel do
-      !$omp parallel do default(shared) private(j)
-      do j = 1, size(var,1)
-        call put_data_2d(var(j,:,:))
-      enddo
-      !$omp end parallel do
-    else if(mype == nxpe*nype-1) then
-      !$omp parallel do default(shared) private(i)
-      do i = 1, size(var,2)
-        call put_data_2d_rev(var(:,i,:))
-      enddo
-      !$omp end parallel do
-      !$omp parallel do default(shared) private(j)
-      do j = 1, size(var,1)
-        call put_data_2d_rev(var(j,:,:))
-      enddo
-      !$omp end parallel do
-    else if(mype>0 .and. mype<nxpe-1) then
-      !$omp parallel do default(shared) private(i)
-      do i = 1, size(var,2)
-        call put_data_2d(var(:,i,:))
-      enddo
-      !$omp end parallel do
-    else if(mype>nxpe*(nype-1) .and. mype<nxpe*nype-1) then
-      !$omp parallel do default(shared) private(i)
-      do i = 1, size(var,2)
-        call put_data_2d_rev(var(:,i,:))
-      enddo
-      !$omp end parallel do
-    else if(mod(mype,nxpe)==0 .and. mype>0 .and. mype<nxpe*(nype-1)) then
-      !$omp parallel do default(shared) private(j)
-      do j = 1, size(var,1)
-        call put_data_2d(var(j,:,:))
-      enddo
-      !$omp end parallel do
-    else if(mod(mype,nxpe)==nxpe-1 .and. mype>nxpe-1 .and. mype<nxpe*nype-1) then
-      !$omp parallel do default(shared) private(j)
-      do j = 1, size(var,1)
-        call put_data_2d_rev(var(j,:,:))
-      enddo
-      !$omp end parallel do
-    endif
   endif
   ptr=var
   if ( trim(vname) == 'oz' ) then
@@ -1292,111 +1145,6 @@ end subroutine final_
          ptr=ptr/constoz   ! RT_TBD: is this the best place for this?
       endif
   endif
-
   end subroutine guess_basics3_
-!--------------------------------------------------------
- subroutine put_data_1d(x)
- implicit none
- real(r_kind), intent(inout) :: x(:)
- real(r_kind), parameter :: rmiss = -3.334767057904812e38
- real(r_kind), parameter :: rmiss_th = -1.0e30
- integer :: n, k, first_valid
-
- n = size(x)
-
- first_valid = 0
- do k = 1, n
-   if (x(k) > rmiss_th) then
-     first_valid = k
-     exit
-   end if
- end do
-
- if (first_valid <= 0) return
-
- if (first_valid > 1) then
-   x(1:first_valid-1) = x(first_valid)
- end if
-
- end subroutine put_data_1d
-!--------------------------------------------------------
- subroutine put_data_1d_rev(x)
- implicit none
- real(r_kind), intent(inout) :: x(:)
- real(r_kind), parameter :: rmiss = -3.334767057904812e38
- real(r_kind), parameter :: rmiss_th = -1.0e30
- integer :: n, k, first_valid
-
- n = size(x)
-
- first_valid = 0
- do k = n, 1, -1
-   if (x(k) > rmiss_th) then
-     first_valid = k
-     exit
-   end if
- end do
-
- if (first_valid <= 0) return
-
- if (first_valid > 1) then
-   x(first_valid+1:n) = x(first_valid)
- end if
-
- end subroutine put_data_1d_rev
-!--------------------------------------------------------
- subroutine put_data_2d(x)
- implicit none
- real(r_kind), intent(inout) :: x(:,:)
- real(r_kind), parameter :: rmiss = -3.334767057904812e38
- real(r_kind), parameter :: rmiss_th = -1.0e30
- integer :: n, k, first_valid, i
-
- n = size(x,1)
-
- first_valid = 0
- do k = 1, n
-   if (x(k,1) > rmiss_th) then
-     first_valid = k
-     exit
-   end if
- end do
-
- if (first_valid <= 0) return
-
- if (first_valid > 1) then
-   do i = 1, first_valid-1
-     x(i,:) = x(first_valid,:)
-   enddo
- end if
-
- end subroutine put_data_2d
-!--------------------------------------------------------
- subroutine put_data_2d_rev(x)
- implicit none
- real(r_kind), intent(inout) :: x(:,:)
- real(r_kind), parameter :: rmiss = -3.334767057904812e38
- real(r_kind), parameter :: rmiss_th = -1.0e30
- integer :: n, k, first_valid, i
-
- n = size(x,1)
-
- first_valid = 0
- do k = n, 1, -1 
-   if (x(k,1) > rmiss_th) then
-     first_valid = k
-     exit
-   end if
- end do
-
- if (first_valid <= 0) return
-
- if (first_valid > 1) then
-   do i = first_valid+1, n
-     x(i,:) = x(first_valid,:)
-   enddo
- end if
-
- end subroutine put_data_2d_rev
 !--------------------------------------------------------
 end module guess_grids

--- a/src/gsibec/gsi/mod_fv3_lola.f90
+++ b/src/gsibec/gsi/mod_fv3_lola.f90
@@ -67,7 +67,7 @@ module mod_fv3_lola
   implicit none
 !
   private
-  public :: generate_anl_grid,m_generate_anl_grid,fv3_h_to_ll,fv3_ll_to_h,fv3uv2earth,earthuv2fv3
+  public :: generate_anl_grid,m_generate_anl_grid,m_generate_anl_grid_without_fv3gridspec,fv3_h_to_ll,fv3_ll_to_h,fv3uv2earth,earthuv2fv3
   public :: fv3dx,fv3dx1,fv3dy,fv3dy1,fv3ix,fv3ixp,fv3jy,fv3jyp,a3dx,a3dx1,a3dy,a3dy1,a3ix,a3ixp,a3jy,a3jyp
   public :: nxa,nya,cangu,sangu,cangv,sangv,nx,ny,bilinear
   public :: definecoef_regular_grids,fv3_h_to_ll_ens,fv3uv2earthens
@@ -821,6 +821,192 @@ subroutine m_generate_anl_grid(nx,ny,grid_lon,grid_lont,grid_lat,grid_latt,gsi_l
   deallocate(region_dxi,region_dyi)
 
 end subroutine m_generate_anl_grid
+
+subroutine m_generate_anl_grid_without_fv3gridspec(gsi_lats,gsi_lons)
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    generate_anl_grid
+!   prgmmr: parrish
+!
+! abstract:  define rotated lat-lon analysis grid which is centered on fv3 tile
+!             and oriented to completely cover the tile.
+!
+! program history log:
+!   2017-05-02  parrish
+!   2017-10-10  wu   - 1. setup analysis A-grid,
+!                      2. compute/setup FV3 to A grid interpolation parameters
+!                      3. compute/setup A to FV3 grid interpolation parameters
+!                      4. setup weightings for wind conversion from FV3 to earth
+!   2019-11-01  wu   - add checks to present the mean longitude correctly to fix
+!                       problem near lon=0
+!
+!   2021-08-11   lei - a fix for an upper bound of the dimnsion of  a3jyp
+!   input argument list:
+!    nx, ny               - number of cells = nx*ny
+!    grid_lon ,grid_lat   - longitudes and latitudes of fv3 grid cell corners
+!    grid_lont,grid_latt  - longitudes and latitudes of fv3 grid cell centers
+!
+!   output argument list:
+!
+! attributes:
+!   language: f90
+!   machine:
+!
+!$$$ end documentation block
+
+  use m_kinds, only: r_kind,i_kind
+  use constants, only: quarter,one,two,half,zero,deg2rad,rearth,rad2deg,pi
+  use gridmod,  only:grid_ratio_fv3_regional, region_lat,region_lon,nlat,nlon
+  use gridmod,  only: region_dy,region_dx,region_dyi,region_dxi,coeffy,coeffx
+  use gridmod,  only:init_general_transform,region_dy,region_dx
+  use gridmod,  only: rlat_start,rlat_end,rlon_start,rlon_end
+  use gridmod,  only: north_pole_lat, north_pole_lon
+  use m_mpimod, only: mype
+  use egrid2agrid_mod, only: egrid2agrid_parm
+  implicit none
+
+  real(r_kind) dyy,dxx,dyyi,dxxi
+  real(r_kind) dyyh,dxxh
+
+  real(r_kind),intent(inout) :: gsi_lats(:,:),gsi_lons(:,:)
+
+  integer(i_kind) i,j,ir,jr,n
+  real(r_kind),allocatable,dimension(:,:) :: rlon_in,rlat_in
+  real(r_kind) centlat,centlon
+  real(r_kind) lonmin,lonmax,latmin,latmax
+  real(r_kind) adlon,adlat,alon,clat,clon
+  integer(i_kind) nlonh,nlath,nxh,nyh
+  integer(i_kind) ib1,ib2,jb1,jb2,jj
+
+  integer(i_kind) nord_e2a
+  real(r_kind)gxa,gya
+
+  real(r_kind) cx,cy
+  real(r_kind) diff,sq180
+  real(r_kind) d(4),ds
+  integer(i_kind) kk,k
+
+
+  nord_e2a=4
+  bilinear=.false.
+
+! centlat/lon from the JEDI yaml
+  centlat = 90.0 - north_pole_lat
+  centlon = north_pole_lon - 180.0
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!  compute analysis A-grid  lats, lons
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+!- analysis grid dimensions from the JEDI yaml
+  if(mype==0) print *,'nlat,nlon= ',nlat,nlon
+
+!- Read xrange and yrange from the JEDI code and obtain analysis grid spacing
+  lonmin = rlon_start
+  lonmax = rlon_end
+  latmin = rlat_start
+  latmax = rlat_end
+  adlat=(latmax-latmin)/(nlat-1)
+  adlon=(lonmax-lonmin)/(nlon-1)
+
+!-------setup analysis A-grid; find center of the domain
+  nlonh=nlon/2
+  nlath=nlat/2
+
+  if(nlonh*2==nlon)then
+     clon=adlon/two
+     cx=half
+  else
+     clon=adlon
+     cx=one
+  endif
+
+  if(nlath*2==nlat)then
+     clat=adlat/two
+     cy=half
+  else
+     clat=adlat
+     cy=one
+  endif
+
+!
+!-----setup analysis A-grid from center of the domain
+!
+  if (allocated(rlat_in)) deallocate(rlat_in)
+  if (allocated(rlon_in)) deallocate(rlon_in)
+  allocate(rlat_in(nlat,nlon))
+  allocate(rlon_in(nlat,nlon))
+  do j=1,nlon
+     alon=(j-nlonh)*adlon-clon
+     do i=1,nlat
+        rlon_in(i,j)=alon
+     enddo
+  enddo
+
+
+  do j=1,nlon
+     do i=1,nlat
+        rlat_in(i,j)=(i-nlath)*adlat-clat
+     enddo
+  enddo
+
+  if (allocated(region_dx )) deallocate(region_dx )
+  if (allocated(region_dy )) deallocate(region_dy )
+  if (allocated(region_dxi )) deallocate(region_dxi )
+  if (allocated(region_dyi )) deallocate(region_dyi )
+  if (allocated(coeffx )) deallocate(coeffx )
+  if (allocated(coeffy )) deallocate(coeffy )
+  allocate(region_dx(nlat,nlon),region_dy(nlat,nlon))
+  allocate(region_dxi(nlat,nlon),region_dyi(nlat,nlon))
+  allocate(coeffx(nlat,nlon),coeffy(nlat,nlon))
+  dyy=rearth*adlat*deg2rad
+  dyyi=one/dyy
+  dyyh=half/dyy
+  do j=1,nlon
+     do i=1,nlat
+        region_dy(i,j)=dyy
+        region_dyi(i,j)=dyyi
+        coeffy(i,j)=dyyh
+     enddo
+  enddo
+
+  do i=1,nlat
+     dxx=rearth*cos(rlat_in(i,1)*deg2rad)*adlon*deg2rad
+     dxxi=one/dxx
+     dxxh=half/dxx
+     do j=1,nlon
+        region_dx(i,j)=dxx
+        region_dxi(i,j)=dxxi
+        coeffx(i,j)=dxxh
+     enddo
+  enddo
+
+!
+!----------  setup  region_lat,region_lon in earth coord
+!
+  if (allocated(region_lat)) deallocate(region_lat)
+  if (allocated(region_lon)) deallocate(region_lon)
+  allocate(region_lat(nlat,nlon),region_lon(nlat,nlon))
+
+  call unrotate2deg(region_lon,region_lat,rlon_in,rlat_in, &
+                    centlon,centlat,nlat,nlon)
+
+  region_lat=region_lat*deg2rad
+  region_lon=region_lon*deg2rad
+
+  do j=1,nlat
+     do i=1,nlon
+        gsi_lats(i,j)=region_lat(j,i)
+        gsi_lons(i,j)=region_lon(j,i)
+        if(gsi_lons(i,j)<0.) gsi_lons(i,j)= gsi_lons(i,j) + 2.*pi
+     enddo
+  enddo
+
+
+  deallocate(rlat_in,rlon_in)
+  deallocate(region_dxi,region_dyi)
+
+end subroutine m_generate_anl_grid_without_fv3gridspec
 
 subroutine definecoef_regular_grids(nxen,nyen,grid_lon,grid_lont,grid_lat,grid_latt)
 !$$$  subprogram documentation block


### PR DESCRIPTION
This PR is intended to enable the generation of rotated lat-lon grids for Recursive Filters (RF) in regional assimilation, without depending on the “fv3_grid_spec” grid information file.

