### PR TITLE
Revise Internal AD Tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 ################################################################################
 
 cmake_minimum_required( VERSION 3.12 )
-project( gsibec VERSION 1.4.2 LANGUAGES Fortran )
+project( gsibec VERSION 1.4.3 LANGUAGES Fortran )
 
 ## Ecbuild integration
 set( ECBUILD_DEFAULT_BUILD_TYPE Release )

--- a/src/gsibec/gsi/gsibec_adjtest_mod.F90
+++ b/src/gsibec/gsi/gsibec_adjtest_mod.F90
@@ -41,26 +41,33 @@ use compact_diffs, only: stvp2uv, tstvp2uv
 
 implicit none
 private
-public adtest_cv
-public adtest_bkgcov
+public adtest_cv1,adtest_cv2
+public adtest_bkgerr
 public adtest_stvp2uv
 public iadtest
+public iadtest_maxiter
+
+interface adtest_bkgerr
+  module procedure adtest_bkgerr_
+end interface adtest_bkgerr
 
 type(control_vector),save :: xtest1,xtest2
 
 ! iadtest           - adjoint tests:
-!                     (1) test CV 
-!                     (2) test B
-!                     (3) test stvp2uv
+!                     (1) test CV1 
+!                     (2) test CV2 - another flavor
+!                     (3) test B - full cov
+!                     (4) test stvp2uv
 
-logical, save :: iadtest(3)=.false.
+logical, save :: iadtest(4)=.false.
 
+integer :: iadtest_maxiter=0
 integer :: nrclen=0
-integer, save :: iadtest_cnt(3)=0
+integer, save :: iadtest_cnt(4)=0
 ! ----------------------------------------------------------------------
 contains
 ! ----------------------------------------------------------------------
-subroutine adtest_cv0(xhat)
+subroutine adtest_cv1(xhat)
 !$$$  subprogram documentation block
 !                .      .    .                                       .
 ! subprogram:    adtest
@@ -93,9 +100,9 @@ type(predictors) :: sbias1,sbias2
 integer(i_kind) :: ii,idig
 real(r_kind) :: zz1,zz2,zz3
 
-if (iadtest_cnt(1)>0) return
+if (iadtest_cnt(1)>iadtest_maxiter) return
 
-if (mype==0) write(6,*)'ADTEST_CV starting'
+if (mype==0) write(6,*)'ADTEST_CV1 starting'
 
 ! ----------------------------------------------------------------------
 ! Allocate local variables
@@ -111,10 +118,10 @@ call allocate_preds(sbias2)
 ! Initialize control space vectors
 if (present(xhat)) then
    xtest1=xhat
-   if (mype==0) write(6,*)'ADTEST_CV use input xhat'
+   if (mype==0) write(6,*)'ADTEST_CV1 use input xhat'
 else
    call random_cv(xtest1)
-   if (mype==0) write(6,*)'ADTEST_CV use random_cv(xhat)'
+   if (mype==0) write(6,*)'ADTEST_CV1 use random_cv(xhat)'
 endif
 xtest2=zero
 
@@ -150,15 +157,15 @@ if ( abs(zz1+zz2) > sqrt(tiny(zz3)) ) then
 else
    zz3=abs(zz1-zz2)
 endif
-idig= int(-log(zz3+tiny(zz3))/log(10.0_r_kind))
+idig= int(-log(abs(zz3)+tiny(zz3))/log(10.0_r_kind))
 
 if (mype==0) then
-   write(6,'(A)')' ADTEST_CV              0.123456789012345678'
-   write(6,'(A,ES25.18)')' ADTEST_CV <F''*F.Y,X>= ',zz1
-   write(6,'(A,ES25.18)')' ADTEST_CV < F.Y,F.X>= ',zz2
-   write(6,'(A,i3,   A)')' ADTEST_CV ',idig,' digits are identical'
-   write(6,'(A,ES25.18)')' ADTEST_CV rel. err.= ',zz3
-   write(6,'(A,ES25.18)')' ADTEST_CV mach.eps = ',epsilon(zz3)
+   write(6,'(A)')' ADTEST_CV1              0.123456789012345678'
+   write(6,'(A,ES25.18)')' ADTEST_CV1 <F''*F.Y,X>= ',zz1
+   write(6,'(A,ES25.18)')' ADTEST_CV1 < F.Y,F.X>= ',zz2
+   write(6,'(A,i3,   A)')' ADTEST_CV1 ',idig,' digits are identical'
+   write(6,'(A,ES25.18)')' ADTEST_CV1 rel. err.= ',zz3
+   write(6,'(A,ES25.18)')' ADTEST_CV1 mach.eps = ',epsilon(zz3)
 endif
 
 ! Release local variables
