### PR TITLE
Mock bkg init fix

### DIFF
--- a/src/gsibec/gsi/guess_grids.f90
+++ b/src/gsibec/gsi/guess_grids.f90
@@ -17,7 +17,6 @@ use gsi_metguess_mod, only: gsi_metguess_destroy_grids
 use mod_vtrans, only: nvmodes_keep,create_vtrans
 use mod_strong, only: l_tlnmc
 use strong_fast_global_mod, only: init_strongvars
-use m_mpimod, only: nxpe,nype
 implicit none
 private
 !

--- a/src/gsibec/gsi/m_gsibec.F90
+++ b/src/gsibec/gsi/m_gsibec.F90
@@ -155,6 +155,9 @@ contains
   integer :: ier
   logical :: already_init_mpi
 
+  if (present(bkgmock) ) then
+    bkgmock = mockbkg
+  endif
   jouter_def = jouter_def + 1
   if(present(jouter)) then
     jouter=jouter_def
@@ -216,9 +219,6 @@ contains
 ! call general_sub2grid_destroy_info(sg)
 
   cv = simcv
-  if (present(bkgmock) ) then
-    bkgmock = mockbkg
-  endif
   gsibec_initialized_=.true.
   end subroutine init_
 !--------------------------------------------------------


### PR DESCRIPTION
Minor fix that addresses this:

https://github.com/JCSDA-internal/fv3-jedi/issues/1502

zero-diff when not using more than a single middle loop.