### PR TITLE
Fix plib (entry was never replaced)

### DIFF
--- a/src/gsibec/gsi/hybrid_ensemble_isotropic.F90
+++ b/src/gsibec/gsi/hybrid_ensemble_isotropic.F90
@@ -338,8 +338,9 @@ subroutine init_rf_z(z_len)
               d1=abs(z_len(k))/dlnp
               d1=min(rnsig,d1)
               aspect(k)=d1**2
-!!            if(mype == 0) write(400,'(" k, vertical localization in grid units for ln(p) scaling =",i4,f10.2,f10.2,f10.2)') &
-!!                                         k,sqrt(aspect(k))
+              if(debug .and. mype == 0) write(400, &
+               '(" k, vertical localization in grid units for ln(p) scaling =", &
+                i4,f10.2,f10.2,f10.2)') k,sqrt(aspect(k))
            enddo
    
            call get_new_alpha_beta(aspect,nsig,fmatz_tmp,fmat0z_tmp)
@@ -844,6 +845,7 @@ subroutine normal_new_factorization_rf_z
 
 ! Check result:
   if(debug)then
+
     do k=1,grd_ens%nsig
        f=zero
        f(:,k)=one

--- a/src/gsibec/gsi/m_plib8mat2.f90
+++ b/src/gsibec/gsi/m_plib8mat2.f90
@@ -1183,6 +1183,7 @@ REAL(r_kind),     INTENT(INOUT) :: c(m1,-mch1:mch2)
 INTEGER(i_kind)                :: nch1, nch2, j, k, jpk, i1,i2
 
 c=zero
+CALL madbb(a,b,c,m1,m2,mah1,mah2,mbh1,mbh2,mch1,mch2)
 END SUBROUTINE mulbb
 !=============================================================================
 SUBROUTINE madbb(a,b,c,m1,m2,mah1,mah2,mbh1,mbh2,mch1,mch2)
@@ -1221,7 +1222,7 @@ REAL(r_kind),     INTENT(INOUT) :: c(m1,-mch1:mch2)
 INTEGER(i_kind)                :: nch1, nch2, j, k, jpk, i1,i2
 
 nch1=mah1+mbh1; nch2=mah2+mbh2
-IF(nch1 /= mch1 .OR. nch2 /= mch2)STOP 'In MULBB, dimensions inconsistent'
+IF(nch1 /= mch1 .OR. nch2 /= mch2)STOP 'In MADBB, dimensions inconsistent'
 DO j=-mah1,mah2
    DO k=-mbh1,mbh2; jpk=j+k; i1=MAX(1,1-j); i2=MIN(m1,m2-j)
       c(i1:i2,jpk)=c(i1:i2,jpk)+a(i1:i2,j)*b(j+i1:j+i2,k)
@@ -1776,7 +1777,7 @@ SUBROUTINE DLDLB(a,b,d,m,mah) ! Modified Cholesky [L(D**-1)U, without sqrt]
 !=============================================================================
 !$$$  subprogram documentation block
 !                .      .    .
-! subprogram:    dl1lb
+! subprogram:    dldlb
 !
 !   prgrmmr:    
 !

--- a/src/gsibec/gsi/mod_vtrans.F90
+++ b/src/gsibec/gsi/mod_vtrans.F90
@@ -874,7 +874,7 @@ subroutine special_eigvv(qmat0,hmat0,smat0,nmat,swww0,szzz0,swwwd0,szzzd0,nvmode
   end do
   mv=0
   atemp8=atemp
-  call eigen(atemp8,btemp8,nmat,mv)
+  call gsi_eigen(atemp8,btemp8,nmat,mv)
   btemp=btemp8
   atemp=atemp8
   do i=1,nvmodes_keep

--- a/src/gsibec/gsi/raflib.f90
+++ b/src/gsibec/gsi/raflib.f90
@@ -4376,10 +4376,10 @@ end subroutine quadfil
 end module raflib
 
 
-SUBROUTINE EIGEN(A,R,N,MV)
+SUBROUTINE GSI_EIGEN(A,R,N,MV)
 !$$$  subprogram documentation block
 !                .      .    .
-! subprogram:    EIGEN
+! subprogram:    GSI_EIGEN
 !
 !   prgrmmr:     R. J. Purser, NCEP 2005
 !
@@ -4617,7 +4617,7 @@ SUBROUTINE EIGEN(A,R,N,MV)
             end do
          end do
          RETURN
-END SUBROUTINE EIGEN
+END SUBROUTINE GSI_EIGEN
 
 
 SUBROUTINE gettri4(us,lguess,lv,lui,w4)


### PR DESCRIPTION
This addressed issue #95 

When I first brought GSI code into JEDI I various troubles w/ plib8. I address most, but left one for later and then forgot about. The original ENTRY statement was causing troubles with the compiler opts in JEDI - I should have replaced the ENTRY w/ a routine call and never did. This cause the issues outlined in #95. This PR solves the problem. 

I also renamed the eigen routine by gsi_eigen - don't want to confuse w/ eigen in math lib.