@@ -172,14 +179,14 @@ call deallocate_preds(sbias1)
 call deallocate_preds(sbias2)
 ! ----------------------------------------------------------------------
 
-if (mype==0) write(6,*)'ADTEST_CV finished'
+if (mype==0) write(6,*)'ADTEST_CV1 finished'
 
 iadtest_cnt(1) = iadtest_cnt(1) + 1
 
 return
-end subroutine adtest_cv0
+end subroutine adtest_cv1
 ! ----------------------------------------------------------------------
-subroutine adtest_cv(xhat)
+subroutine adtest_cv2(xhat)
 !$$$  subprogram documentation block
 !                .      .    .                                       .
 ! subprogram:    adtest
@@ -214,9 +221,9 @@ type(predictors) :: sbias1,sbias2
 integer(i_kind) :: ii,idig
 real(r_kind) :: zz1,zz2,zz3
 
-if (iadtest_cnt(1)>0) return
+if (iadtest_cnt(2)>iadtest_maxiter) return
 
-if (mype==0) write(6,*)'ADTEST_CV starting'
+if (mype==0) write(6,*)'ADTEST_CV2 starting'
 
 ! ----------------------------------------------------------------------
 ! Allocate local variables
@@ -232,10 +239,10 @@ call allocate_preds(sbias2)
 ! Initialize control space vectors
 if (present(xhat)) then
    xtest1=xhat
-   if (mype==0) write(6,*)'ADTEST_CV use input xhat'
+   if (mype==0) write(6,*)'ADTEST_CV2 use input xhat'
 else
    call random_cv(xtest1)
-   if (mype==0) write(6,*)'ADTEST_CV use random_cv(xhat)'
+   if (mype==0) write(6,*)'ADTEST_CV2 use random_cv(xhat)'
 endif
 call random_cv(xtest2,kseed=1999)
 
@@ -272,15 +279,15 @@ if ( abs(zz1+zz2) > sqrt(tiny(zz3)) ) then
 else
    zz3=abs(zz1-zz2)
 endif
-idig= int(-log(zz3+tiny(zz3))/log(10.0_r_kind))
+idig= int(-log(abs(zz3)+tiny(zz3))/log(10.0_r_kind))
 
 if (mype==0) then
-   write(6,'(A)')' ADTEST_CV                0.123456789012345678'
-   write(6,'(A,ES25.18)')' ADTEST_CV <F''*F.Y,  X>= ',zz1
-   write(6,'(A,ES25.18)')' ADTEST_CV <   F.Y,F.X>= ',zz2
-   write(6,'(A,i3,   A)')' ADTEST_CV ',idig,' digits are identical'
-   write(6,'(A,ES25.18)')' ADTEST_CV rel. err.= ',zz3
-   write(6,'(A,ES25.18)')' ADTEST_CV mach.eps = ',epsilon(zz3)
+   write(6,'(A)')' ADTEST_CV2                0.123456789012345678'
+   write(6,'(A,ES25.18)')' ADTEST_CV2 <F''*F.Y,  X>= ',zz1
+   write(6,'(A,ES25.18)')' ADTEST_CV2 <   F.Y,F.X>= ',zz2
+   write(6,'(A,i3,   A)')' ADTEST_CV2 ',idig,' digits are identical'
+   write(6,'(A,ES25.18)')' ADTEST_CV2 rel. err.= ',zz3
+   write(6,'(A,ES25.18)')' ADTEST_CV2 mach.eps = ',epsilon(zz3)
 endif
 
 ! Release local variables
