### PR TITLE
make sure the length of each code line is less than 132

### DIFF
--- a/src/gsibec/gsi/gsi_rfv3io_mod.f90
+++ b/src/gsibec/gsi/gsi_rfv3io_mod.f90
@@ -109,12 +109,14 @@ module gsi_rfv3io_mod
       "u","v","u_w","u_s","v_w","v_s","t","tv","tsen","w","delp","ps","delzinc"]
   character(len=max_varname_length), dimension(ntracerslist+naero_cmaq_fv3+7+naero_smoke_fv3), parameter :: & 
     vartracers =  [character(len=max_varname_length) :: &
-      'q','oz','ql','qi','qr','qs','qg','qnr',aeronames_cmaq_fv3,'pm25at','pm25ac','pm25co','pm2_5','amassi','amassj','amassk',aeronames_smoke_fv3]
+      'q','oz','ql','qi','qr','qs','qg','qnr',aeronames_cmaq_fv3, &
+      'pm25at','pm25ac','pm25co','pm2_5','amassi','amassj','amassk',aeronames_smoke_fv3]
   character(len=max_varname_length), dimension(nphyvarslist), parameter :: &
     varphyvars = [character(len=max_varname_length) :: 'dbz','fed']
   character(len=max_varname_length), dimension(16+naero_cmaq_fv3+7+naero_smoke_fv3+1), parameter :: &
     varfv3name = [character(len=max_varname_length) :: &
-      'u','v','W','T','delp','sphum','o3mr','liq_wat','ice_wat','rainwat','snowwat','graupel','rain_nc','ref_f3d','flash_extent_density','ps','DZ', & 
+      'u','v','W','T','delp','sphum','o3mr','liq_wat','ice_wat','rainwat','snowwat', &
+      'graupel','rain_nc','ref_f3d','flash_extent_density','ps','DZ', & 
       aeronames_cmaq_fv3,'pm25at','pm25ac','pm25co','pm2_5','amassi','amassj','amassk',aeronames_smoke_fv3], &
       vgsiname = [character(len=max_varname_length) :: &
         'u','v','w','tsen','delp','q','oz','ql','qi','qr','qs','qg','qnr','dbz','fed','ps','delzinc', &
@@ -883,7 +885,8 @@ subroutine gsi_fv3ncdf_read(grd_ionouv,cstate_nouv,filenamein,fv3filenamegin,ens
           allocate(gfile_loc_layout(0:fv3_io_layout_y-1))
           do nio=0,fv3_io_layout_y-1
              write(filename_layout,'(a,a,I4.4)') trim(filenamein),'.',nio
-             iret=nf90_open(filename_layout,ior(nf90_nowrite,nf90_mpiio),gfile_loc_layout(nio),comm=mpi_comm_read,info=MPI_INFO_NULL) !clt
+             iret=nf90_open(filename_layout,ior(nf90_nowrite,nf90_mpiio), &
+               gfile_loc_layout(nio),comm=mpi_comm_read,info=MPI_INFO_NULL) !clt
              if(iret/=nf90_noerr) then
                 write(6,*)' gsi_fv3ncdf_read: problem opening ',trim(filename_layout),gfile_loc_layout(nio),', Status = ',iret
                 call stop2(333)
@@ -2048,7 +2051,8 @@ subroutine gsi_fv3ncdf_writeuv(grd_uv,ges_u,ges_v,add_saved,fv3filenamegin)
           allocate(gfile_loc_layout(0:fv3_io_layout_y-1))
           do nio=0,fv3_io_layout_y-1
              write(filename_layout,'(a,a,I4.4)') trim(filenamein),".",nio
-             call check( nf90_open(filename_layout,ior(nf90_write, nf90_mpiio),gfile_loc_layout(nio),comm=mpi_comm_read,info=MPI_INFO_NULL) )
+             call check( nf90_open(filename_layout,ior(nf90_write, nf90_mpiio),gfile_loc_layout(nio), &
+               comm=mpi_comm_read,info=MPI_INFO_NULL) )
           enddo
           gfile_loc=gfile_loc_layout(0)
        else
@@ -2670,11 +2674,13 @@ subroutine gsi_fv3ncdf_write(grd_ionouv,cstate_nouv,add_saved,filenamein,fv3file
           allocate(gfile_loc_layout(0:fv3_io_layout_y-1))
           do nio=0,fv3_io_layout_y-1
              write(filename_layout,'(a,a,I4.4)') trim(filenamein),'.',nio
-             call check( nf90_open(filename_layout,ior(nf90_netcdf4,ior(nf90_write, nf90_mpiio)),gfile_loc_layout(nio),comm=mpi_comm_read,info=MPI_INFO_NULL) )
+             call check( nf90_open(filename_layout,ior(nf90_netcdf4,ior(nf90_write, nf90_mpiio)),gfile_loc_layout(nio), &
+               comm=mpi_comm_read,info=MPI_INFO_NULL) )
           enddo
           gfile_loc=gfile_loc_layout(0)
        else
-          call check( nf90_open(filenamein,ior(nf90_netcdf4,ior(nf90_write, nf90_mpiio)),gfile_loc,comm=mpi_comm_read,info=MPI_INFO_NULL) )
+          call check( nf90_open(filenamein,ior(nf90_netcdf4,ior(nf90_write, nf90_mpiio)),gfile_loc, &
+            comm=mpi_comm_read,info=MPI_INFO_NULL) )
        endif
        
        do ilevtot=kbgn,kend
@@ -2915,7 +2921,8 @@ subroutine gsi_fv3ncdf_write_v1(grd_ionouv,cstate_nouv,add_saved,filenamein,fv3f
     call setcomm(iworld,iworld_group,nread,mype_read_rank,mpi_comm_read,ierror)
 
     if (procuse) then
-    call check ( nf90_open(filenamein,ior(nf90_netcdf4,ior(nf90_write, nf90_mpiio)),gfile_loc,comm=mpi_comm_read,info=MPI_INFO_NULL)) !clt
+    call check ( nf90_open(filenamein,ior(nf90_netcdf4,ior(nf90_write, nf90_mpiio)),gfile_loc, &
+      comm=mpi_comm_read,info=MPI_INFO_NULL)) !clt
     do ilevtot=kbgn,kend
       vgsiname=grd_ionouv%names(1,ilevtot)
       if(trim(vgsiname)=='amassi') cycle

--- a/src/gsibec/gsi/mod_fv3_lola.f90
+++ b/src/gsibec/gsi/mod_fv3_lola.f90
@@ -67,11 +67,13 @@ module mod_fv3_lola
   implicit none
 !
   private
-  public :: generate_anl_grid,m_generate_anl_grid,m_generate_anl_grid_without_fv3gridspec,fv3_h_to_ll,fv3_ll_to_h,fv3uv2earth,earthuv2fv3
+  public :: generate_anl_grid,m_generate_anl_grid,m_generate_anl_grid_without_fv3gridspec, &
+    fv3_h_to_ll,fv3_ll_to_h,fv3uv2earth,earthuv2fv3
   public :: fv3dx,fv3dx1,fv3dy,fv3dy1,fv3ix,fv3ixp,fv3jy,fv3jyp,a3dx,a3dx1,a3dy,a3dy1,a3ix,a3ixp,a3jy,a3jyp
   public :: nxa,nya,cangu,sangu,cangv,sangv,nx,ny,bilinear
   public :: definecoef_regular_grids,fv3_h_to_ll_ens,fv3uv2earthens
-  public :: fv3dxens,fv3dx1ens,fv3dyens,fv3dy1ens,fv3ixens,fv3ixpens,fv3jyens,fv3jypens,a3dxens,a3dx1ens,a3dyens,a3dy1ens,a3ixens,a3ixpens,a3jyens,a3jypens
+  public :: fv3dxens,fv3dx1ens,fv3dyens,fv3dy1ens,fv3ixens,fv3ixpens,fv3jyens,fv3jypens, &
+    a3dxens,a3dx1ens,a3dyens,a3dy1ens,a3ixens,a3ixpens,a3jyens,a3jypens
   public :: nxe,nye,canguens,sanguens,cangvens,sangvens
 
   logical bilinear
@@ -1558,9 +1560,11 @@ subroutine fv3uv2earthens(u,v,nxen,nyen,u_out,v_out)
   do j=1,nyen
      do i=1,nxen
         u_out(i,j)=half *((u(i,j)*sangvens(i,j)-v(i,j)*sanguens(i,j))/(canguens(i,j)*sangvens(i,j)-sanguens(i,j)*cangvens(i,j)) &
-                       +(u(i,j+1)*sangvens(i+1,j)-v(i+1,j)*sanguens(i,j+1))/(canguens(i,j+1)*sangvens(i+1,j)-sanguens(i,j+1)*cangvens(i+1,j)))
+                       +(u(i,j+1)*sangvens(i+1,j)-v(i+1,j)*sanguens(i,j+1))/(canguens(i,j+1)*sangvens(i+1,j) &
+                       -sanguens(i,j+1)*cangvens(i+1,j)))
         v_out(i,j)=half *((u(i,j)*cangvens(i,j)-v(i,j)*canguens(i,j))/(sanguens(i,j)*cangvens(i,j)-canguens(i,j)*sangvens(i,j)) &
-                       +(u(i,j+1)*cangvens(i+1,j)-v(i+1,j)*canguens(i,j+1))/(sanguens(i,j+1)*cangvens(i+1,j)-canguens(i,j+1)*sangvens(i+1,j)))
+                       +(u(i,j+1)*cangvens(i+1,j)-v(i+1,j)*canguens(i,j+1))/(sanguens(i,j+1)*cangvens(i+1,j) &
+                       -canguens(i,j+1)*sangvens(i+1,j)))
      end do
   end do
   return

--- a/src/gsibec/gsi/rapidrefresh_cldsurf_mod.f90
+++ b/src/gsibec/gsi/rapidrefresh_cldsurf_mod.f90
@@ -497,13 +497,15 @@ contains
       if ( trim(svars2d(i2))=='howv' .or. trim(svars2d(i2))=='HOWV'   ) then
         i_howv_3dda = 1
         if ( mype == 0 ) then
-          write(6,'(1x,A,1x,A8,1x,A,1x,I4)')"init_rapidrefresh_cldsurf: anavinfo svars2d (state variable): ",trim(adjustl(svars2d(i2))), " is found in anavinfo, set i_howv_3dda = ", i_howv_3dda
+          write(6,'(1x,A,1x,A8,1x,A,1x,I4)')"init_rapidrefresh_cldsurf: anavinfo svars2d (state variable): ", &
+            trim(adjustl(svars2d(i2))), " is found in anavinfo, set i_howv_3dda = ", i_howv_3dda
         end if
       end if
       if ( trim(svars2d(i2))=='gust' .or. trim(svars2d(i2))=='GUST'   ) then
         i_gust_3dda = 1
         if ( mype == 0 ) then
-          write(6,'(1x,A,1x,A8,1x,A,1x,I4)')"init_rapidrefresh_cldsurf: anavinfo svars2d (state variable): ",trim(adjustl(svars2d(i2))), " is found in anavinfo, set i_gust_3dda = ", i_gust_3dda
+          write(6,'(1x,A,1x,A8,1x,A,1x,I4)')"init_rapidrefresh_cldsurf: anavinfo svars2d (state variable): ", &
+            trim(adjustl(svars2d(i2))), " is found in anavinfo, set i_gust_3dda = ", i_gust_3dda
         end if
       end if
     end do ! i2 : looping over 2-D anasv

--- a/src/gsibec/gsigeos/m_nc_GEOSens.f90
+++ b/src/gsibec/gsigeos/m_nc_GEOSens.f90
@@ -354,7 +354,8 @@ subroutine write_GEOSens_ (fname,bvars,lats,lons,rc, myid,root,plevs)
   enddo
   allocate(varid3d(bvars%nv3d))
   do nv = 1, bvars%nv3d
-     call check_( nf90_def_var(ncid, trim(bvars%fvars3d(nv)), NF90_REAL, (/ x_dimid, y_dimid, z_dimid /), varid3d(nv)), rc, mype_, root_ )
+     call check_( nf90_def_var(ncid, trim(bvars%fvars3d(nv)), NF90_REAL, (/ x_dimid, y_dimid, z_dimid /), &
+       varid3d(nv)), rc, mype_, root_ )
   enddo
 
 ! End define mode. This tells netCDF we are done defining metadata.


### PR DESCRIPTION
Some lines of some source code files exceeded the maximum length of 132 allowed by the Fortran standard.
Intel compilers does not care about this, but gcc compilers truncate the line and hence the compiling fails.
This caused the gcc test failure in this PR https://github.com/JCSDA-internal/saber/pull/1088

This PR modifies each of those super long lines to two lines so that they are less than 132 in length.

Tested both intel and gcc compiling and all worked as expected.