### PR TITLE
Add back call to turbl in calctends

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 ################################################################################
 
 cmake_minimum_required( VERSION 3.12 )
-project( gsibec VERSION 1.4.4 LANGUAGES Fortran )
+project( gsibec VERSION 1.5.0 LANGUAGES Fortran )
 
 ## Ecbuild integration
 set( ECBUILD_DEFAULT_BUILD_TYPE Release )

--- a/src/gsibec/gsi/CMakeLists.txt
+++ b/src/gsibec/gsi/CMakeLists.txt
@@ -123,6 +123,7 @@ strong_bal_correction.f90
 strong_baldiag_inc.f90
 strong_fast_global_mod.F90
 turblmod.f90
+turbl.f90
 turbl_ad.f90
 turbl_tl.f90
 zrnmi_mod.f90

--- a/src/gsibec/gsi/calctends.F90
+++ b/src/gsibec/gsi/calctends.F90
@@ -371,7 +371,7 @@ subroutine calctends(mype,teta,pri,guess,xderivative,yderivative,tendency)
       end do
     end do  !end do k
 
-!   call turbl(u,v,pri,t,teta,z,u_t,v_t,t_t,jtstart(kk),jtstop(kk))
+    call turbl(u,v,pri,t,teta,z,u_t,v_t,t_t,jtstart(kk),jtstop(kk))
 
 #ifdef USE_ALL_ORIGINAL
     if(.not.wrf_nmm_regional.and..not.nems_nmmb_regional)then

--- a/src/gsibec/gsi/gsimod.F90
+++ b/src/gsibec/gsi/gsimod.F90
@@ -51,6 +51,8 @@
 
   use gridmod, only: init_reg_glob_ll,regional,fv3_regional,grid_ratio_fv3_regional,mpas_regional,use_fv3_grid_spec
 
+  use turblmod, only: use_pbl,init_turbl
+
   use constants, only: zero,one,init_constants,gps_constants,three
   use constants, only: init_constants,init_constants_derived
   use constants, only: final_constants,final_constants_derived
@@ -382,7 +384,8 @@
        nmn_obsbin,&
        iadtest,&
        iadtest_maxiter,&
-       mockbkg
+       mockbkg,&
+       use_pbl
 
 ! GRIDOPTS (grid setup variables,including regional specific variables):
 !     jcap     - spectral resolution
@@ -586,6 +589,7 @@
   call init_balmod
   call init_berror
   call init_grid
+  call init_turbl
   call init_compact_diffs
   call init_smooth_polcas
   call init_strongvars

--- a/src/gsibec/gsi/strong_bal_correction.f90
+++ b/src/gsibec/gsi/strong_bal_correction.f90
@@ -1,4 +1,6 @@
-subroutine strong_bal_correction(u_t,v_t,t_t,ps_t,mype,psi,chi,t,ps,bal_diagnostic,fullfield,update,uvflag)
+subroutine strong_bal_correction(u_t,v_t,t_t,ps_t,mype,&
+                                 psi,chi,t,ps,&
+                                 bal_diagnostic,fullfield,update,uvflag)
 
 !$$$  subprogram documentation block
 !                .      .    .                                       .