@@ -294,63 +301,91 @@ call deallocate_preds(sbias1)
 call deallocate_preds(sbias2)
 ! ----------------------------------------------------------------------
 
-if (mype==0) write(6,*)'ADTEST_CV finished'
+if (mype==0) write(6,*)'ADTEST_CV2 finished'
 
-iadtest_cnt(1) = iadtest_cnt(1) + 1
+iadtest_cnt(2) = iadtest_cnt(2) + 1
 
 return
-end subroutine adtest_cv
+end subroutine adtest_cv2
 ! ----------------------------------------------------------------------
-subroutine adtest_bkgcov (s)
-use gsi_bundlemod, only: gsi_bundlecreate
-use gsi_bundlemod, only: assignment(=)
-use state_vectors, only: set_random
-use state_vectors, only: dot_product
-use state_vectors, only: prt_state_norms
+subroutine adtest_bkgerr_ (g1,g2)
+use control_vectors, only: control_vector
+use control_vectors, only: allocate_cv
+use control_vectors, only: deallocate_cv
+use control_vectors, only: allocate_cv,deallocate_cv
+use control_vectors, only: assignment(=)
+use control_vectors, only: random_cv
+use control_vectors, only: prt_control_norms
+use jfunc, only: nsclen,npclen,ntclen
+use hybrid_ensemble_parameters,only : l_hyb_ens
+use hybrid_ensemble_isotropic, only: bkerror_a_en
 implicit none
-type(gsi_bundle) :: s
-type(gsi_bundle) :: xs
-type(gsi_bundle) :: ys
-type(gsi_bundle) :: zs
+type(control_vector), optional :: g1,g2
+type(control_vector) :: gx
+type(control_vector) :: gy
+type(control_vector) :: gz
 integer(i_kind) :: idig, istatus
 real(r_kind) :: zz1,zz2,zz3
 
-if (iadtest_cnt(2) > 0) return
+if (iadtest_cnt(3)>2*iadtest_maxiter+1) return
 
-call gsi_bundlecreate ( xs, s, 'control2state work x', istatus )
-call gsi_bundlecreate ( ys, s, 'control2state work y', istatus )
-call gsi_bundlecreate ( zs, s, 'control2state work x', istatus )
-call set_random(xs)
-call set_random(ys,myseed=4567)
-call prt_state_norms(xs,'x')
-call prt_state_norms(ys,'y')
+call allocate_cv(gx)
+call allocate_cv(gy)
+call allocate_cv(gz)
 
-zs = ys
-call bkgcov(zs)
-zz1 = dot_product(zs,xs)
-zs = xs
-call bkgcov(zs)
-zz2 = dot_product(ys,zs)
+if (present(g1).and.present(g2) ) then
+  gx = g1
+  gy = g2
+else
+  call random_cv(gx,kseed=8765)
+  call random_cv(gy,kseed=54321)
+endif
+call prt_control_norms(gx,'ADTEST_BKGERR: gx')
+call prt_control_norms(gy,'ADTEST_BKGERR: gy')
+
+! z=By
+gz=zero
+call bkerror(gy,gz, &
+             1,nsclen,npclen,ntclen)
+if (l_hyb_ens) then
+   call bkerror_a_en(gy,gz)
+endif
+call prt_control_norms(gz,'ADTEST_BKGERR: By')
+zz1 = dot_product(gz,gx) ! (By)''*x
+
+! z=Bx
+gz=zero
+call bkerror(gx,gz, &
+             1,nsclen,npclen,ntclen)
+if (l_hyb_ens) then
+   call bkerror_a_en(gx,gz)
+endif
+call prt_control_norms(gz,'ADTEST_BKGERR: Bx')
+zz2 = dot_product(gy,gz) !  y''(Bx)
 
 if ( abs(zz1+zz2) > sqrt(tiny(zz3)) ) then
    zz3=two*abs(zz1-zz2)/(zz1+zz2)
 else
    zz3=abs(zz1-zz2)
 endif
-idig= int(-log(zz3+tiny(zz3))/log(10.0_r_kind))
+idig= int(-log(abs(zz3)+tiny(zz3))/log(10.0_r_kind))
 
 if (mype==0) then
