### PR TITLE
initialize ak5, bk5, ck5, tref5 to zero

### DIFF
--- a/src/gsibec/gsi/gridmod.F90
+++ b/src/gsibec/gsi/gridmod.F90
@@ -863,8 +863,13 @@ contains
 
   subroutine create_vgrid_vars
     implicit none
-    if(.not.allocated(ak5)) &
-      allocate(ak5(nsig+1),bk5(nsig+1),ck5(nsig+1),tref5(nsig))
+    if(.not.allocated(ak5)) then
+       allocate(ak5(nsig+1),bk5(nsig+1),ck5(nsig+1),tref5(nsig))
+       ak5=0.0_r_kind
+       bk5=0.0_r_kind
+       ck5=0.0_r_kind
+       tref5=0.0_r_kind
+    endif
   end subroutine create_vgrid_vars
     
 !-------------------------------------------------------------------------


### PR DESCRIPTION
This PR initialize vertical coefficient arrays `ak5`, `bk5`, `ck5`, and `tref5` to `0.0_r_kind` after the arrays are initialized.

Resolves #106

GDASApp built on WCOSS2 generates `tlnmc_option=1` and `tlnmc_option=2` results consisten with GSI when the changes in this PR are include in the GDASApp code base.