@@ -66,7 +68,8 @@ subroutine strong_bal_correction(u_t,v_t,t_t,ps_t,mype,psi,chi,t,ps,bal_diagnost
   implicit none
 
   integer(i_kind)                       ,intent(in   ) :: mype
-  logical                               ,intent(in   ) :: bal_diagnostic,update,fullfield,uvflag
+  logical                               ,intent(in   ) :: bal_diagnostic,update
+  logical                               ,intent(in   ) :: fullfield,uvflag
   real(r_kind),dimension(lat2,lon2,nsig),intent(inout) :: u_t,v_t,t_t
   real(r_kind),dimension(lat2,lon2)     ,intent(inout) :: ps_t
   real(r_kind),dimension(lat2,lon2,nsig),intent(inout) :: psi,chi,t
@@ -76,7 +79,8 @@ subroutine strong_bal_correction(u_t,v_t,t_t,ps_t,mype,psi,chi,t,ps,bal_diagnost
 
 !    global option:
 
-     call strong_bal_correction_fast_global(u_t,v_t,t_t,ps_t,mype,psi,chi,t,ps,bal_diagnostic,fullfield,update,uvflag)
+     call strong_bal_correction_fast_global(u_t,v_t,t_t,ps_t,mype,psi,chi,t,ps,&
+                                            bal_diagnostic,fullfield,update,uvflag)
 
   else
 
@@ -84,7 +88,8 @@ subroutine strong_bal_correction(u_t,v_t,t_t,ps_t,mype,psi,chi,t,ps,bal_diagnost
 
 !       regional option 1:
 
-        call zrnmi_strong_bal_correction(u_t,v_t,t_t,ps_t,psi,chi,t,ps,bal_diagnostic,fullfield,update,mype)
+        call zrnmi_strong_bal_correction(u_t,v_t,t_t,ps_t,psi,chi,t,ps,&
+                                         bal_diagnostic,fullfield,update,mype)
 
      elseif(reg_tlnmc_type==2) then
 
@@ -93,7 +98,8 @@ subroutine strong_bal_correction(u_t,v_t,t_t,ps_t,mype,psi,chi,t,ps,bal_diagnost
         !call fmg_strong_bal_correction_ad_test(u_t,v_t,t_t,ps_t,psi,chi,t,ps,mype)
         !call zrnmi_filter_uvm_ad_test(mype)
 
-        call fmg_strong_bal_correction(u_t,v_t,t_t,ps_t,psi,chi,t,ps,bal_diagnostic,fullfield,update,mype)
+        call fmg_strong_bal_correction(u_t,v_t,t_t,ps_t,psi,chi,t,ps,&
+                                      bal_diagnostic,fullfield,update,mype)
 
      end if
 
@@ -173,7 +179,8 @@ subroutine strong_bal_correction_ad(u_t,v_t,t_t,ps_t,mype,psi,chi,t,ps,uvflag)
 
 !    global option:
 
-     call strong_bal_correction_fast_global_ad(u_t,v_t,t_t,ps_t,mype,psi,chi,t,ps,uvflag)
+     call strong_bal_correction_fast_global_ad(u_t,v_t,t_t,ps_t,mype,&
+                                               psi,chi,t,ps,uvflag)
 
   else
 
@@ -182,7 +189,8 @@ subroutine strong_bal_correction_ad(u_t,v_t,t_t,ps_t,mype,psi,chi,t,ps,uvflag)
 !       regional option 1:
 
         update=.true.
-        call zrnmi_strong_bal_correction_ad(u_t,v_t,t_t,ps_t,psi,chi,t,ps,update,mype)
+        call zrnmi_strong_bal_correction_ad(u_t,v_t,t_t,ps_t,&
+                                            psi,chi,t,ps,update,mype)
 
      elseif(reg_tlnmc_type==2) then
 

--- a/src/gsibec/gsi/turbl.f90
+++ b/src/gsibec/gsi/turbl.f90
@@ -1,0 +1,181 @@
+subroutine turbl(uges,vges,pges,tges,oges,zges,termu,termv,termt,jstart,jstop)
+
+!$$$  subprogram documentation block
+!                .      .    .
+! subprogram:    turbl
+!
+!   prgrmmr: 
+!
+! abstract:      Calculate tendencies of wind and virtual temperature
+!                due to vertical turbulent mixing. 
+!
+! program history log:
+!   2008-04-02  safford -- add subprogram doc block, rm unused uses
+!   2010-11-03  derber - added jstart and jstop for threading use
+!
+!   input argument list:
+!     zges     -
+!     pges     -
+!     uges     - 
+!     vges     - 
+!     tges     - 
+!     termu    - 
+!     termv    - 
+!     termt    - 
+!     oges     - 
+!     jstart   - starting point of j loop
+!     jstop    - stopping point of j loop
+!
+!   output argument list:
+!     termu    - 
+!     termv    - 
+!     termt    - 
+!     oges     - 
+!
+! attributes:
+!   language:  f90
+!   machine:   ibm RS/6000 SP
+!
+!$$$
+
+  use m_kinds,only: r_kind,i_kind
+  use constants,only: zero,one,two,half,rd_over_g,rd_over_cp,grav
+  use gridmod,only: lat2,lon2,nsig,nsig_hlf
+  use turblmod, only: use_pbl
+  use turblmod, only: dudz,dvdz,dodz,ri,rf,zi,km,kh,sm,sh
+  use turblmod, only: lmix,dudtm,dvdtm,dtdtm,rdzi,rdzl
+  use turblmod, only: kar0my20
+  use turblmod, only: a0my20,b0my20,c0my20,d0my20,f1my20,f2my20, &
+                      f3my20,f4my20,f5my20,f6my20,f7my20,f8my20,b1my20, &
+                      karmy20,l0my20
+  use turblmod, only: ricmy20,rfcmy20,shcmy20,smcmy20,eps_m
+  use turblmod, only: ri_int
+  implicit none
+
+! Declare local parameters
+  real(r_kind),parameter:: r200 = 200.0_r_kind
+
+! Declare passed variables
+  real(r_kind),dimension(lat2,lon2)       ,intent(in   ) :: zges
+  real(r_kind),dimension(lat2,lon2,nsig+1),intent(in   ) :: pges
+  real(r_kind),dimension(lat2,lon2,nsig)  ,intent(in   ) :: uges,vges,tges
+  real(r_kind),dimension(lat2,lon2,nsig)  ,intent(inout) :: termu,termv,termt,oges
+  integer(i_kind)                         ,intent(in   ) :: jstart,jstop
+
+! Declare local variables
+  real(r_kind),dimension(nsig_hlf):: zl,kmaz,khaz
+  real(r_kind),dimension(nsig_hlf):: tloc,uloc,vloc,oloc,zmix
+  real(r_kind),dimension(nsig_hlf+1):: ploc
+
+  real(r_kind) px,rdzik,rdzlk,kmrdz,khrdz,ssq,aux,l0
+  integer(i_kind) i,j,k
+  
+  if(.not. use_pbl)return
+
+  do k=1,nsig_hlf
+     do j=jstart,jstop
+        do i=1,lat2
+           oges(i,j,k)=tges(i,j,k)*(                  &
+               r200/( pges(i,j,k)+pges(i,j,k+1) ))**rd_over_cp
+        end do
+     end do
+  end do
+
+  do j=jstart,jstop
+     do i=1,lat2
+        do k=1,nsig_hlf
+           tloc(k)=tges(i,j,k)
+           uloc(k)=uges(i,j,k)
+           vloc(k)=vges(i,j,k)
+           ploc(k)=pges(i,j,k)
+           oloc(k)=oges(i,j,k)
+        end do
+        ploc(nsig_hlf+1)=pges(i,j,nsig_hlf+1)
+        zi(i,j,1) = zges(i,j)
+        do k=1,nsig_hlf
+           zi(i,j,k+1)=zi(i,j,k)-rd_over_g*two*tloc(k) &
+                    *(ploc(k+1)-ploc(k))/(ploc(k+1)+ploc(k))
+           zl(k)=half*(zi(i,j,k+1)+zi(i,j,k))
+           rdzi(i,j,k)=one/(zi(i,j,k+1)-zi(i,j,k))
+        end do
+
+!m      l0=l0my20 *0.1_r_kind   !  8 m
+        l0=l0my20 *0.15_r_kind  !  12 m
+!m      l0=l0my20 *0.20_r_kind  !  16 m
+!m      l0=l0my20 *0.25_r_kind  !  20 m
+!m      l0=l0my20 *0.5_r_kind   !  40 m
+!m      l0=l0my20        !  80 m
+        kar0my20(i,j)=karmy20/l0
+
+        do k=2,nsig_hlf
+           rdzl(i,j,k)=one/(zl(k)-zl(k-1))
+        end do
+
+        do k=2,nsig_hlf
+           rdzlk=rdzl(i,j,k)
+           dodz(i,j,k)=(oloc(k)-oloc(k-1))*rdzlk
+           dudz(i,j,k)=(uloc(k)-uloc(k-1))*rdzlk
+           dvdz(i,j,k)=(vloc(k)-vloc(k-1))*rdzlk
+           zmix(k)=zi(i,j,k)-zi(i,j,1)
+           ssq=dudz(i,j,k)**2+dvdz(i,j,k)**2
+           if(ssq < eps_m) ssq=eps_m
+           lmix(i,j,k)=karmy20*zmix(k)/(one+kar0my20(i,j)*zmix(k))
+           ri(i,j,k)=two*grav*dodz(i,j,k)/((tloc(k)+tloc(k-1))*ssq)
+           if(ri(i,j,k) > ricmy20) then
+              ri_int(i,j,k)=1
+              ri(i,j,k)=ricmy20
+              rf(i,j,k)=rfcmy20
+              sh(i,j,k)=shcmy20
+              sm(i,j,k)=smcmy20
+              km(i,j,k)=zero
+              kh(i,j,k)=zero
+           else
+              ri_int(i,j,k)=0
+              rf(i,j,k)=a0my20*(ri(i,j,k)+b0my20-sqrt(ri(i,j,k)**2-c0my20*ri(i,j,k)+d0my20))
+              sh(i,j,k)=f1my20*(f2my20-f3my20*rf(i,j,k))/(one-rf(i,j,k))
+              sm(i,j,k)=f4my20*(f5my20-f6my20*rf(i,j,k))/(f7my20-f8my20*rf(i,j,k))*sh(i,j,k)
+              aux=sqrt(ssq*b1my20*(one-rf(i,j,k))*sm(i,j,k))*lmix(i,j,k)**2
+              km(i,j,k)=aux*sm(i,j,k) 
+              kh(i,j,k)=aux*sh(i,j,k) 
+           end if
+        end do
+        km(i,j,1)=zero; km(i,j,nsig_hlf+1)=zero
+        kh(i,j,1)=zero; kh(i,j,nsig_hlf+1)=zero
+     end do
+  end do
+  
+  do j=jstart,jstop
+     do i=1,lat2
+        do k=1,nsig_hlf
+           kmaz(k)=(km(i,j,k)+km(i,j,k+1))*half
+           khaz(k)=(kh(i,j,k)+kh(i,j,k+1))*half
+        end do
+ 
+        dudtm(i,j,nsig_hlf)=zero
+        dvdtm(i,j,nsig_hlf)=zero
+        dtdtm(i,j,nsig_hlf)=zero
+
+        do k=1,nsig_hlf
+           px=tges(i,j,k)/oges(i,j,k)
+           rdzik=rdzi(i,j,k)
+           kmrdz=kmaz(k)*rdzik
+           khrdz=khaz(k)*rdzik
+           if(k < nsig_hlf)then
+              dudtm(i,j,k)=kmrdz*dudz(i,j,k+1)
+              dvdtm(i,j,k)=kmrdz*dvdz(i,j,k+1)
+              dtdtm(i,j,k)=khrdz*dodz(i,j,k+1)*px
+           end if
+           if(k > 1)then
+              dudtm(i,j,k)=dudtm(i,j,k)-kmrdz*dudz(i,j,k)
+              dvdtm(i,j,k)=dvdtm(i,j,k)-kmrdz*dvdz(i,j,k)
+              dtdtm(i,j,k)=dtdtm(i,j,k)-khrdz*dodz(i,j,k)*px
+           end if
+           termu(i,j,k)=termu(i,j,k)+dudtm(i,j,k)
+           termv(i,j,k)=termv(i,j,k)+dvdtm(i,j,k)
+           termt(i,j,k)=termt(i,j,k)+dtdtm(i,j,k)
+        end do
+     end do
+  end do
+
+  return
+end subroutine turbl


### PR DESCRIPTION
Add back call to turbl in calctends - this only affects those using use_pbl = true - which nobody was to this point since this was not available as an option in GSIBEC (only in GSI proper).

ZERO-DIFF - placing back GSI-proper capability in GSIBEC.

This does bring in a change to the version of GSIBEC - it's a  bump in the second digit since I forgot to bump that before accepting the previous change going in that fixed a but in TLNMC - non-zero diff.