-   write(6,'(A)')' ADTEST_BKGCOV             0.123456789012345678'
-   write(6,'(A,ES25.18)')' ADTEST_BKGCOV <B.Y,X>  = ',zz1
-   write(6,'(A,ES25.18)')' ADTEST_BKGCOV <Y,B.X>  = ',zz2
-   write(6,'(A,i3,   A)')' ADTEST_BGCOV ',idig,' digits are identical'
-   write(6,'(A,ES25.18)')' ADTEST_BKGCOV rel. err.= ',zz3
-   write(6,'(A,ES25.18)')' ADTEST_BKGCOV mach.eps = ',epsilon(zz3)
+   write(6,'(A)')' ADTEST_BKGERR             0.123456789012345678'
+   write(6,'(A,ES25.18)')' ADTEST_BKGERR <B.Y,X>  = ',zz1
+   write(6,'(A,ES25.18)')' ADTEST_BKGERR <Y,B.X>  = ',zz2
+   write(6,'(A,i3,   A)')' ADTEST_BKGERR ',idig,' digits are identical'
+   write(6,'(A,ES25.18)')' ADTEST_BKGERR rel. err.= ',zz3
+   write(6,'(A,ES25.18)')' ADTEST_BKGERR mach.eps = ',epsilon(zz3)
 endif
 
-iadtest_cnt(2) = iadtest_cnt(2) + 1
+call deallocate_cv (gz)
+call deallocate_cv (gy)
+call deallocate_cv (gx)
 
-end subroutine adtest_bkgcov
+iadtest_cnt(3) = iadtest_cnt(3) + 1
+
+end subroutine adtest_bkgerr_
 ! ----------------------------------------------------------------------
 
 subroutine adtest_stvp2uv(idx,mype)
@@ -365,7 +400,7 @@ subroutine adtest_stvp2uv(idx,mype)
   real(r_kind) zz1, zz2, zz3
   integer(i_kind) :: idig,i,j,k,idim
 
-  if (iadtest_cnt(3)>0) return
+  if (iadtest_cnt(4)>iadtest_maxiter) return
 
   idim=2
   allocate(x(idim,nlat,nlon))
@@ -399,7 +434,7 @@ subroutine adtest_stvp2uv(idx,mype)
   else
      zz3=abs(zz1-zz2)
   endif
-  idig= int(-log(zz3+tiny(zz3))/log(10.0_r_kind))
+  idig= int(-log(abs(zz3)+tiny(zz3))/log(10.0_r_kind))
 
   if (mype==0) then
     write(6,'(A)')' ADTEST_STVP2UV            0.123456789012345678'
@@ -410,7 +445,7 @@ subroutine adtest_stvp2uv(idx,mype)
     write(6,'(A,ES25.18)')' ADTEST_STVP2UV mach.eps = ',epsilon(zz3)
   endif
   deallocate(x,y,z)
-  iadtest_cnt(3) = iadtest_cnt(3) + 1
+  iadtest_cnt(4) = iadtest_cnt(4) + 1
 end subroutine adtest_stvp2uv
  
 real(r_kind) function my_dot_product(x,y)

--- a/src/gsibec/gsi/gsimod.F90
+++ b/src/gsibec/gsi/gsimod.F90
@@ -27,7 +27,7 @@
   use gsi_4dvar, only: setup_4dvar,init_4dvar,clean_4dvar
   use gsi_4dvar, only: l4densvar,nmn_obsbin
 
-  use gsibec_adjtest_mod, only: iadtest
+  use gsibec_adjtest_mod, only: iadtest,iadtest_maxiter
 
   use state_vectors, only: init_anasv,final_anasv
   use control_vectors, only: init_anacv,final_anacv,nrf,nvars,nrf_3d,cvars3d,cvars2d,&
@@ -364,6 +364,8 @@
 !     pseudo_q2- breed between q1/q2 options, that is, (q1/sig(q))
 !     mockbgk - if .true., use internally defined (fake) background fields
 !     iadtest - perform various adjoint tests: <=0: none; 1=cv/sv; 2=<x,By>
+!     iadtest_maxiter - will keep doing AD-test up this iteration+1
+!                       (default 0: do tests only once)
 !
 
   namelist/setup/&
@@ -374,6 +376,7 @@
        l4densvar,&
        nmn_obsbin,&
        iadtest,&
+       iadtest_maxiter,&
        mockbkg
 
 ! GRIDOPTS (grid setup variables,including regional specific variables):

--- a/src/gsibec/gsi/m_gsibec.F90
+++ b/src/gsibec/gsi/m_gsibec.F90
@@ -61,8 +61,8 @@ use general_sub2grid_mod, only: sub2grid_info
 use general_sub2grid_mod, only: general_sub2grid_create_info
 use general_sub2grid_mod, only: general_sub2grid_destroy_info
 
-use gsibec_adjtest_mod, only: adtest_cv
-use gsibec_adjtest_mod, only: adtest_bkgcov
+use gsibec_adjtest_mod, only: adtest_cv1,adtest_cv2
+use gsibec_adjtest_mod, only: adtest_bkgerr
 use gsibec_adjtest_mod, only: adtest_stvp2uv
 
 use mpeu_util, only: die
@@ -841,9 +841,9 @@ contains
   endif
 
 ! Perform adjoint test
-  if (iadtest(1)) call adtest_cv()
-  if (iadtest(2)) call adtest_bkgcov(sval(1))
-  if (iadtest(3)) call adtest_stvp2uv(1,mype)
+  if (iadtest(1)) call adtest_cv1()
+  if (iadtest(2)) call adtest_cv2()
+! if (iadtest(3)) call adtest_bkgerr()
 
 ! start work space
   if (l_hyb_ens) then
@@ -917,6 +917,13 @@ contains
      enddo
   end if
 
+! Perform adjoint test
+  if (iadtest(1)) call adtest_cv1(grady)
+  if (iadtest(2)) call adtest_cv2(grady)
+  if (iadtest(3)) call adtest_bkgerr(g1=gradx,g2=grady)
+  if (iadtest(4)) call adtest_stvp2uv(1,mype)
+
+  call control2state(grady,mval,sbias)
 ! if so write out fields from gsi (in GSI units)
   if(bkgv_write_sv/='null') &
   call write_bundle(sval(ntguessig),trim(bkgv_write_sv)//'_final')

--- a/src/gsibec/gsi/tv_to_tsen.f90
+++ b/src/gsibec/gsi/tv_to_tsen.f90
@@ -124,3 +124,134 @@ subroutine tv_to_tsen_ad(tv,q,tsen)
   end if
 
 end subroutine tv_to_tsen_ad
+
+
+
+subroutine tsen_to_tv(tsen,q,tv)
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    tv_to_tsen  tlm for normalized virtual to sensible temp
+!   prgmmr: wu               org: np20                date: 2005-03-06
+!
+! abstract: get sensible temperature from virtual temperature
+!
+! program history log:
+!   2006-07-17  derber
+!   2008-03-31  safford - rm unused uses
+!   2008-10-14  derber - modify to use fact_tv
+!   2008-11-03  sato - change for twodvar_regional
+!   2008-11-28  todling - no longer does tendencies (need to call twice)
+!
+!   input argument list:
+!      tsen   - sensible temperature
+!      q      - specific humidity
+!
+!   output argument list:
+!      tv     - virtual temperature
+!
+! attributes:
+!   language: f90
+!   machine:  ibm RS/6000 SP
+!
+!$$$
+  use m_kinds, only: r_kind,i_kind
+  use gridmod, only: lat2,lon2,nsig,twodvar_regional
+  use constants, only: fv
+  use guess_grids, only: ges_tsen,fact_tv,ntguessig
+  use guess_grids, only: tsensible
+! use jfunc, only: tsensible
+
+  implicit none
+
+  real(r_kind),intent(in   ) :: tsen(lat2,lon2,nsig)
+  real(r_kind),intent(in   ) ::  q(lat2,lon2,nsig)
+
+  real(r_kind),intent(out  ) :: tv(lat2,lon2,nsig)
+
+! local arrays
+  integer(i_kind) i,j,k
+
+! Convert normalized tv to tsen
+  if (twodvar_regional .and. tsensible) then
+     tv=tsen
+  else
+     do k=1,nsig
+        do j=1,lon2
+           do i=1,lat2
+              tv(i,j,k) = tsen(i,j,k)/fact_tv(i,j,k) + fv*ges_tsen(i,j,k,ntguessig)*q(i,j,k)
+           end do
+        end do
+     end do
+  end if
+
+end subroutine tsen_to_tv
+
+subroutine tsen_to_tv_ad(tsen,q,tv)
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    tv_to_tsen_ad  adjoint of tv_to_tsen
+!   prgmmr: wu               org: np20                date: 2005-03-06
+!
+! abstract: adjoint of tv_to_tsen
+!
+! program history log:
+!   2005-03-06  wu
+!   2005-03-30  treadon - reformat code (cosmetic change only)
+!   2005-11-21  kleist - use 3d pressure increment for coupling
+!   2005-11-21  derber modify to make qoption =1 work same as =2
+!   2006-01-09  derber move sigsum calculation to compute_derived and clean up
+!   2008-03-31  safford - rm unused uses
+!   2008-10-14  derber - modify to use fact_tv
+!   2008-11-03  sato - change for twodvar_regional
+!   2008-11-28  todling - no longer does tendencies (need to call twice)
+!   2009-11-25  todling - zero out tsen
+!
+!   input argument list:
+!      tv     - virtual temperature
+!      q      - specific humidity
+!      tsen   - sensible temperature
+!
+!   output argument list:
+!      q      - specific humidity
+!
+! attributes:
+!   language: f90
+!   machine:  ibm RS/6000 SP
+!
+!$$$
+
+  use m_kinds, only: r_kind,i_kind
+  use gridmod, only: lat2,lon2,nsig,twodvar_regional
+  use constants, only: fv,zero
+  use guess_grids, only: ges_tsen,fact_tv,ntguessig
+  use guess_grids, only: tsensible
+! use jfunc, only: tsensible
+
+  implicit none
+
+  real(r_kind),intent(inout) :: tsen(lat2,lon2,nsig)
+  real(r_kind),intent(inout) :: q (lat2,lon2,nsig)
+  real(r_kind),intent(inout) :: tv(lat2,lon2,nsig)
+
+! local variables:
+  integer(i_kind) i,j,k
+
+! Adjoint of convert tv to t sensible
+  if (twodvar_regional .and. tsensible) then
+     tsen=tsen+tv
+  else
+     do k=1,nsig
+        do j=1,lon2
+           do i=1,lat2
+              tsen(i,j,k)=tsen(i,j,k)+tv(i,j,k)/fact_tv(i,j,k)
+              q(i,j,k) = q(i,j,k) + fv * ges_tsen(i,j,k,ntguessig) * tv(i,j,k)
+              tv(i,j,k)=zero
+           end do
+        end do
+     end do
+  end if
+
+end subroutine tsen_to_tv_ad
+
+
+


### PR DESCRIPTION
This is a set of zero-diff changes that add the ability to test various adjoints in GSIBEC. The trigger for the AD-Test can be placed in the SETUP namelist of GSIBEC - they go as such:

A logical multi-element variable named `iadtest`  controls which tests to run as in:

iadtest(1) -  test CV1 
            (2) test CV2 - another flavor
            (3) test B - full covariance 
            (4) test stvp2uv

In the case of (3), one can test the TLNMC around B by setting tlnmc to be on (or off). 

Presently, all tests pass except the test when TLNMC is on.  Correction to the TLNMC issue is left as another issue - for another day. Here, I only introduce the tests.

Notice that in association w/ the tests above, the optional argument, named 
iadtest_maxiter can be placed in the setup namelist, to tell GSIBEC at each iteration to stop running the AD-Test. In actuality the tests need to be run for only a single iteration , but some of the tests, use the underlying gradient vector as RHS to the test (as opposed to a random vector), in such cases, since the initial gradient can be flaky, it is a good idea to run the test for a second or third iteration.